### PR TITLE
LSP: error if script evaluates to a function

### DIFF
--- a/inferno-lsp/CHANGELOG.md
+++ b/inferno-lsp/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Revision History for inferno-lsp
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.1.4 -- 2023-06-19
+* Raise error if script evaluates to a function (and suggest adding input parameters instead)
+
 ## 0.1.3 -- 2023-06-14
 * Update inferno-core version and remove unused packages
 

--- a/inferno-lsp/inferno-lsp.cabal
+++ b/inferno-lsp/inferno-lsp.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                inferno-lsp
-version:             0.1.3
+version:             0.1.4
 synopsis:            LSP for Inferno
 description:         A language server protocol implementation for the Inferno language
 category:            IDE,DSL,Scripting


### PR DESCRIPTION
I added a check in the LSP that checks if the script type returns a function (by checking if it expects more inputs than input parameters supplied). This should warn users and make it less likely that they confuse the input parameters that are selected in the frontend UI with the parameters of a lambda function.