### PR TITLE
Fix dependency version conflict

### DIFF
--- a/inferno-core/inferno-core.cabal
+++ b/inferno-core/inferno-core.cabal
@@ -59,7 +59,7 @@ library
     , parser-combinators   >= 1.3.0 && < 1.4
     , picosat              >= 0.1.6 && < 0.2
     , prettyprinter        >= 1.7.1 && < 1.8
-    , recursion-schemes    >= 5.2.2 && < 5.3
+    , recursion-schemes    >= 5.2.2.3 && < 5.3
     , syb                  >= 0.7.2 && < 0.8
     , template-haskell     >= 2.15 && < 2.19
     , text                 >= 2.0.1 && < 2.1

--- a/inferno-types/inferno-types.cabal
+++ b/inferno-types/inferno-types.cabal
@@ -47,7 +47,7 @@ library
     , QuickCheck                         >= 2.14.2 && < 2.15
     , quickcheck-arbitrary-adt           >= 0.3.1 && < 0.4
     , quickcheck-instances               >= 0.3.28 && < 0.4
-    , recursion-schemes                  >= 5.2.2.3 && < 5.3
+    , recursion-schemes                  >= 5.2.2 && < 5.3
     , servant                            >= 0.19 && < 0.20
     , text                               >= 2.0.1 && < 2.1
   default-language: Haskell2010

--- a/inferno-types/inferno-types.cabal
+++ b/inferno-types/inferno-types.cabal
@@ -47,7 +47,7 @@ library
     , QuickCheck                         >= 2.14.2 && < 2.15
     , quickcheck-arbitrary-adt           >= 0.3.1 && < 0.4
     , quickcheck-instances               >= 0.3.28 && < 0.4
-    , recursion-schemes                  >= 5.2.2 && < 5.3
+    , recursion-schemes                  >= 5.2.2.3 && < 5.3
     , servant                            >= 0.19 && < 0.20
     , text                               >= 2.0.1 && < 2.1
   default-language: Haskell2010

--- a/inferno-vc/src/Inferno/VersionControl/Operations.hs
+++ b/inferno-vc/src/Inferno/VersionControl/Operations.hs
@@ -10,13 +10,13 @@
 -- This module defines operations on the Inferno VC store. The store structure is as follows:
 --
 -- * `<storePath>` stores the JSON serialised `VCMeta VCObject`s, where the filename is the cryptographic hash (`VCOBjectHash`) of the object's contents
--- * `<storePath>/heads` is a set of current HEAD objects of the store, which can be seen as the roots of the VC tree
 -- * `<storePath>/heads` is a set of current HEAD objects of the store, which can be seen as the roots of the VC tree. Each filename is the hash of an object,
---    and the file's contents are all the predecessors of this object, starting from the time it was created or cloned.
+--    and the file's contents are all the predecessors of this object, in chronological order, starting from the time it was created or cloned.
 -- * `<storePath>/to_head` is a map from every `VCOBjectHash` to its current HEAD, where the file name is the source hash and the contents of the file are the HEAD hash
 -- * `<storePath>/deps` is a map from every `VCOBjectHash` to its (transitive) dependencies, i.e. the file `<storePath>/deps/<hash>` describes the closure of `<hash>`
 -- * Deleting `VCMeta VCObject` - Delete is implemented as soft delete. Object is moved to a directory called `removed`. Object's preds are also removed.
 --   When an object is removed, its directory structure is preserved so you can undo it easily. i.e. `removed` directory has the same structure as `vc_store` directory.
+
 module Inferno.VersionControl.Operations where
 
 import Control.Monad (filterM, foldM, forM, forM_)

--- a/inferno-vc/src/Inferno/VersionControl/Operations.hs
+++ b/inferno-vc/src/Inferno/VersionControl/Operations.hs
@@ -16,7 +16,6 @@
 -- * `<storePath>/deps` is a map from every `VCOBjectHash` to its (transitive) dependencies, i.e. the file `<storePath>/deps/<hash>` describes the closure of `<hash>`
 -- * Deleting `VCMeta VCObject` - Delete is implemented as soft delete. Object is moved to a directory called `removed`. Object's preds are also removed.
 --   When an object is removed, its directory structure is preserved so you can undo it easily. i.e. `removed` directory has the same structure as `vc_store` directory.
-
 module Inferno.VersionControl.Operations where
 
 import Control.Monad (filterM, foldM, forM, forM_)


### PR DESCRIPTION
#20 updated the version of `recursion-schemes` in `inferno-types.cabal`, but this conflicts with the version picked by `inferno-core.cabal` by my HLS:

```
2023-01-12 06:22:17.2560000 [client] ERROR Error: haskell-language-server --project-ghc-version exited with exit code 1:
Failed to find the GHC version of this Cabal project.
Error when calling cabal exec -v0 -- ghc --print-libdir

cabal: Could not resolve dependencies:
[__0] trying: inferno-core-0.1.0.3 (user goal)
[__1] trying: recursion-schemes-5.2.2.2 (dependency of inferno-core)
[__2] next goal: inferno-types (user goal)
[__2] rejecting: inferno-types-0.1.0.0 (conflict: recursion-schemes==5.2.2.2,
inferno-types => recursion-schemes>=5.2.2.3 && <5.3)
[__2] fail (backjumping, conflict set: inferno-types, recursion-schemes)
After searching the rest of the dependency tree exhaustively, these were the
goals I've had most trouble fulfilling: inferno-types, recursion-schemes,
inferno-core
```

So this PR updates the versions to be consistent.