### PR TITLE
Don't build `devShells..default`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -252,10 +252,7 @@
                 {
                   combined =
                     builtins.concatLists [
-                      [
-                        self.checks.${system}.treefmt
-                        flakes.${defaultCompiler}.devShell
-                      ]
+                      [ self.checks.${system}.treefmt ]
                       (builtins.attrValues flakes.${defaultCompiler}.checks)
                       (
                         builtins.attrValues (


### PR DESCRIPTION
Since merging the GHC upgrade it seems that HLS gets rebuilt on every CI run. We don't actually need to have the dev shell built and it appears to be working locally, so we can disable it for the time being while I investigate