### PR TITLE
Revert usage of chooseInt (not supported on old Quickcheck versions)

### DIFF
--- a/inferno-core/src/Inferno/Instances/Arbitrary.hs
+++ b/inferno-core/src/Inferno/Instances/Arbitrary.hs
@@ -76,7 +76,7 @@ import Test.QuickCheck
   ( Arbitrary (..),
     Gen,
     PrintableString (getPrintableString),
-    chooseInt,
+    choose,
     elements,
     listOf,
     oneof,
@@ -245,7 +245,7 @@ instance Arbitrary a => Arbitrary (TList a) where
 
 instance Arbitrary a => Arbitrary (SomeIStr a) where
   arbitrary = sized $ \n -> do
-    k <- chooseInt (0, n)
+    k <- choose (0, n)
     oneof [SomeIStr <$> goT k, SomeIStr <$> goF k]
     where
       goT :: Arbitrary a => Int -> Gen (IStr 'True a)
@@ -363,7 +363,7 @@ instance (Arbitrary hash, Arbitrary pos) => Arbitrary (Expr hash pos) where
         InterpolatedString
           <$> arbitrary
           <*> do
-            k <- chooseInt (0, n)
+            k <- choose (0, n)
             oneof [SomeIStr <$> goT k, SomeIStr <$> goF k]
           <*> arbitrary
         where
@@ -452,7 +452,7 @@ instance (Arbitrary hash, Arbitrary pos) => Arbitrary (Expr hash pos) where
         (\e cs p1 p2 p3 -> Case p1 e p2 (NonEmpty.fromList cs) p3)
           <$> (arbitrarySized $ n `div` 3)
           <*> ( do
-                  k <- chooseInt (1, n)
+                  k <- choose (1, n)
                   sequence
                     [ (\i e p1 p2 -> (p1, i, p2, e))
                         <$> arbitrarySizedPat (n `div` (3 * k))
@@ -478,7 +478,7 @@ instance (Arbitrary hash, Arbitrary pos) => Arbitrary (Expr hash pos) where
           <*> arbitrary
           <*> ( NonEmpty.fromList
                   <$> do
-                    k <- chooseInt (1, n)
+                    k <- choose (1, n)
                     sequence [(,,,,) <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrarySized (n `div` (3 * k)) <*> pure Nothing | _ <- [1 .. k]]
               )
           <*> oneof [(\p e -> Just (p, e)) <$> arbitrary <*> (arbitrarySized $ n `div` 3), pure Nothing]
@@ -507,7 +507,7 @@ instance (Arbitrary hash, Arbitrary pos) => Arbitrary (Expr hash pos) where
             Array
               <$> arbitrary
               <*> ( do
-                      k <- chooseInt (0, n)
+                      k <- choose (0, n)
                       sequence [(,Nothing) <$> arbitrarySized (n `div` 3) | _ <- [1 .. k]]
                   )
               <*> arbitrary,
@@ -542,7 +542,7 @@ arbitrarySizedPat n =
       (\p1 ts p2 -> PTuple p1 (tListFromList ts) p2)
         <$> arbitrary
         <*> ( do
-                k <- chooseInt (0, n)
+                k <- choose (0, n)
                 sequence [(,Nothing) <$> arbitrarySizedPat (n `div` 3) | _ <- [1 .. k]]
             )
           `suchThat` (\xs -> length xs /= 1)


### PR DESCRIPTION
Issue:
Trying to use Inferno in our internal repo:
```
src/Inferno/Instances/Arbitrary.hs:79:5: error:
    Module ‘Test.QuickCheck’ does not export ‘chooseInt’
   |
79 |     chooseInt,
   |     ^^^^^^^^^
[19 of 19] Compiling Inferno.Utils.QQ.Script ( src/Inferno/Utils/QQ/Script.hs, dist/build/Inferno/Utils/QQ/Script.o )
error: builder for '/nix/store/g05v588giyqmlhsc0lrdw4iir9sasyfa-inferno-core-lib-inferno-core-0.1.2.drv' failed with exit code 1;
       last 10 log lines:
       > [16 of 19] Compiling Inferno.Utils.QQ.Module ( src/Inferno/Utils/QQ/Module.hs, dist/build/Inferno/Utils/QQ/Module.o )
       > [17 of 19] Compiling Inferno.Module.Prelude ( src/Inferno/Module/Prelude.hs, dist/build/Inferno/Module/Prelude.o )
       > [18 of 19] Compiling Inferno.Instances.Arbitrary ( src/Inferno/Instances/Arbitrary.hs, dist/build/Inferno/Instances/Arbitrary.o )
       >
       > src/Inferno/Instances/Arbitrary.hs:79:5: error:
       >     Module ‘Test.QuickCheck’ does not export ‘chooseInt’
       >    |
       > 79 |     chooseInt,
       >    |     ^^^^^^^^^
       > [19 of 19] Compiling Inferno.Utils.QQ.Script ( src/Inferno/Utils/QQ/Script.hs, dist/build/Inferno/Utils/QQ/Script.o )
       For full logs, run 'nix log /nix/store/g05v588giyqmlhsc0lrdw4iir9sasyfa-inferno-core-lib-inferno-core-0.1.2.drv'.
```