### PR TITLE
Add MonadIO to prelude and monad stack to allow random primitive

### DIFF
--- a/inferno-core/CHANGELOG.md
+++ b/inferno-core/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Revision History for inferno-core
 
+## 0.2.0 -- 2023-05-29
+* Add MonadIO to prelude and monad stack and add random primitive
+
 ## 0.1.4 -- 2023-04-14
 * Added `toBCD` and `fromBCD` functions to Prelude
 

--- a/inferno-core/CHANGELOG.md
+++ b/inferno-core/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Revision History for inferno-core
+*Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
-## 0.2.0 -- 2023-05-29
+## 0.2.0 -- 2023-05-30
 * Add MonadIO to prelude and monad stack and add random primitive
 
 ## 0.1.4 -- 2023-04-14

--- a/inferno-core/app/Main.hs
+++ b/inferno-core/app/Main.hs
@@ -56,7 +56,7 @@ main = do
                     Left err -> print err
                     Right res -> showPretty res
   where
-    prelude :: ModuleMap (Either EvalError) ()
+    prelude :: ModuleMap (ExceptT EvalError IO) ()
     prelude = builtinModules
 
     allClasses = Set.unions $ moduleTypeClasses builtinModule : [cls | Module {moduleTypeClasses = cls} <- Map.elems prelude]

--- a/inferno-core/app/Main.hs
+++ b/inferno-core/app/Main.hs
@@ -2,13 +2,11 @@
 
 module Main where
 
-import Control.Monad.Except (ExceptT)
 import Data.Bifunctor (bimap)
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import qualified Data.Text.IO as Text
 import Inferno.Eval (TermEnv, runEvalIO)
-import Inferno.Eval.Error (EvalError)
 import Inferno.Infer (inferExpr, inferTypeReps)
 import Inferno.Infer.Pinned (pinExpr)
 import Inferno.Module (Module (..))
@@ -56,12 +54,12 @@ main = do
                     Left err -> print err
                     Right res -> showPretty res
   where
-    prelude :: ModuleMap (ExceptT EvalError IO) ()
+    prelude :: ModuleMap IO ()
     prelude = builtinModules
 
     allClasses = Set.unions $ moduleTypeClasses builtinModule : [cls | Module {moduleTypeClasses = cls} <- Map.elems prelude]
 
-    mkEnv :: ImplEnvM (ExceptT EvalError IO) () (TermEnv VCObjectHash () (ImplEnvM (ExceptT EvalError IO) ()))
+    mkEnv :: ImplEnvM IO () (TermEnv VCObjectHash () (ImplEnvM IO ()))
     mkEnv = do
       pinnedEnv <- snd <$> (builtinModulesTerms builtinModules)
       pure (mempty, pinnedEnv)

--- a/inferno-core/inferno-core.cabal
+++ b/inferno-core/inferno-core.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                inferno-core
-version:             0.1.5
+version:             0.2.0
 synopsis:            A statically-typed functional scripting language
 description:         Parser, type inference, and interpreter for a statically-typed functional scripting language
 category:            DSL,Scripting

--- a/inferno-core/inferno-core.cabal
+++ b/inferno-core/inferno-core.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                inferno-core
-version:             0.1.4
+version:             0.1.5
 synopsis:            A statically-typed functional scripting language
 description:         Parser, type inference, and interpreter for a statically-typed functional scripting language
 category:            DSL,Scripting

--- a/inferno-core/inferno-core.cabal
+++ b/inferno-core/inferno-core.cabal
@@ -65,6 +65,7 @@ library
     , QuickCheck                >= 2.14.2 && < 2.15
     , quickcheck-arbitrary-adt  >= 0.3.1 && < 0.4
     , quickcheck-instances      >= 0.3.28 && < 0.4
+    , random                    >= 1.2.1 && < 1.3
     , recursion-schemes         >= 5.2.2.3 && < 5.3
     , syb                       >= 0.7.2 && < 0.8
     , template-haskell          >= 2.15 && < 2.19

--- a/inferno-core/src/Inferno/Eval/Error.hs
+++ b/inferno-core/src/Inferno/Eval/Error.hs
@@ -1,5 +1,6 @@
 module Inferno.Eval.Error where
 
+import Control.Monad.Catch (Exception)
 import Inferno.Types.Syntax (ExtIdent)
 
 data EvalError
@@ -8,3 +9,5 @@ data EvalError
   | CastError String
   | NotFoundInImplicitEnv ExtIdent
   deriving (Show, Eq)
+
+instance Exception EvalError

--- a/inferno-core/src/Inferno/Instances/Arbitrary.hs
+++ b/inferno-core/src/Inferno/Instances/Arbitrary.hs
@@ -18,7 +18,6 @@
 --   we could move this module to test/ folder, but by providing the instances as part of the core, we allow others to re-use them.
 module Inferno.Instances.Arbitrary where
 
-import Control.Monad.Except (ExceptT)
 import Crypto.Hash (Digest, hash)
 import Crypto.Hash.Algorithms (SHA256)
 import qualified Data.ByteString as ByteString (pack)
@@ -29,7 +28,6 @@ import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Set as Set (fromList)
 import qualified Data.Text as Text (Text, all, null, pack)
 import GHC.Generics (Generic (..), Rep)
-import Inferno.Eval.Error (EvalError)
 import qualified Inferno.Module.Prelude as Prelude
 import qualified Inferno.Types.Module as Module (Module)
 import Inferno.Types.Syntax
