### PR TITLE
[perf] Refactor parsing of tuples and prefix ops

### DIFF
--- a/inferno-core/CHANGELOG.md
+++ b/inferno-core/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Revision History for inferno-core
 
+## 0.1.0.4 -- 2022-01-13
+* Improve parser performance by refactoring parsing of bracketed expressions
+
 ## 0.1.0.3 -- 2022-01-01
 * Fix incorrect shadowing of variables in match expressions
 

--- a/inferno-core/inferno-core.cabal
+++ b/inferno-core/inferno-core.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                inferno-core
-version:             0.1.0.3
+version:             0.1.0.4
 synopsis:            A statically-typed functional scripting language
 description:         Parser, type inference, and interpreter for a statically-typed functional scripting language
 category:            DSL,Scripting

--- a/inferno-core/test/Eval/Spec.hs
+++ b/inferno-core/test/Eval/Spec.hs
@@ -36,6 +36,7 @@ evalTests = describe "evaluate" $
     shouldEvaluateTo "3.0" $ VDouble 3.0
     shouldEvaluateTo "3.0-2" $ VDouble 1.0
     shouldEvaluateTo "3.0/2" $ VDouble 1.5
+    shouldEvaluateTo "(+) 3.0 1.0" $ VDouble 4.0
     -- Reciprocals
     shouldEvaluateTo "3.14 * recip 3.14" $ VDouble 1.0
     -- Power


### PR DESCRIPTION
This PR improves the speed of parsing parenthesised expressions. For example:
```
let x = ((((((((2)))))))) in x + 1
```
currently takes 30s to parse! This PR refactors parsing of tuples and prefix ops so that the parser does less backtracking, and parses the example in 0.1s.