### PR TITLE
Generate `cabal.project.local` in the `shellHook`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -15,14 +15,3 @@ source-repository-package
     location: https://github.com/plow-technologies/hspec-golden-cereal.git
     tag: f9e3e485409c5a1de1de99a8ec0f35226c79da79
     --sha256: j+SZk5AZsNP674fb+1aiA7vrsk6Eq5BQM2losQSnaeE=
-
--- NOTE
--- Do not remove or change the following comment! It's necessary to make
--- haskell.nix work with the conditional below!
-
--- *SNIP*
-
--- All Hasktorch-related things need to go into this separate cabal.project,
--- otherwise we can't build with GHC 8.x
-if impl(ghc >= 9)
-   import: nix/ghc9.cabal.project


### PR DESCRIPTION
This removes the awful hack I originally implemented to get the conditional import in the `cabal.project` working with haskell.nix. The GHC 9 config is still read in conditionally in the haskell.nix setup, but I removed it from the main `cabal.project` (so it doesn't need to be removed when building with Nix as before)

For building outside of Nix, the `shellHook` in `devShells..default` now generates a `cabal.project.local` with the `import` stanza (but it won't overwrite an existing file). This is nice because it can imported using an absolute path this, which wasn't possible before, so Cabal and HLS will actually work now if invoked from a different directory than the project root