### PR TITLE
Profiling build of `inferno` binary

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -342,11 +342,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1669684649,
-        "narHash": "sha256-Xfclngyj/2wSKR7qvOMmZwxIUx80nWFKR6QDGn7H9Mc=",
+        "lastModified": 1672791896,
+        "narHash": "sha256-zbISIhV/H66RkyJcrbynokbNewgda6xj96/2WYyNM6k=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "c959f7547c7adaf4fd15866cae1423a3a1165f9c",
+        "rev": "21307956a6f92e39ecea0d54561d3c3b82075896",
         "type": "github"
       },
       "original": {
@@ -368,6 +368,7 @@
         "hackage": "hackage",
         "hpc-coveralls": "hpc-coveralls",
         "hydra": "hydra",
+        "iserv-proxy": "iserv-proxy",
         "nixpkgs": [
           "haskell-nix",
           "nixpkgs-unstable"
@@ -376,17 +377,18 @@
         "nixpkgs-2105": "nixpkgs-2105",
         "nixpkgs-2111": "nixpkgs-2111",
         "nixpkgs-2205": "nixpkgs-2205",
+        "nixpkgs-2211": "nixpkgs-2211",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "old-ghc-nix": "old-ghc-nix",
         "stackage": "stackage",
         "tullia": "tullia"
       },
       "locked": {
-        "lastModified": 1669684773,
-        "narHash": "sha256-se+NPVmMEKuokhwzdZ85SBfem0VGuz7YAnSnrAbzzvQ=",
+        "lastModified": 1672826296,
+        "narHash": "sha256-BBBEu/qrkqQ2VVf7Ty6Eqcm5W9GfdLxXPEnEhGiX2mQ=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "506208fc9226e207a7beb1b4a26bbd9504a0f680",
+        "rev": "e339ff5b2862443f19971c524a09169c10706aaa",
         "type": "github"
       },
       "original": {
@@ -432,6 +434,22 @@
       "original": {
         "id": "hydra",
         "type": "indirect"
+      }
+    },
+    "iserv-proxy": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1639165170,
+        "narHash": "sha256-QsWL/sBDL5GM8IXd/dE/ORiL4RvteEN+aok23tXgAoc=",
+        "rev": "6e95df7be6dd29680f983db07a057fc2f34f81f6",
+        "revCount": 7,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/iserv-proxy.git"
+      },
+      "original": {
+        "rev": "6e95df7be6dd29680f983db07a057fc2f34f81f6",
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/iserv-proxy.git"
       }
     },
     "lowdown-src": {
@@ -679,6 +697,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-2211": {
+      "locked": {
+        "lastModified": 1669997163,
+        "narHash": "sha256-vhjC0kZMFoN6jzK0GR+tBzKi5KgBXgehadfidW8+Va4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6f87491a54d8d64d30af6663cb3bf5d2ee7db958",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-22.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
@@ -856,11 +890,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1669598217,
-        "narHash": "sha256-UioviNyxA3fexeguXLQpgMR6uWL9Q/wulipCbET3C8w=",
+        "lastModified": 1672790972,
+        "narHash": "sha256-8J6s+gFzjeGENyehEKdRyTJ4W+Dv4gLNBxt29cWtOS8=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "8400280d894949e26354123aebc20801a2165182",
+        "rev": "5c1a68f2f6642fe7419c5c1c5f4d6668786f8bf7",
         "type": "github"
       },
       "original": {
@@ -937,11 +971,11 @@
         "std": "std"
       },
       "locked": {
-        "lastModified": 1666200256,
-        "narHash": "sha256-cJPS8zBu30SMhxMe7I8DWutwqMuhPsEez87y9gxMKc4=",
+        "lastModified": 1668711738,
+        "narHash": "sha256-CBjky16o9pqsGE1bWu6nRlRajgSXMEk+yaFQLibqXcE=",
         "owner": "input-output-hk",
         "repo": "tullia",
-        "rev": "575362c2244498e8d2c97f72861510fa72e75d44",
+        "rev": "ead1f515c251f0e060060ef0e2356a51d3dfe4b0",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -342,11 +342,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1672791896,
-        "narHash": "sha256-zbISIhV/H66RkyJcrbynokbNewgda6xj96/2WYyNM6k=",
+        "lastModified": 1673137629,
+        "narHash": "sha256-HJfuXQ6NkhdZIMo4/S/Y9QX1xmuBS7XSB4xhmEVZSWc=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "21307956a6f92e39ecea0d54561d3c3b82075896",
+        "rev": "5cc584651a4895c7abad166cf695a3ee8b873386",
         "type": "github"
       },
       "original": {
@@ -384,11 +384,11 @@
         "tullia": "tullia"
       },
       "locked": {
-        "lastModified": 1672826296,
-        "narHash": "sha256-BBBEu/qrkqQ2VVf7Ty6Eqcm5W9GfdLxXPEnEhGiX2mQ=",
+        "lastModified": 1673139096,
+        "narHash": "sha256-EzMIx2nxXoHbMFHIKFiXVE6AC+PcCm4NjKChk9MAgM8=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "e339ff5b2862443f19971c524a09169c10706aaa",
+        "rev": "f5da0a34b5dbbeb57e6d7595f46a930cd62bcd77",
         "type": "github"
       },
       "original": {
@@ -890,11 +890,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1672790972,
-        "narHash": "sha256-8J6s+gFzjeGENyehEKdRyTJ4W+Dv4gLNBxt29cWtOS8=",
+        "lastModified": 1673050158,
+        "narHash": "sha256-/1WWFQDUisdEuSOUTvQTzkED9Z6riX3XuVMuaMIbyq4=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "5c1a68f2f6642fe7419c5c1c5f4d6668786f8bf7",
+        "rev": "46c3d80f024585ddf22a54f3c505799dca778865",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -88,7 +88,12 @@
               compiler
               # TODO
               # Do we want to enable any `crossPlatforms` here?
-              ((infernoFor compiler pkgs).flake { })
+              ((infernoFor compiler pkgs {}).flake { })
+            ) ++
+          lib.lists.forEach [ defaultCompiler ]
+            (compiler: lib.attrsets.nameValuePair
+              (compiler + "-prof")
+              ((infernoFor compiler pkgs {profiling = true; ghcOptions = [ "-eventlog" ];}).flake { })
             )
         );
 
