### PR TITLE
Improve unification error when it fails

### DIFF
--- a/inferno-core/CHANGELOG.md
+++ b/inferno-core/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Revision History for inferno-core
 
+## 0.1.0.1 -- 2022-12-23
+* Return unification error instead of empty list when unification failed
+
 ## 0.1.0.0 -- 2022-11-28
 * Prepare for OSS release

--- a/inferno-core/inferno-core.cabal
+++ b/inferno-core/inferno-core.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                inferno-core
-version:             0.1.0.0
+version:             0.1.0.1
 synopsis:            A statically-typed functional scripting language
 description:         Parser, type inference, and interpreter for a statically-typed functional scripting language
 category:            DSL,Scripting


### PR DESCRIPTION
- Previously, this returns an empty list when no two types match. 
- Also, this handles returning error with dummy location when carried type errors are empty. Otherwise, when the carried type errors are empty, this function just returns an empty list instead of unification error.