### PR TITLE
Upgrade to GHC 9.2.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ jobs:
           extra_nix_config: |
             substituters = https://cache.nixos.org https://cache.iog.io
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
+            narinfo-cache-negative-ttl = 60
       - uses: cachix/cachix-action@v12
         with:
           name: inferno

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
           extra_nix_config: |
             substituters = https://cache.nixos.org https://cache.iog.io
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
-      - uses: cachix/cachix-action@v8
+      - uses: cachix/cachix-action@v12
         with:
           name: inferno
           authToken: "${{ secrets.CACHIX_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ $ cd ./vscode-inferno-syntax-highlighting
 
 To build/run Inferno on GPU machines, use the
 ```
-nix develop .#ghc924-cuda
+nix develop .#ghc925-cuda
 ```
 dev-shell. You can run a test on the GPU with
 ```
@@ -213,13 +213,13 @@ To run a formatting check that will fail if any files are not formatted, run `ni
 We have a profiling build of the inferno binary, which can be used via:
 
 ```
-$ nix run .#inferno-core:exe:inferno-ghc924-prof 
+$ nix run .#inferno-core:exe:inferno-ghc925-prof
 ```
 
 Or equivalently:
 
 ```
-$ nix build .#inferno-core:exe:inferno-ghc924-prof
+$ nix build .#inferno-core:exe:inferno-ghc925-prof
 $ ./result/bin/inferno
 ```
 One can also obtain a shell with profiling enabled:

--- a/flake.nix
+++ b/flake.nix
@@ -282,7 +282,7 @@
           # To run a check for a particular compiler version, suffix the derivation
           # name with the GHC version, e.g.
           #
-          # `nix build .#checks.x86_64-linux.inferno-core:test:inferno-tests-ghc924`
+          # `nix build .#checks.x86_64-linux.inferno-core:test:inferno-tests-ghc925`
           checks = flakes.${defaultCompiler}.checks
             // collectOutputs "checks" flakes;
 

--- a/flake.nix
+++ b/flake.nix
@@ -52,7 +52,7 @@
     let
       inherit (nixpkgs) lib;
 
-      defaultCompiler = "ghc924";
+      defaultCompiler = "ghc925";
 
       # Takes an attribute set mapping compiler versions to `flake`s generated
       # by `haskell.nix` and suffixes each derivation in all flake outputs

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -74,10 +74,8 @@ pkgs.haskell-nix.cabalProject {
     withHoogle = false;
     tools = {
       cabal = { };
-      # FIXME
-      # See https://github.com/plow-technologies/inferno/issues/25
-      #
-      # # This is the final supported version for our current compilers
+      # We can't have HLS for both compiler versions
+    } // lib.optionalAttrs isAtLeastGhc924 {
       haskell-language-server = {
         # This is broken and we don't need it as a plugin
         configureArgs = "-f-stylishHaskell";

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -80,6 +80,13 @@ pkgs.haskell-nix.cabalProject {
       haskell-language-server = {
         # This is broken and we don't need it as a plugin
         configureArgs = "-f-stylishHaskell";
+        version = "1.9.0.0";
+        src = pkgs.lib.mkForce (pkgs.fetchFromGitHub {
+          owner = "haskell";
+          repo = "haskell-language-server";
+          rev = "2598fcec399835a3ac83e76e8b3451f1dd9a86a1";
+          sha256 = "sha256-5ylyv4reSVCz2xCrNVsHF3MfcuSbju8cKUbQmZa04ns=";
+        });
       };
     };
     buildInputs = [ config.treefmt.build.wrapper ]

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -81,12 +81,16 @@ pkgs.haskell-nix.cabalProject {
         # This is broken and we don't need it as a plugin
         configureArgs = "-f-stylishHaskell";
         version = "1.9.0.0";
-        src = pkgs.lib.mkForce (pkgs.fetchFromGitHub {
-          owner = "haskell";
-          repo = "haskell-language-server";
-          rev = "2598fcec399835a3ac83e76e8b3451f1dd9a86a1";
-          sha256 = "sha256-5ylyv4reSVCz2xCrNVsHF3MfcuSbju8cKUbQmZa04ns=";
-        });
+        # It seems that HLS from our hackage.nix has some issues. Rather than
+        # upgrading hackage.nix, we can just override the source
+        src = pkgs.lib.mkForce (
+          pkgs.fetchFromGitHub {
+            owner = "haskell";
+            repo = "haskell-language-server";
+            rev = "2598fcec399835a3ac83e76e8b3451f1dd9a86a1";
+            sha256 = "sha256-5ylyv4reSVCz2xCrNVsHF3MfcuSbju8cKUbQmZa04ns=";
+          }
+        );
       };
     };
     buildInputs = [ config.treefmt.build.wrapper ]

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,4 +1,4 @@
-{ compiler ? "ghc924"
+{ compiler ? "ghc925"
 , config
 , ghcOptions ? [ ]
 , profiling ? false
@@ -78,7 +78,10 @@ pkgs.haskell-nix.cabalProject {
       # See https://github.com/plow-technologies/inferno/issues/25
       #
       # # This is the final supported version for our current compilers
-      # haskell-language-server = "1.8.0.0";
+      haskell-language-server = {
+        # This is broken and we don't need it as a plugin
+        configureArgs = "-f-stylishHaskell";
+      };
     };
     buildInputs = [ config.treefmt.build.wrapper ]
       ++ builtins.attrValues config.treefmt.build.programs;


### PR DESCRIPTION
Closes #25 

I'd like to do this for a few reason:
- `haskell-language-server` integration is currently broken, this fixes that
- we're planning GHC upgrades elsewhere, it's a good idea to do this incrementally, especially considering our recent Hasktorch integration
- using `cabal repl` with GHC 9.2.4 (which is my primary development mode) has an irritating bug where auto-completing any module name leads to a compiler panic

Note: I haven't changed anything else regarding e.g. the `index-state`, so we're still using the same dependencies. The only other change is that now some of the flake outputs are suffixed with `-ghc925` instead of `-ghc924`