### PR TITLE
Ensure scripts are Lam(...) and better error message when not

### DIFF
--- a/inferno-lsp/CHANGELOG.md
+++ b/inferno-lsp/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Revision History for inferno-lsp
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.1.8 -- 2023-08-07
+* Ensure parsed Expr looks like: Lam (...)
+
 ## 0.1.7 -- 2023-07-11
 * Update inferno-types version
 

--- a/inferno-lsp/inferno-lsp.cabal
+++ b/inferno-lsp/inferno-lsp.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                inferno-lsp
-version:             0.1.7
+version:             0.1.8
 synopsis:            LSP for Inferno
 description:         A language server protocol implementation for the Inferno language
 category:            IDE,DSL,Scripting

--- a/inferno-types/CHANGELOG.md
+++ b/inferno-types/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Revision History for inferno-types
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.2.1 -- 2023-08-07
+* Nicer error message when extractArgsAndPrettyPrint fails
+
 ## 0.2.0 -- 2023-07-11
 * Add Array pattern matching syntax
 

--- a/inferno-types/inferno-types.cabal
+++ b/inferno-types/inferno-types.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                inferno-types
-version:             0.2.0
+version:             0.2.1
 synopsis:            Core types for Inferno
 description:         Core types for the Inferno language
 category:            DSL,Scripting

--- a/inferno-types/src/Inferno/Types/Syntax.hs
+++ b/inferno-types/src/Inferno/Types/Syntax.hs
@@ -1055,15 +1055,15 @@ hideInternalIdents = ana $ \case
 
 -- | Extract the arguments of a script and pretty print the script body.
 -- This hides the internal variable arguments.
-extractArgsAndPrettyPrint :: Expr hash pos -> Either String ([Maybe Ident], Text)
+extractArgsAndPrettyPrint :: Expr hash pos -> ([Maybe Ident], Text)
 extractArgsAndPrettyPrint expr =
   extract False [] (hideInternalIdents expr)
   where
     extract foundLam args = \case
       Lam _ (x :| xs) _ e -> extract True (args <> map snd (x : xs)) e
-      e | foundLam -> Right (mapMaybe extIdentToIdent args, renderPretty e)
+      e | foundLam -> (mapMaybe extIdentToIdent args, renderPretty e)
       e ->
-        Left $
+        error $
           "Corrupted script. Expected a Lam but got "
             ++ take 20 (show $ bimap (const ()) (const ()) e)
             ++ "..."

--- a/inferno-types/src/Inferno/Types/Syntax.hs
+++ b/inferno-types/src/Inferno/Types/Syntax.hs
@@ -97,6 +97,7 @@ import Control.DeepSeq (NFData (..))
 import Control.Monad (replicateM)
 import Data.Aeson (FromJSON (..), FromJSONKey (..), FromJSONKeyFunction (FromJSONKeyTextParser), ToJSON (..), ToJSONKey (..))
 import Data.Aeson.Types (toJSONKeyText)
+import Data.Bifunctor (bimap)
 import Data.Bifunctor.TH (deriveBifunctor)
 import Data.Data (Constr, Data (..), Typeable, gcast1, mkConstr, mkDataType)
 import qualified Data.Data as Data
@@ -1054,13 +1055,16 @@ hideInternalIdents = ana $ \case
 
 -- | Extract the arguments of a script and pretty print the script body.
 -- This hides the internal variable arguments.
-extractArgsAndPrettyPrint :: Expr hash pos -> ([Maybe Ident], Text)
+extractArgsAndPrettyPrint :: Expr hash pos -> Either String ([Maybe Ident], Text)
 extractArgsAndPrettyPrint expr =
-  extract [] (hideInternalIdents expr)
+  extract False [] (hideInternalIdents expr)
   where
-    extract args = \case
-      Lam _ (x :| xs) _ e -> extract (args <> map snd (x : xs)) e
-      e -> (mapMaybe extIdentToIdent args, renderPretty e)
+    extract foundLam args = \case
+      Lam _ (x :| xs) _ e -> extract True (args <> map snd (x : xs)) e
+      e | foundLam -> Right (mapMaybe extIdentToIdent args, renderPretty e)
+      e -> Left $
+        "Corrupted script. Expected a Lam but got "
+        ++ take 20 (show $ bimap (const ()) (const ()) e) ++ "..."
     -- Strip the runtime type rep arguments, and convert others to Ident
     extIdentToIdent = \case
       (Just (ExtIdent (Left _))) -> Nothing

--- a/inferno-types/src/Inferno/Types/Syntax.hs
+++ b/inferno-types/src/Inferno/Types/Syntax.hs
@@ -1062,9 +1062,11 @@ extractArgsAndPrettyPrint expr =
     extract foundLam args = \case
       Lam _ (x :| xs) _ e -> extract True (args <> map snd (x : xs)) e
       e | foundLam -> Right (mapMaybe extIdentToIdent args, renderPretty e)
-      e -> Left $
-        "Corrupted script. Expected a Lam but got "
-        ++ take 20 (show $ bimap (const ()) (const ()) e) ++ "..."
+      e ->
+        Left $
+          "Corrupted script. Expected a Lam but got "
+            ++ take 20 (show $ bimap (const ()) (const ()) e)
+            ++ "..."
     -- Strip the runtime type rep arguments, and convert others to Ident
     extIdentToIdent = \case
       (Just (ExtIdent (Left _))) -> Nothing


### PR DESCRIPTION
A script like `"foo" // bar` with input parameter `input0` was being saved by LSP as `CommentAfter(... Lam(...))` which broke `extractArgsAndPrettyPrint`, which expects it to look like `Lam(...)`.

This PR ensures that the LSP returns an Expr that has Lam as the outermost constructor.