### PR TITLE
Fix `torch` versions, document, use on CI

### DIFF
--- a/.github/torch.sh
+++ b/.github/torch.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+mkdir -p "$(dirname "${MNIST_FNAME}")"
+cd "$(dirname "${MNIST_FNAME}")" || exit
+wget "https://github.com/hasktorch/hasktorch/raw/${MNIST_COMMIT}/examples/model-serving/04-python-torchscript/mnist.py"
+python mnist.py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,11 +45,7 @@ jobs:
       - name: Download and train MNIST (if not cached)
         if: steps.cache-mnist.outputs.cache-hit != 'true'
         run: |
-          mkdir -p "$(dirname ${MNIST_FNAME})"
-          cd "$(dirname ${MNIST_FNAME})"
-          nix develop .#pytorch
-          wget https://github.com/hasktorch/hasktorch/raw/${MNIST_COMMIT}/examples/model-serving/04-python-torchscript/mnist.py
-          python mnist.py
+          nix develop .#pytorch -c .github/torch.sh
       - name: Cache MNIST model
         uses: actions/cache/save@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,9 +47,7 @@ jobs:
         run: |
           mkdir -p "$(dirname ${MNIST_FNAME})"
           cd "$(dirname ${MNIST_FNAME})"
-          python -m pip install --upgrade pip
-          # Need specific torch version for the serialized torchscript models (e.g. Bert) to be compatible with hasktorch:
-          pip install torch==1.11.0+cpu torchvision==0.12.0+cpu torchaudio==0.11.0 --extra-index-url https://download.pytorch.org/whl/cpu
+          nix develop .#pytorch
           wget https://github.com/hasktorch/hasktorch/raw/${MNIST_COMMIT}/examples/model-serving/04-python-torchscript/mnist.py
           python mnist.py
       - name: Cache MNIST model

--- a/README.md
+++ b/README.md
@@ -200,6 +200,16 @@ cabal run inferno-ml-exe inferno-ml/test/test-gpu.inferno
 ```
 (expected output `Tensor Float []  8.5899e9`)
 
+#### Development with `pytorch`
+
+When working with `inferno-ml`, there may be cases where you need to use `pytorch` directly. `devShells..pytorch` can be used to obtain a development environment with the `torch-bin` package and dependencies and a Python interpreter:
+
+```
+nix develop .#pytorch
+```
+
+The `torch` version and its dependencies are the same as those used in Inferno's Hasktorch integration and should be compatible with `inferno-ml`.
+
 ### Formatting all sources
 
 To format all of the Nix and Haskell sources, run `nix fmt`. Alternately, running `nix develop` and then the command `treefmt` in the development shell will perform the same formatting.

--- a/flake.lock
+++ b/flake.lock
@@ -910,6 +910,10 @@
           "nixpkgs-unstable"
         ],
         "npm-buildpackage": "npm-buildpackage",
+        "stable": [
+          "haskell-nix",
+          "nixpkgs-2205"
+        ],
         "tokenizers": "tokenizers",
         "treefmt-nix": "treefmt-nix"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,7 @@
 
   inputs = {
     nixpkgs.follows = "haskell-nix/nixpkgs-unstable";
+    stable.follows = "haskell-nix/nixpkgs-2205";
     flake-parts.url = "github:hercules-ci/flake-parts";
     treefmt-nix.url = "github:numtide/treefmt-nix";
     # haskell.nix has far better support for multi-component projects, so it's
@@ -168,7 +169,11 @@
             overlays = [ self.overlays.combined ];
           };
 
-          legacyPackages = pkgs // infernoFor { compiler = defaultCompiler; };
+          legacyPackages = pkgs // infernoFor {
+            compiler = defaultCompiler;
+          } // {
+            stable = inputs.stable.legacyPackages.${system};
+          };
 
           # To enter a development environment for a particular GHC version, use
           # the compiler name, e.g. `nix develop .#ghc8107`

--- a/flake.nix
+++ b/flake.nix
@@ -169,10 +169,10 @@
             overlays = [ self.overlays.combined ];
           };
 
-          legacyPackages = pkgs // infernoFor {
-            compiler = defaultCompiler;
-          } // {
+          legacyPackages = pkgs // {
             stable = inputs.stable.legacyPackages.${system};
+          } // infernoFor {
+            compiler = defaultCompiler;
           };
 
           # To enter a development environment for a particular GHC version, use
@@ -211,8 +211,12 @@
                 pkgs.mkShell {
                   packages = [
                     (
-                      pkgs.python3.withPackages (
-                        ps: with ps; [ torch torchvision ]
+                      legacyPackages.stable.python3.withPackages (
+                        ps: with ps; [
+                          pytorch-bin
+                          torchvision-bin
+                          torchaudio-bin
+                        ]
                       )
                     )
                   ];


### PR DESCRIPTION
Closes #65. Previously `devShells..pytorch` was using an incorrect version (one major version too high). I added something to the docs mentioning `devShells..pytorch` and also used it to run the MNIST example on CI. This way we will always be using the same version everywhere. I temporarily modified the workflow file in order to ignore the cache and ran the CI job manually and it worked (otherwise that part wouldn't run because it's been cached)