@@ -96,7 +101,7 @@
       # want users who get packages from our `overlays.default` to be able to
       # use their own `nixpkgs` without having to instantiate ours as well
       # (which would happen if we just use `self.packages` directly in the overlay)
-      infernoFor = compiler: pkgs: pkgs.haskell-nix.cabalProject {
+      infernoFor = compiler: pkgs: { ghcOptions ? [], profiling ? false}: pkgs.haskell-nix.cabalProject {
         name = "inferno";
         compiler-nix-name = compiler;
         src = builtins.path {
@@ -118,9 +123,15 @@
         };
         modules = [
           {
+            enableLibraryProfiling = profiling;
             packages = {
               # This takes forever to build
               ghc.components.library.doHaddock = false;
+            };
+            packages.inferno-core = {
+                enableLibraryProfiling = profiling;
+                enableProfiling = profiling;
+                inherit ghcOptions;
             };
           }
         ];

--- a/flake.nix
+++ b/flake.nix
@@ -88,12 +88,12 @@
               compiler
               # TODO
               # Do we want to enable any `crossPlatforms` here?
-              ((infernoFor compiler pkgs {}).flake { })
+              ((infernoFor compiler pkgs { }).flake { })
             ) ++
           lib.lists.forEach [ defaultCompiler ]
             (compiler: lib.attrsets.nameValuePair
               (compiler + "-prof")
-              ((infernoFor compiler pkgs {profiling = true; ghcOptions = [ "-eventlog" ];}).flake { })
+              ((infernoFor compiler pkgs { profiling = true; ghcOptions = [ "-eventlog" ]; }).flake { })
             )
         );
 
@@ -101,7 +101,7 @@
       # want users who get packages from our `overlays.default` to be able to
       # use their own `nixpkgs` without having to instantiate ours as well
       # (which would happen if we just use `self.packages` directly in the overlay)
-      infernoFor = compiler: pkgs: { ghcOptions ? [], profiling ? false}: pkgs.haskell-nix.cabalProject {
+      infernoFor = compiler: pkgs: { ghcOptions ? [ ], profiling ? false }: pkgs.haskell-nix.cabalProject {
         name = "inferno";
         compiler-nix-name = compiler;
         src = builtins.path {
@@ -129,9 +129,9 @@
               ghc.components.library.doHaddock = false;
             };
             packages.inferno-core = {
-                enableLibraryProfiling = profiling;
-                enableProfiling = profiling;
-                inherit ghcOptions;
+              enableLibraryProfiling = profiling;
+              enableProfiling = profiling;
+              inherit ghcOptions;
             };
           }
         ];

--- a/inferno-types/inferno-types.cabal
+++ b/inferno-types/inferno-types.cabal
@@ -47,7 +47,7 @@ library
     , QuickCheck                         >= 2.14.2 && < 2.15
     , quickcheck-arbitrary-adt           >= 0.3.1 && < 0.4
     , quickcheck-instances               >= 0.3.28 && < 0.4
-    , recursion-schemes                  >= 5.2.2 && < 5.3
+    , recursion-schemes                  >= 5.2.2.3 && < 5.3
     , servant                            >= 0.19 && < 0.20
     , text                               >= 2.0.1 && < 2.1
   default-language: Haskell2010


### PR DESCRIPTION
This adds a profiling build of the inferno binary, which can be used via

```
nix shell .#inferno-core:exe:inferno-ghc924-prof
```

However, I've had to update `haskell.nix`, as the profiling build needs `recursion-schemes` >=5.2.2.3, due to:

> Workaround for https://gitlab.haskell.org/ghc/ghc/-/issues/18320, which was preventing code calling makeBaseFunctor from being profiled. 

The update to `haskell.nix` seems to have broken the dev shell??