@@ -97,7 +95,7 @@ instance (Generic a, GArbitrary ga, ga ~ Rep a) => Arbitrary (GenericArbitrary a
   arbitrary = GenericArbitrary <$> genericArbitrary
 
 baseOpsTable :: OpsTable
-baseOpsTable = Prelude.baseOpsTable @(ExceptT EvalError IO) @() $ Prelude.builtinModules @(ExceptT EvalError IO) @()
+baseOpsTable = Prelude.baseOpsTable @IO @() $ Prelude.builtinModules @IO @()
 
 -- | Arbitrary and ToADTArbitrary instances for Inferno.Types.Module
 deriving instance Arbitrary objs => ToADTArbitrary (Module.Module objs)

--- a/inferno-core/src/Inferno/Module.hs
+++ b/inferno-core/src/Inferno/Module.hs
@@ -18,14 +18,13 @@ module Inferno.Module
 where
 
 import Control.Monad (foldM)
-import Control.Monad.Except (MonadError)
+import Control.Monad.Catch (MonadThrow (..))
 import Data.Bifunctor (bimap)
 import Data.Foldable (foldl')
 import qualified Data.IntMap as IntMap
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import Inferno.Eval (TermEnv, eval)
-import Inferno.Eval.Error (EvalError)
 import Inferno.Infer (inferExpr)
 import Inferno.Infer.Env (Namespace (..), TypeMetadata (..))
 import Inferno.Infer.Pinned (pinExpr)
@@ -64,13 +63,13 @@ import Prettyprinter (Pretty)
 import Text.Megaparsec (SourcePos)
 
 combineTermEnvs ::
-  MonadError EvalError m =>
+  MonadThrow m =>
   Map.Map ModuleName (PinnedModule (ImplEnvM m c (TermEnv VCObjectHash c (ImplEnvM m c)))) ->
   ImplEnvM m c (TermEnv VCObjectHash c (ImplEnvM m c))
 combineTermEnvs modules = foldM (\env m -> (env <>) <$> pinnedModuleTerms m) mempty $ Map.elems modules
 
 buildPinnedQQModules ::
-  (MonadError EvalError m, Pretty c) =>
+  (MonadThrow m, Pretty c) =>
   [(ModuleName, OpsTable, [TopLevelDefn (Either (TCScheme, ImplEnvM m c (Value c (ImplEnvM m c))) (Maybe TCScheme, Expr () SourcePos))])] ->
   Map.Map ModuleName (PinnedModule (ImplEnvM m c (TermEnv VCObjectHash c (ImplEnvM m c))))
 buildPinnedQQModules modules =
@@ -95,7 +94,7 @@ buildPinnedQQModules modules =
       modules
   where
     buildModule ::
-      (MonadError EvalError m, Pretty c) =>
+      (MonadThrow m, Pretty c) =>
       Map.Map (Scoped ModuleName) (Map.Map Namespace (Pinned VCObjectHash)) ->
       Map.Map ModuleName (PinnedModule (ImplEnvM m c (TermEnv VCObjectHash c (ImplEnvM m c)))) ->
       [TopLevelDefn (Either (TCScheme, ImplEnvM m c (Value c (ImplEnvM m c))) (Maybe TCScheme, Expr () SourcePos))] ->

--- a/inferno-core/src/Inferno/Module/Cast.hs
+++ b/inferno-core/src/Inferno/Module/Cast.hs
@@ -6,7 +6,7 @@
 -- module Inferno.Module.Cast (FromValue, ToValue) where
 module Inferno.Module.Cast where
 
-import Control.Monad.Except (MonadError (..))
+import Control.Monad.Catch (MonadCatch (..), MonadThrow (..))
 import Control.Monad.Reader (ask)
 import Data.Int (Int64)
 import qualified Data.Map as Map
@@ -37,11 +37,11 @@ type Either7 a b c d e f g = Either a (Either6 b c d e f g)
 
 -- | Types that can be converted to script values, allowing IO in the process.
 class ToValue c m a where
-  toValue :: MonadError EvalError m => a -> m (Value c m)
+  toValue :: MonadThrow m => a -> m (Value c m)
 
 -- | Class of types that can be converted from script values.
 class FromValue c m a where
-  fromValue :: MonadError EvalError m => (Value c m) -> m a
+  fromValue :: MonadThrow m => (Value c m) -> m a
 
 -- | Haskell types that can be casted to mask script types.
 class Kind0 a where
@@ -49,9 +49,9 @@ class Kind0 a where
 
 -- Instances
 
-couldNotCast :: forall c m a. (Pretty c, MonadError EvalError m, Typeable a) => Value c m -> m a
+couldNotCast :: forall c m a. (Pretty c, MonadThrow m, Typeable a) => Value c m -> m a
 couldNotCast v =
-  throwError $
+  throwM $
     CastError $
       "Could not cast value "
         <> (unpack $ renderPretty v)
@@ -106,12 +106,12 @@ instance Pretty c => FromValue c m Int64 where
 instance ToValue c m Int where
   toValue = toValue . (fromIntegral :: Int -> Int64)
 
-instance Pretty c => FromValue c m Int where
-  fromValue v = do
-    i <- fromValue v `catchError` (\_ -> couldNotCast v)
+instance (Pretty c) => FromValue c m Int where
+  fromValue v@(VInt i) =
     if (i :: Int64) < fromIntegral (minBound :: Int) || i > fromIntegral (maxBound :: Int)
       then couldNotCast v
       else pure $ fromIntegral i
+  fromValue v = couldNotCast v
 
 instance ToValue c m Integer where
   toValue = pure . VInt . fromInteger
@@ -220,7 +220,7 @@ instance (Monad m, FromValue c (ImplEnvM m c) a1, FromValue c (ImplEnvM m c) a2,
           x <- fromValue v
           b <- fromValue b'
           toValue $ f x b
-        Nothing -> throwError $ NotFoundInImplicitEnv i
+        Nothing -> throwM $ NotFoundInImplicitEnv i
 
 -- | In this instance, the 'IO' in the type is ignored.
 instance Kind0 a => Kind0 (IO a) where
@@ -249,8 +249,8 @@ instance (Typeable a, FromValue c m a, Pretty c) => FromValue c m [a] where
   fromValue (VArray vs) = mapM fromValue vs
   fromValue v = couldNotCast v
 
-instance (FromValue c m a, FromValue c m b) => FromValue c m (Either a b) where
-  fromValue v = (Left <$> fromValue v) `catchError` (\_ -> Right <$> fromValue v)
+instance (FromValue c m a, FromValue c m b, MonadCatch m) => FromValue c m (Either a b) where
+  fromValue v = (Left <$> fromValue v) `catch` (\(_ :: EvalError) -> Right <$> fromValue v)
 
 instance Kind0 (Either a b) where
   toType _ = error "Definitions with Either must have explicit type signature"
@@ -274,7 +274,7 @@ instance Kind0 (Either a b) where
 --   toValue (Here  x) = toValue x
 --   toValue (Next x) = toValue x
 
--- serializeToDouble :: MonadError EvalError m => Env -> Value m' -> m Double
+-- serializeToDouble :: MonadThrow m => Env -> Value m' -> m Double
 -- serializeToDouble TypeEnv{..} = \case
 --   VInt i -> return $ fromIntegral i
 --   VDouble d -> return d
@@ -283,13 +283,13 @@ instance Kind0 (Either a b) where
 --   VEnum e -> case Map.lookup e enums of
 --     Just (EnumMeta _ _ cs _) -> case fromIntegral <$> elemIndex e cs of
 --       Just d -> return d
---       Nothing -> throwError $ RuntimeError $ "Malformed environment! Could not find enum constructor in the list"
---     Just _ -> throwError $ RuntimeError $ "Malformed environment! Was expecting enum metadata"
---     Nothing -> throwError $ CastError $ "Enum #" <> Text.unpack e <> " could not be found in the environment."
+--       Nothing -> throwM $ RuntimeError $ "Malformed environment! Could not find enum constructor in the list"
+--     Just _ -> throwM $ RuntimeError $ "Malformed environment! Was expecting enum metadata"
+--     Nothing -> throwM $ CastError $ "Enum #" <> Text.unpack e <> " could not be found in the environment."
 --   VWord16 w -> return $ fromIntegral w
 --   VWord32 w -> return $ fromIntegral w
 --   VWord64 w -> return $ fromIntegral w
 
--- -- deserializeFromDouble :: MonadError EvalError m => Env -> Double -> InfernoType -> m (Value m')
+-- -- deserializeFromDouble :: MonadThrow m => Env -> Double -> InfernoType -> m (Value m')
 -- -- deserializeFromDouble env d = \case
 -- --   TBase TInt -> return $ VInt $

--- a/inferno-core/src/Inferno/Module/Prelude.hs
+++ b/inferno-core/src/Inferno/Module/Prelude.hs
@@ -8,6 +8,7 @@
 module Inferno.Module.Prelude where
 
 import Control.Monad.Except (MonadError)
+import Control.Monad.IO.Class (MonadIO)
 import qualified Data.IntMap as IntMap
 import qualified Data.Map as Map
 import Inferno.Eval (TermEnv)
@@ -79,6 +80,7 @@ import Inferno.Module.Prelude.Defs
     orFun,
     piFun,
     powFun,
+    randomFun,
     recipFun,
     roundFun,
     roundToFun,
@@ -112,7 +114,6 @@ import Inferno.Module.Prelude.Defs
     yearFun,
     yearsBeforeFun,
     zeroFun,
-    randomFun,
   )
 import Inferno.Parse (OpsTable)
 import Inferno.Types.Syntax (ModuleName, Scoped (..))
@@ -121,7 +122,6 @@ import Inferno.Types.Value (ImplEnvM)
 import Inferno.Types.VersionControl (Pinned (..), VCObjectHash)
 import Inferno.Utils.QQ.Module (infernoModules)
 import Prettyprinter (Pretty)
-import Control.Monad.IO.Class (MonadIO)
 
 type ModuleMap m c = Map.Map ModuleName (PinnedModule (ImplEnvM m c (TermEnv VCObjectHash c (ImplEnvM m c))))
 

--- a/inferno-core/src/Inferno/Module/Prelude.hs
+++ b/inferno-core/src/Inferno/Module/Prelude.hs
@@ -112,6 +112,7 @@ import Inferno.Module.Prelude.Defs
     yearFun,
     yearsBeforeFun,
     zeroFun,
+    randomFun,
   )
 import Inferno.Parse (OpsTable)
 import Inferno.Types.Syntax (ModuleName, Scoped (..))
@@ -120,6 +121,7 @@ import Inferno.Types.Value (ImplEnvM)
 import Inferno.Types.VersionControl (Pinned (..), VCObjectHash)
 import Inferno.Utils.QQ.Module (infernoModules)
 import Prettyprinter (Pretty)
+import Control.Monad.IO.Class (MonadIO)
 
 type ModuleMap m c = Map.Map ModuleName (PinnedModule (ImplEnvM m c (TermEnv VCObjectHash c (ImplEnvM m c))))
 
@@ -163,7 +165,7 @@ preludeNameToTypeMap moduleMap =
 -- as these require an accompanying definition of a typeclass, via the syntax:
 -- `define typeclass_name on t1 ... tn;`.
 
-builtinModules :: (MonadError EvalError m, Pretty c, Eq c) => ModuleMap m c
+builtinModules :: (MonadIO m, MonadError EvalError m, Pretty c, Eq c) => ModuleMap m c
 builtinModules =
   [infernoModules|
 
@@ -336,9 +338,8 @@ module Number
   @doc Convert double to int;
   doubleToInt : double -> int := ###doubleToInt###;
 
-  // TODO how to deal with IO?
-  // @doc A (pseudo)random `double`;
-  // random : unit -> double := ###randomFun###;
+  @doc A (pseudo)random `double`;
+  random : () -> double := ###!randomFun###;
 
 module Option
   @doc `Option.reduce f o d` unwraps an optional value `o` and applies `f` to it, if o contains a `Some` value. Otherwise it returns the default value `d`.

--- a/inferno-core/src/Inferno/Module/Prelude.hs
+++ b/inferno-core/src/Inferno/Module/Prelude.hs
@@ -7,12 +7,11 @@
 
 module Inferno.Module.Prelude where
 
-import Control.Monad.Except (MonadError)
+import Control.Monad.Catch (MonadCatch (..), MonadThrow (..))
 import Control.Monad.IO.Class (MonadIO)
 import qualified Data.IntMap as IntMap
 import qualified Data.Map as Map
 import Inferno.Eval (TermEnv)
-import Inferno.Eval.Error (EvalError)
 import qualified Inferno.Infer.Pinned as Pinned
 import Inferno.Module (Module (..), PinnedModule, combineTermEnvs, pinnedModuleHashToTy, pinnedModuleNameToHash)
 import Inferno.Module.Builtin (builtinModule)
@@ -125,15 +124,15 @@ import Prettyprinter (Pretty)
 
 type ModuleMap m c = Map.Map ModuleName (PinnedModule (ImplEnvM m c (TermEnv VCObjectHash c (ImplEnvM m c))))
 
-baseOpsTable :: forall m c. (MonadError EvalError m, Pretty c, Eq c) => ModuleMap m c -> OpsTable
+baseOpsTable :: forall m c. (MonadThrow m, Pretty c, Eq c) => ModuleMap m c -> OpsTable
 baseOpsTable moduleMap =
   let Module {moduleOpsTable = ops, moduleName = modNm} = moduleMap Map.! "Base"
    in IntMap.unionWith (<>) ops (IntMap.map (\xs -> [(fix, Scope modNm, op) | (fix, _, op) <- xs]) ops)
 
-builtinModulesOpsTable :: forall m c. (MonadError EvalError m, Pretty c, Eq c) => ModuleMap m c -> Map.Map ModuleName OpsTable
+builtinModulesOpsTable :: forall m c. (MonadThrow m, Pretty c, Eq c) => ModuleMap m c -> Map.Map ModuleName OpsTable
 builtinModulesOpsTable moduleMap = Map.map (\Module {moduleOpsTable} -> moduleOpsTable) $ moduleMap
 
-builtinModulesPinMap :: forall m c. (MonadError EvalError m, Pretty c, Eq c) => ModuleMap m c -> Map.Map (Scoped ModuleName) (Map.Map Namespace (Pinned VCObjectHash))
+builtinModulesPinMap :: forall m c. (MonadThrow m, Pretty c, Eq c) => ModuleMap m c -> Map.Map (Scoped ModuleName) (Map.Map Namespace (Pinned VCObjectHash))
 builtinModulesPinMap moduleMap =
   Pinned.openModule "Base" $
     Pinned.insertBuiltinModule $
@@ -141,10 +140,10 @@ builtinModulesPinMap moduleMap =
         Map.map (Map.map Builtin . pinnedModuleNameToHash) $
           moduleMap
 
-builtinModulesTerms :: forall m c. (MonadError EvalError m, Pretty c, Eq c) => ModuleMap m c -> ImplEnvM m c (TermEnv VCObjectHash c (ImplEnvM m c))
+builtinModulesTerms :: forall m c. (MonadThrow m, Pretty c, Eq c) => ModuleMap m c -> ImplEnvM m c (TermEnv VCObjectHash c (ImplEnvM m c))
 builtinModulesTerms moduleMap = combineTermEnvs moduleMap
 
-preludeNameToTypeMap :: forall m c. (MonadError EvalError m, Pretty c, Eq c) => ModuleMap m c -> Map.Map (Maybe ModuleName, Namespace) (TypeMetadata TCScheme)
+preludeNameToTypeMap :: forall m c. (MonadThrow m, Pretty c, Eq c) => ModuleMap m c -> Map.Map (Maybe ModuleName, Namespace) (TypeMetadata TCScheme)
 preludeNameToTypeMap moduleMap =
   let unqualifiedN2h = pinnedModuleNameToHash $ moduleMap Map.! "Base"
       n2h =
@@ -165,7 +164,7 @@ preludeNameToTypeMap moduleMap =
 -- as these require an accompanying definition of a typeclass, via the syntax:
 -- `define typeclass_name on t1 ... tn;`.
 
-builtinModules :: (MonadIO m, MonadError EvalError m, Pretty c, Eq c) => ModuleMap m c
+builtinModules :: (MonadIO m, MonadThrow m, MonadCatch m, Pretty c, Eq c) => ModuleMap m c
 builtinModules =
   [infernoModules|
 

--- a/inferno-core/src/Inferno/Module/Prelude/Defs.hs
+++ b/inferno-core/src/Inferno/Module/Prelude/Defs.hs
@@ -41,6 +41,8 @@ import Inferno.Types.Value (Value (..))
 import Inferno.Utils.Prettyprinter (renderPretty)
 import Prettyprinter (Pretty)
 import System.Posix.Types (EpochTime)
+import System.Random (randomIO)
+import Control.Monad.IO.Class (MonadIO)
 
 zeroVal :: Value c m
 zeroVal = VInt 0
@@ -116,6 +118,9 @@ formatTime :: CTime -> Text -> Text
 formatTime t f =
   let t1 = posixSecondsToUTCTime $ realToFrac t
    in pack $ Time.Format.formatTime Time.Format.defaultTimeLocale (unpack f) t1
+
+randomFun :: (MonadIO m) => Value c m
+randomFun = VFun $ \_ -> VDouble <$> randomIO
 
 keepSomesFun :: (MonadError EvalError m) => Value c m
 keepSomesFun =

--- a/inferno-core/src/Inferno/Module/Prelude/Defs.hs
+++ b/inferno-core/src/Inferno/Module/Prelude/Defs.hs
@@ -3,7 +3,7 @@
 module Inferno.Module.Prelude.Defs where
 
 import Control.Monad (foldM)
-import Control.Monad.Except (MonadError (throwError))
+import Control.Monad.Catch (MonadThrow (..))
 import Control.Monad.IO.Class (MonadIO)
 import Data.Bifunctor (bimap)
 import Data.Bits
@@ -122,7 +122,7 @@ formatTime t f =
 randomFun :: (MonadIO m) => Value c m
 randomFun = VFun $ \_ -> VDouble <$> randomIO
 
-keepSomesFun :: (MonadError EvalError m) => Value c m
+keepSomesFun :: (MonadThrow m) => Value c m
 keepSomesFun =
   VFun $ \case
     VArray xs ->
@@ -135,9 +135,9 @@ keepSomesFun =
             )
             []
             xs
-    _ -> throwError $ RuntimeError "keepSomes: expecting an array"
+    _ -> throwM $ RuntimeError "keepSomes: expecting an array"
 
-foldlFun :: (MonadError EvalError m) => Value c m
+foldlFun :: (MonadThrow m) => Value c m
 foldlFun =
   VFun $ \case
     VFun f ->
@@ -149,14 +149,14 @@ foldlFun =
                 ( \acc x ->
                     f acc >>= \case
                       VFun f' -> f' x
-                      _ -> throwError $ RuntimeError "reduce: expecting a function when folding"
+                      _ -> throwM $ RuntimeError "reduce: expecting a function when folding"
                 )
                 z
                 xs
-            _ -> throwError $ RuntimeError "reduce: expecting an array in the third argument"
-    _ -> throwError $ RuntimeError "reduce: expecting a function in the first argument"
+            _ -> throwM $ RuntimeError "reduce: expecting an array in the third argument"
+    _ -> throwM $ RuntimeError "reduce: expecting a function in the first argument"
 
-foldrFun :: (MonadError EvalError m) => Value c m
+foldrFun :: (MonadThrow m) => Value c m
 foldrFun =
   VFun $ \case
     VFun f ->
@@ -168,12 +168,12 @@ foldrFun =
                 ( \x acc ->
                     f x >>= \case
                       VFun f' -> f' acc
-                      _ -> throwError $ RuntimeError "reduceRight: expecting a function when folding"
+                      _ -> throwM $ RuntimeError "reduceRight: expecting a function when folding"
                 )
                 z
                 xs
-            _ -> throwError $ RuntimeError "reduceRight: expecting an array in the third argument"
-    _ -> throwError $ RuntimeError "reduceRight: expecting a function in the first argument"
+            _ -> throwM $ RuntimeError "reduceRight: expecting an array in the third argument"
+    _ -> throwM $ RuntimeError "reduceRight: expecting a function in the first argument"
 
 traceFun :: (Monad m, Pretty c) => (Value c m)
 traceFun = VFun $ \msg -> trace ("TRACE: " <> unpack (renderPretty msg)) $ return idFun
@@ -400,7 +400,7 @@ toWord16Fun = either fromBool (either id (either (fromIntegral . (.&.) 0xFFFF) (
 fromWordFun :: Either4 Bool Word16 Word32 Word64 -> Int64
 fromWordFun = either fromBool (either fromIntegral (either fromIntegral fromIntegral))
 
-zeroFun :: MonadError EvalError m => (Value c m)
+zeroFun :: MonadThrow m => (Value c m)
 zeroFun = VFun $ \case
   VTypeRep (TBase TInt) -> return $ VInt 0
   VTypeRep (TBase TDouble) -> return $ VDouble 0
@@ -408,14 +408,14 @@ zeroFun = VFun $ \case
   VTypeRep (TBase TWord16) -> return $ VWord16 0
   VTypeRep (TBase TWord32) -> return $ VWord32 0
   VTypeRep (TBase TWord64) -> return $ VWord64 0
-  VTypeRep ty -> throwError $ RuntimeError $ "zeroFun: unexpected runtimeRep " <> show ty
-  _ -> throwError $ RuntimeError "zeroFun: expecting a runtimeRep"
+  VTypeRep ty -> throwM $ RuntimeError $ "zeroFun: unexpected runtimeRep " <> show ty
+  _ -> throwM $ RuntimeError "zeroFun: expecting a runtimeRep"
 
-lengthFun :: (MonadError EvalError m) => Value c m
+lengthFun :: (MonadThrow m) => Value c m
 lengthFun =
   VFun $ \case
     VArray xs -> pure $ VInt $ fromIntegral $ length xs
-    _ -> throwError $ RuntimeError "length: expecting an array"
+    _ -> throwM $ RuntimeError "length: expecting an array"
 
 -- | Convenience function for comparing numbered value
 -- in an array while maintaining the original value type
@@ -428,26 +428,26 @@ keepNumberValues =
         _ -> Nothing
     )
 
-minimumFun :: (MonadError EvalError m) => Value c m
+minimumFun :: (MonadThrow m) => Value c m
 minimumFun =
   VFun $ \case
-    VArray [] -> throwError $ RuntimeError "minimum: expecting a non-empty array"
+    VArray [] -> throwM $ RuntimeError "minimum: expecting a non-empty array"
     VArray xs -> return $ fst $ minimumBy (comparing snd) $ keepNumberValues xs
-    _ -> throwError $ RuntimeError "minimum: expecting an array"
+    _ -> throwM $ RuntimeError "minimum: expecting an array"
 
-maximumFun :: (MonadError EvalError m) => Value c m
+maximumFun :: (MonadThrow m) => Value c m
 maximumFun =
   VFun $ \case
-    VArray [] -> throwError $ RuntimeError "maximum: expecting a non-empty array"
+    VArray [] -> throwM $ RuntimeError "maximum: expecting a non-empty array"
     VArray xs -> return $ fst $ maximumBy (comparing snd) $ keepNumberValues xs
-    _ -> throwError $ RuntimeError "maximum: expecting an array"
+    _ -> throwM $ RuntimeError "maximum: expecting an array"
 
-averageFun :: (MonadError EvalError m) => Value c m
+averageFun :: (MonadThrow m) => Value c m
 averageFun =
   VFun $ \case
-    VArray [] -> throwError $ RuntimeError "average: expecting a non-empty array"
+    VArray [] -> throwM $ RuntimeError "average: expecting a non-empty array"
     VArray xs -> return $ VDouble $ sum (mapMaybe toDouble xs) / fromIntegral (length xs)
-    _ -> throwError $ RuntimeError "average: expecting an array"
+    _ -> throwM $ RuntimeError "average: expecting an array"
   where
     toDouble :: Value c m -> Maybe Double
     toDouble = \case
@@ -455,42 +455,42 @@ averageFun =
       VDouble v -> Just v
       _ -> Nothing
 
-argminFun :: (MonadError EvalError m) => Value c m
+argminFun :: (MonadThrow m) => Value c m
 argminFun =
   VFun $ \case
     VArray xs -> pure $ VInt $ fromIntegral $ argMin' $ map snd $ keepNumberValues xs
-    _ -> throwError $ RuntimeError "argmin: expecting an array"
+    _ -> throwM $ RuntimeError "argmin: expecting an array"
   where
     argMin' :: [Double] -> Int
     argMin' = fst . minimumBy (comparing snd) . zip [0 ..]
 
-argmaxFun :: (MonadError EvalError m) => Value c m
+argmaxFun :: (MonadThrow m) => Value c m
 argmaxFun =
   VFun $ \case
     VArray xs -> pure $ VInt $ fromIntegral $ argMax' $ map snd $ keepNumberValues xs
-    _ -> throwError $ RuntimeError "argmax: expecting an array"
+    _ -> throwM $ RuntimeError "argmax: expecting an array"
   where
     argMax' :: [Double] -> Int
     argMax' = fst . maximumBy (comparing snd) . zip [0 ..]
 
-argsortFun :: (MonadError EvalError m) => Value c m
+argsortFun :: (MonadThrow m) => Value c m
 argsortFun =
   VFun $ \case
     VArray xs -> pure $ VArray $ argsort' $ keepNumberValues xs
-    _ -> throwError $ RuntimeError "argsort: expecting an array"
+    _ -> throwM $ RuntimeError "argsort: expecting an array"
   where
     argsort' :: [(Value c m, Double)] -> [Value c m]
     argsort' xs = map (VInt . fst) $ sortOn (snd . snd) $ zip [0 ..] xs
 
-magnitudeFun :: (MonadError EvalError m) => Value c m
+magnitudeFun :: (MonadThrow m) => Value c m
 magnitudeFun =
   VFun $ \case
     VDouble x -> pure $ VDouble $ abs x
     VInt x -> pure $ VInt $ abs x
     VArray xs -> pure $ VDouble $ sqrt $ sum $ map (\x -> x ** 2) $ map snd (keepNumberValues xs)
-    _ -> throwError $ RuntimeError "magnitude: expecting a number"
+    _ -> throwM $ RuntimeError "magnitude: expecting a number"
 
-normFun :: (MonadError EvalError m) => Value c m
+normFun :: (MonadThrow m) => Value c m
 normFun = magnitudeFun
 
 appendText :: Text -> Text -> Text
@@ -502,7 +502,7 @@ textLength = fromIntegral . Text.length
 stripText :: Text -> Text
 stripText = Text.strip
 
-textSplitAt :: (MonadError EvalError m) => Value c m
+textSplitAt :: (MonadThrow m) => Value c m
 textSplitAt =
   VFun $ \case
     VInt n -> pure $
@@ -510,8 +510,8 @@ textSplitAt =
         VText txt ->
           let (a, b) = Text.splitAt (fromIntegral n) txt
            in pure $ VTuple [VText a, VText b]
-        _ -> throwError $ RuntimeError "splitAt: expecting text for the second argument"
-    _ -> throwError $ RuntimeError "splitAt: expecting an int for the first argument"
+        _ -> throwM $ RuntimeError "splitAt: expecting text for the second argument"
+    _ -> throwM $ RuntimeError "splitAt: expecting an int for the first argument"
 
 -- | Convert unsigned integer to binary-coded decimal.
 toBCD :: Word -> Word

--- a/inferno-core/src/Inferno/Module/Prelude/Defs.hs
+++ b/inferno-core/src/Inferno/Module/Prelude/Defs.hs
@@ -4,6 +4,7 @@ module Inferno.Module.Prelude.Defs where
 
 import Control.Monad (foldM)
 import Control.Monad.Except (MonadError (throwError))
+import Control.Monad.IO.Class (MonadIO)
 import Data.Bifunctor (bimap)
 import Data.Bits
   ( clearBit,
@@ -42,7 +43,6 @@ import Inferno.Utils.Prettyprinter (renderPretty)
 import Prettyprinter (Pretty)
 import System.Posix.Types (EpochTime)
 import System.Random (randomIO)
-import Control.Monad.IO.Class (MonadIO)
 
 zeroVal :: Value c m
 zeroVal = VInt 0

--- a/inferno-core/src/Inferno/Utils/QQ/Script.hs
+++ b/inferno-core/src/Inferno/Utils/QQ/Script.hs
@@ -5,6 +5,8 @@
 
 module Inferno.Utils.QQ.Script where
 
+import Control.Monad.Except (MonadError)
+import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.Reader (ReaderT (..))
 import Control.Monad.Writer (WriterT (..), appEndo)
 import qualified Crypto.Hash as Crypto
@@ -40,8 +42,6 @@ import Text.Megaparsec
     errorOffset,
     runParser',
   )
-import Control.Monad.IO.Class (MonadIO)
-import Control.Monad.Except (MonadError)
 
 inferno :: forall m c. (MonadIO m, MonadError EvalError m, Pretty c, Eq c) => QuasiQuoter
 inferno =

--- a/inferno-core/src/Inferno/Utils/QQ/Script.hs
+++ b/inferno-core/src/Inferno/Utils/QQ/Script.hs
@@ -5,7 +5,7 @@
 
 module Inferno.Utils.QQ.Script where
 
-import Control.Monad.Except (MonadError)
+import Control.Monad.Catch (MonadCatch (..), MonadThrow (..))
 import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.Reader (ReaderT (..))
 import Control.Monad.Writer (WriterT (..), appEndo)
@@ -18,7 +18,6 @@ import Data.List (intercalate)
 import qualified Data.List.NonEmpty as NEList
 import qualified Data.Maybe as Maybe
 import Data.Text (pack)
-import Inferno.Eval.Error (EvalError)
 import Inferno.Infer (inferExpr)
 import Inferno.Infer.Pinned (pinExpr)
 import Inferno.Module.Prelude (baseOpsTable, builtinModules, builtinModulesOpsTable, builtinModulesPinMap)
@@ -43,7 +42,7 @@ import Text.Megaparsec
     runParser',
   )
 
-inferno :: forall m c. (MonadIO m, MonadError EvalError m, Pretty c, Eq c) => QuasiQuoter
+inferno :: forall m c. (MonadIO m, MonadThrow m, MonadCatch m, Pretty c, Eq c) => QuasiQuoter
 inferno =
   QuasiQuoter
     { quoteExp = \str -> do

--- a/inferno-core/src/Inferno/Utils/QQ/Script.hs
+++ b/inferno-core/src/Inferno/Utils/QQ/Script.hs
@@ -40,8 +40,10 @@ import Text.Megaparsec
     errorOffset,
     runParser',
   )
+import Control.Monad.IO.Class (MonadIO)
+import Control.Monad.Except (MonadError)
 
-inferno :: forall c. (Pretty c, Eq c) => QuasiQuoter
+inferno :: forall m c. (MonadIO m, MonadError EvalError m, Pretty c, Eq c) => QuasiQuoter
 inferno =
   QuasiQuoter
     { quoteExp = \str -> do
@@ -71,7 +73,7 @@ inferno =
       quoteDec = error "inferno: Invalid use of this quasi-quoter in top-level declaration context."
     }
   where
-    builtins = builtinModules @(Either EvalError) @c
+    builtins = builtinModules @m @c
     vcObjectHashToValue :: Crypto.Digest Crypto.SHA256 -> Maybe TH.ExpQ
     vcObjectHashToValue h =
       let str = (convert h) :: ByteString

--- a/inferno-core/test/Utils.hs
+++ b/inferno-core/test/Utils.hs
@@ -2,8 +2,6 @@
 
 module Utils where
 
-import Control.Monad.Catch (MonadCatch)
-import Control.Monad.Except (ExceptT)
 import qualified Data.Map as Map
 import Inferno.Eval as Eval
 import Inferno.Eval.Error (EvalError (..))
@@ -22,25 +20,24 @@ import Inferno.Types.VersionControl (Pinned (..), VCObjectHash)
 
 type TestCustomValue = ()
 
-builtinModules :: Map.Map ModuleName (PinnedModule (ImplEnvM (ExceptT EvalError IO) TestCustomValue (Eval.TermEnv VCObjectHash TestCustomValue (ImplEnvM (ExceptT EvalError IO) TestCustomValue))))
-builtinModules = Prelude.builtinModules @(ExceptT EvalError IO) @TestCustomValue
+builtinModules :: Map.Map ModuleName (PinnedModule (ImplEnvM IO TestCustomValue (Eval.TermEnv VCObjectHash TestCustomValue (ImplEnvM IO TestCustomValue))))
+builtinModules = Prelude.builtinModules @IO @TestCustomValue
 
 builtinModulesOpsTable :: Map.Map ModuleName OpsTable
-builtinModulesOpsTable = Prelude.builtinModulesOpsTable @(ExceptT EvalError IO) @TestCustomValue builtinModules
+builtinModulesOpsTable = Prelude.builtinModulesOpsTable @IO @TestCustomValue builtinModules
 
 builtinModulesPinMap :: Map.Map (Scoped ModuleName) (Map.Map Namespace (Pinned VCObjectHash))
-builtinModulesPinMap = Prelude.builtinModulesPinMap @(ExceptT EvalError IO) @TestCustomValue builtinModules
+builtinModulesPinMap = Prelude.builtinModulesPinMap @IO @TestCustomValue builtinModules
 
 baseOpsTable :: OpsTable
-baseOpsTable = Prelude.baseOpsTable @(ExceptT EvalError IO) @TestCustomValue builtinModules
+baseOpsTable = Prelude.baseOpsTable @IO @TestCustomValue builtinModules
 
-builtinModulesTerms :: ImplEnvM (ExceptT EvalError IO) TestCustomValue (Eval.TermEnv VCObjectHash TestCustomValue (ImplEnvM (ExceptT EvalError IO) TestCustomValue))
-builtinModulesTerms = Prelude.builtinModulesTerms @(ExceptT EvalError IO) @TestCustomValue builtinModules
+builtinModulesTerms :: ImplEnvM IO TestCustomValue (Eval.TermEnv VCObjectHash TestCustomValue (ImplEnvM IO TestCustomValue))
+builtinModulesTerms = Prelude.builtinModulesTerms @IO @TestCustomValue builtinModules
 
 runEvalIO ::
-  (MonadCatch m) =>
-  ImplEnvM (ExceptT EvalError m) TestCustomValue (Eval.TermEnv VCObjectHash TestCustomValue (ImplEnvM (ExceptT EvalError m) TestCustomValue)) ->
-  Map.Map ExtIdent (Value TestCustomValue (ImplEnvM (ExceptT EvalError m) TestCustomValue)) ->
+  ImplEnvM IO TestCustomValue (TermEnv VCObjectHash TestCustomValue (ImplEnvM IO TestCustomValue)) ->
+  Map.Map ExtIdent (Value TestCustomValue (ImplEnvM IO TestCustomValue)) ->
   Expr (Maybe VCObjectHash) a ->
-  m (Either EvalError (Value TestCustomValue (ImplEnvM (ExceptT EvalError m) TestCustomValue)))
-runEvalIO = Eval.runEvalIO @_ @TestCustomValue
+  IO (Either EvalError (Value TestCustomValue (ImplEnvM IO TestCustomValue)))
+runEvalIO = Eval.runEvalIO @TestCustomValue

--- a/inferno-lsp/CHANGELOG.md
+++ b/inferno-lsp/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Revision History for inferno-lsp
+*Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
+
+## 0.1.2 -- 2023-05-30
+* Update inferno-core version
 
 ## 0.1.1 -- 2023-03-06
 * Update inferno-vc version

--- a/inferno-lsp/app/Main.hs
+++ b/inferno-lsp/app/Main.hs
@@ -3,14 +3,12 @@
 
 module Main where
 
-import Control.Monad.Except (ExceptT)
-import Inferno.Eval.Error (EvalError)
 import Inferno.LSP.Server (runInfernoLspServer)
 import Inferno.Module.Prelude (builtinModules)
 import System.Exit (ExitCode (ExitFailure), exitSuccess, exitWith)
 
 main :: IO ()
 main = do
-  runInfernoLspServer @() @(ExceptT EvalError IO) builtinModules >>= \case
+  runInfernoLspServer @() @IO builtinModules >>= \case
     0 -> exitSuccess
     c -> exitWith . ExitFailure $ c

--- a/inferno-lsp/app/Main.hs
+++ b/inferno-lsp/app/Main.hs
@@ -7,9 +7,10 @@ import Inferno.Eval.Error (EvalError)
 import Inferno.LSP.Server (runInfernoLspServer)
 import Inferno.Module.Prelude (builtinModules)
 import System.Exit (ExitCode (ExitFailure), exitSuccess, exitWith)
+import Control.Monad.Except (ExceptT)
 
 main :: IO ()
 main = do
-  runInfernoLspServer @() @(Either EvalError) builtinModules >>= \case
+  runInfernoLspServer @() @(ExceptT EvalError IO) builtinModules >>= \case
     0 -> exitSuccess
     c -> exitWith . ExitFailure $ c

--- a/inferno-lsp/app/Main.hs
+++ b/inferno-lsp/app/Main.hs
@@ -3,11 +3,11 @@
 
 module Main where
 
+import Control.Monad.Except (ExceptT)
 import Inferno.Eval.Error (EvalError)
 import Inferno.LSP.Server (runInfernoLspServer)
 import Inferno.Module.Prelude (builtinModules)
 import System.Exit (ExitCode (ExitFailure), exitSuccess, exitWith)
-import Control.Monad.Except (ExceptT)
 
 main :: IO ()
 main = do

--- a/inferno-lsp/inferno-lsp.cabal
+++ b/inferno-lsp/inferno-lsp.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                inferno-lsp
-version:             0.1.1
+version:             0.1.2
 synopsis:            LSP for Inferno
 description:         A language server protocol implementation for the Inferno language
 category:            IDE,DSL,Scripting

--- a/inferno-lsp/inferno-lsp.cabal
+++ b/inferno-lsp/inferno-lsp.cabal
@@ -33,6 +33,7 @@ library
     , bytestring                         >= 0.10.10 && < 0.12
     , co-log-core                        >= 0.3.1 && < 0.4
     , containers                         >= 0.6.2 && < 0.7
+    , exceptions                         >= 0.10.4 && < 0.11
     , inferno-core                       >= 0.2.0 && < 0.3
     , inferno-types                      >= 0.1.0 && < 0.2
     , inferno-vc                         >= 0.2.0 && < 0.3

--- a/inferno-lsp/inferno-lsp.cabal
+++ b/inferno-lsp/inferno-lsp.cabal
@@ -33,7 +33,7 @@ library
     , bytestring                         >= 0.10.10 && < 0.12
     , co-log-core                        >= 0.3.1 && < 0.4
     , containers                         >= 0.6.2 && < 0.7
-    , inferno-core                       >= 0.1.0 && < 0.2
+    , inferno-core                       >= 0.2.0 && < 0.3
     , inferno-types                      >= 0.1.0 && < 0.2
     , inferno-vc                         >= 0.2.0 && < 0.3
     , lsp                                >= 1.6.0 && < 1.7

--- a/inferno-lsp/inferno-lsp.cabal
+++ b/inferno-lsp/inferno-lsp.cabal
@@ -73,4 +73,5 @@ executable inferno-lsp-server
       base >=4.7 && <5
     , inferno-core
     , inferno-lsp
+    , mtl
   default-language: Haskell2010

--- a/inferno-lsp/src/Inferno/LSP/Completion.hs
+++ b/inferno-lsp/src/Inferno/LSP/Completion.hs
@@ -5,14 +5,13 @@
 
 module Inferno.LSP.Completion where
 
-import Control.Monad.Except (MonadError)
+import Control.Monad.Catch (MonadThrow (..))
 import Data.List (delete, nub)
 import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Map as Map
 import qualified Data.Maybe as Maybe
 import Data.Text (Text)
 import qualified Data.Text as Text
-import Inferno.Eval.Error (EvalError)
 import Inferno.LSP.ParseInfer (getTypeMetadataText, mkPrettyTy)
 import Inferno.Module.Prelude (ModuleMap)
 import Inferno.Types.Syntax (Ident (..), ModuleName (..), rws)
@@ -100,7 +99,7 @@ findInPrelude preludeNameToTypeMap prefix =
         ModuleNamespace (ModuleName n) -> lcPrefix `Text.isPrefixOf` Text.append mn' (Text.toLower n)
         TypeNamespace _ -> False
 
-mkCompletionItem :: forall m c. (MonadError EvalError m, Pretty c, Eq c) => ModuleMap m c -> Text -> (Maybe ModuleName, Namespace) -> TypeMetadata TCScheme -> CompletionItem
+mkCompletionItem :: forall m c. (MonadThrow m, Pretty c, Eq c) => ModuleMap m c -> Text -> (Maybe ModuleName, Namespace) -> TypeMetadata TCScheme -> CompletionItem
 mkCompletionItem prelude txt (modNm, ns) tm@TypeMetadata {ty} =
   CompletionItem
     { _label = insertModNm $ renderPretty ns,

--- a/inferno-types/CHANGELOG.md
+++ b/inferno-types/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Revision History for inferno-types
+*Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
 ## 0.1.2 -- 2023-02-00
 * Remove Arbitrary and ToADTArbitrary instances

--- a/inferno-types/inferno-types.cabal
+++ b/inferno-types/inferno-types.cabal
@@ -38,6 +38,7 @@ library
     , cereal                             >= 0.5.8 && < 0.6
     , containers                         >= 0.6.2 && < 0.7
     , cryptonite                         >= 0.30 && < 0.31
+    , exceptions                         >= 0.10.4 && < 0.11
     , deepseq                            >= 1.4.4 && < 1.5
     , hashable                           >= 1.4.1 && < 1.5
     , megaparsec                         >= 9.2.1 && < 9.3

--- a/inferno-vc/CHANGELOG.md
+++ b/inferno-vc/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Revision History for inferno-vc
+*Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
 ## 0.2.1 -- 2023-04-26
 * Fixes an issue in `fetchVCObjectHistory` that occurred when deleting the source script immediately after cloning it


### PR DESCRIPTION
This PR adds IO to the monad stack of the inferno interpreter. This is needed to have primitives whose implementations perform IO actions, e.g., impure random number generation. This will also be used by the ML primitives that call out to torch.