### PR TITLE
Pluggable storage backend

### DIFF
--- a/inferno-vc/inferno-vc.cabal
+++ b/inferno-vc/inferno-vc.cabal
@@ -30,6 +30,7 @@ library
     , Inferno.VersionControl.Server.Types
     , Inferno.VersionControl.Server.UnzipRequest
     , Inferno.VersionControl.Types
+    , Inferno.VersionControl.Testing
   hs-source-dirs:
       src
   ghc-options: -Wall -Wunused-packages -Wincomplete-uni-patterns -Wincomplete-record-updates
@@ -64,6 +65,8 @@ library
     , yaml                               >= 0.11.8 && < 0.12
     , zlib                               >= 0.6.3 && < 0.7
     , atomic-write                       >= 0.2   && < 0.3
+    , hspec
+    , QuickCheck
 
   default-language: Haskell2010
   default-extensions:
@@ -84,17 +87,11 @@ test-suite inferno-vc-tests
   main-is:             Spec.hs
   build-depends:
       base >=4.7 && <5
-    , containers
     , hspec
     , http-client
-    , inferno-types
     , inferno-vc
-    , QuickCheck
     , servant-client
-    , servant-server
-    , servant-typed-error
     , temporary
-    , time
   default-language:    Haskell2010
   default-extensions:
       DeriveDataTypeable

--- a/inferno-vc/inferno-vc.cabal
+++ b/inferno-vc/inferno-vc.cabal
@@ -88,7 +88,6 @@ test-suite inferno-vc-tests
   build-depends:
       base >=4.7 && <5
     , hspec
-    , http-client
     , inferno-vc
     , servant-client
     , temporary

--- a/inferno-vc/inferno-vc.cabal
+++ b/inferno-vc/inferno-vc.cabal
@@ -89,10 +89,8 @@ test-suite inferno-vc-tests
       base >=4.7 && <5
     , hspec
     , inferno-vc
-    , plow-log
     , servant-client
     , temporary
-    , text
   default-language:    Haskell2010
   default-extensions:
       DeriveDataTypeable

--- a/inferno-vc/inferno-vc.cabal
+++ b/inferno-vc/inferno-vc.cabal
@@ -23,6 +23,7 @@ library
       Inferno.VersionControl.Client
     , Inferno.VersionControl.Client.Cached
     , Inferno.VersionControl.Operations
+    , Inferno.VersionControl.Operations.Filesystem
     , Inferno.VersionControl.Operations.Error
     , Inferno.VersionControl.Log
     , Inferno.VersionControl.Server
@@ -62,6 +63,7 @@ library
     , warp                               >= 3.3.23 && < 3.4
     , yaml                               >= 0.11.8 && < 0.12
     , zlib                               >= 0.6.3 && < 0.7
+    , atomic-write                       >= 0.2   && < 0.3
 
   default-language: Haskell2010
   default-extensions:

--- a/inferno-vc/inferno-vc.cabal
+++ b/inferno-vc/inferno-vc.cabal
@@ -89,8 +89,10 @@ test-suite inferno-vc-tests
       base >=4.7 && <5
     , hspec
     , inferno-vc
+    , plow-log
     , servant-client
     , temporary
+    , text
   default-language:    Haskell2010
   default-extensions:
       DeriveDataTypeable

--- a/inferno-vc/src/Inferno/VersionControl/Client/Cached.hs
+++ b/inferno-vc/src/Inferno/VersionControl/Client/Cached.hs
@@ -17,7 +17,6 @@ import qualified Data.ByteString as B
 import qualified Data.ByteString.Base64.URL as Base64
 import qualified Data.ByteString.Char8 as Char8
 import qualified Data.ByteString.Lazy as BL
-import System.AtomicWrite.Writer.LazyByteString (atomicWriteFile)
 import Data.Either (partitionEithers)
 import Data.Generics.Product (HasType, getTyped)
 import Data.Generics.Sum (AsType (..))
@@ -34,6 +33,7 @@ import Inferno.VersionControl.Types
   )
 import Servant.Client (ClientEnv, ClientError)
 import Servant.Typed.Error (TypedClientM, runTypedClientM)
+import System.AtomicWrite.Writer.LazyByteString (atomicWriteFile)
 import System.Directory (createDirectoryIfMissing, doesFileExist)
 import System.FilePath.Posix ((</>))
 
@@ -48,7 +48,6 @@ data CachedVCClientError
 initVCCachedClient :: VCCachePath -> IO ()
 initVCCachedClient (VCCachePath storePath) =
   createDirectoryIfMissing True $ storePath </> "deps"
-
 
 fetchVCObjectClosure ::
   ( MonadError err m,

--- a/inferno-vc/src/Inferno/VersionControl/Client/Cached.hs
+++ b/inferno-vc/src/Inferno/VersionControl/Client/Cached.hs
@@ -1,39 +1,144 @@
-module Inferno.VersionControl.Client.Cached where
+module Inferno.VersionControl.Client.Cached
+  ( VCCachePath (..),
+    CachedVCClientError (..),
+    fetchVCObjectClosure,
+    initVCCachedClient,
+  )
+where
 
 import Control.Monad (forM, forM_)
 import Control.Monad.Error.Lens (throwing)
 import Control.Monad.Except (MonadError (..))
 import Control.Monad.IO.Class (MonadIO (..))
-import Control.Monad.Reader (MonadReader (..))
-import Data.Aeson (FromJSON, ToJSON, encode)
+import Control.Monad.Reader (MonadReader (..), asks)
+import Crypto.Hash (digestFromByteString)
+import Data.Aeson (FromJSON, ToJSON, eitherDecode, encode)
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Base64.URL as Base64
+import qualified Data.ByteString.Char8 as Char8
 import qualified Data.ByteString.Lazy as BL
+import System.AtomicWrite.Writer.LazyByteString (atomicWriteFile)
 import Data.Either (partitionEithers)
 import Data.Generics.Product (HasType, getTyped)
 import Data.Generics.Sum (AsType (..))
 import qualified Data.Map as Map
 import GHC.Generics (Generic)
 import qualified Inferno.VersionControl.Client as VCClient
-import Inferno.VersionControl.Log (VCServerTrace)
-import qualified Inferno.VersionControl.Operations as Ops
-import qualified Inferno.VersionControl.Operations.Error as Ops
+import Inferno.VersionControl.Operations.Error (VCStoreError (..))
 import Inferno.VersionControl.Server (VCServerError)
 import Inferno.VersionControl.Types
   ( VCMeta,
     VCObject,
-    VCObjectHash,
+    VCObjectHash (..),
     vcObjectHashToByteString,
   )
-import Plow.Logging (IOTracer)
 import Servant.Client (ClientEnv, ClientError)
 import Servant.Typed.Error (TypedClientM, runTypedClientM)
-import System.Directory (doesFileExist)
+import System.Directory (createDirectoryIfMissing, doesFileExist)
 import System.FilePath.Posix ((</>))
+
+newtype VCCachePath = VCCachePath FilePath deriving (Generic)
 
 data CachedVCClientError
   = ClientVCStoreError VCServerError
   | ClientServantError ClientError
-  | LocalVCStoreError Ops.VCStoreError
+  | LocalVCStoreError VCStoreError
   deriving (Show, Generic)
+
+initVCCachedClient :: VCCachePath -> IO ()
+initVCCachedClient (VCCachePath storePath) =
+  createDirectoryIfMissing True $ storePath </> "deps"
+
+
+fetchVCObjectClosure ::
+  ( MonadError err m,
+    HasType VCCachePath env,
+    HasType ClientEnv env,
+    AsType VCServerError err,
+    AsType ClientError err,
+    AsType VCStoreError err,
+    MonadReader env m,
+    MonadIO m,
+    FromJSON a,
+    FromJSON g,
+    ToJSON a,
+    ToJSON g
+  ) =>
+  ([VCObjectHash] -> VCClient.ClientMWithVCStoreError (Map.Map VCObjectHash (VCMeta a g VCObject))) ->
+  (VCObjectHash -> VCClient.ClientMWithVCStoreError [VCObjectHash]) ->
+  VCObjectHash ->
+  m (Map.Map VCObjectHash (VCMeta a g VCObject))
+fetchVCObjectClosure fetchVCObjects remoteFetchVCObjectClosureHashes objHash = do
+  VCCachePath storePath <- getTyped <$> ask
+  deps <-
+    (liftIO $ doesFileExist $ storePath </> "deps" </> show objHash) >>= \case
+      False -> do
+        deps <- liftServantClient $ remoteFetchVCObjectClosureHashes objHash
+        liftIO
+          $ atomicWriteFile
+            (storePath </> "deps" </> show objHash)
+          $ BL.concat [BL.fromStrict (vcObjectHashToByteString h) <> "\n" | h <- deps]
+        pure deps
+      True -> fetchVCObjectClosureHashes objHash
+  (nonLocalHashes, localHashes) <-
+    partitionEithers
+      <$> ( forM (objHash : deps) $ \depHash -> do
+              (liftIO $ doesFileExist $ storePath </> show depHash) >>= \case
+                True -> pure $ Right depHash
+                False -> pure $ Left depHash
+          )
+  localObjs <-
+    Map.fromList
+      <$> ( forM localHashes $ \h ->
+              (h,) <$> fetchVCObjectUnsafe h
+          )
+
+  nonLocalObjs <- liftServantClient $ fetchVCObjects nonLocalHashes
+  forM_ (Map.toList nonLocalObjs) $ \(h, o) ->
+    liftIO $ atomicWriteFile (storePath </> show h) $ encode o
+  pure $ localObjs `Map.union` nonLocalObjs
+
+fetchVCObjectClosureHashes ::
+  ( MonadError err m,
+    MonadIO m,
+    MonadReader env m,
+    AsType VCStoreError err,
+    HasType VCCachePath env
+  ) =>
+  VCObjectHash ->
+  m [VCObjectHash]
+fetchVCObjectClosureHashes h = do
+  VCCachePath storePath <- asks getTyped
+  let fp = storePath </> "deps" </> show h
+  readVCObjectHashTxt fp
+
+readVCObjectHashTxt ::
+  ( MonadError err m,
+    AsType VCStoreError err,
+    MonadIO m
+  ) =>
+  FilePath ->
+  m [VCObjectHash]
+readVCObjectHashTxt fp = do
+  deps <- filter (not . B.null) . Char8.lines <$> (liftIO $ B.readFile fp)
+  forM deps $ \dep -> do
+    decoded <- either (const $ throwing _Typed $ InvalidHash $ Char8.unpack dep) pure $ Base64.decode dep
+    maybe (throwing _Typed $ InvalidHash $ Char8.unpack dep) (pure . VCObjectHash) $ digestFromByteString decoded
+
+fetchVCObjectUnsafe ::
+  ( MonadReader r m,
+    HasType VCCachePath r,
+    MonadError e m,
+    AsType VCStoreError e,
+    MonadIO m,
+    FromJSON b
+  ) =>
+  VCObjectHash ->
+  m b
+fetchVCObjectUnsafe h = do
+  VCCachePath storePath <- asks getTyped
+  let fp = storePath </> show h
+  either (throwing _Typed . CouldNotDecodeObject h) pure =<< liftIO (eitherDecode <$> BL.readFile fp)
 
 liftServantClient ::
   ( MonadError e m,
@@ -48,54 +153,6 @@ liftServantClient ::
 liftServantClient m = do
   client <- getTyped <$> ask
   (liftIO $ runTypedClientM m client) >>= \case
-    Left (Left clientErr) -> throwing _Typed $ clientErr
-    Left (Right serverErr) -> throwing _Typed $ serverErr
+    Left (Left clientErr) -> throwing _Typed clientErr
+    Left (Right serverErr) -> throwing _Typed serverErr
     Right res -> pure res
-
-fetchVCObjectClosure ::
-  ( AsType VCServerError err,
-    AsType ClientError err,
-    AsType Ops.VCStoreError err,
-    MonadError err m,
-    HasType (IOTracer VCServerTrace) env,
-    HasType Ops.VCStorePath env,
-    HasType ClientEnv env,
-    MonadReader env m,
-    MonadIO m,
-    FromJSON a,
-    FromJSON g,
-    ToJSON a,
-    ToJSON g
-  ) =>
-  ([VCObjectHash] -> VCClient.ClientMWithVCStoreError (Map.Map VCObjectHash (VCMeta a g VCObject))) ->
-  (VCObjectHash -> VCClient.ClientMWithVCStoreError [VCObjectHash]) ->
-  VCObjectHash ->
-  m (Map.Map VCObjectHash (VCMeta a g VCObject))
-fetchVCObjectClosure fetchVCObjects fetchVCObjectClosureHashes objHash = do
-  Ops.VCStorePath storePath <- getTyped <$> ask
-  deps <-
-    (liftIO $ doesFileExist $ storePath </> "deps" </> show objHash) >>= \case
-      False -> do
-        deps <- liftServantClient $ fetchVCObjectClosureHashes objHash
-        Ops.writeBS
-          (storePath </> "deps" </> show objHash)
-          $ BL.concat [BL.fromStrict (vcObjectHashToByteString h) <> "\n" | h <- deps]
-        pure deps
-      True -> Ops.fetchVCObjectClosureHashes objHash
-  (nonLocalHashes, localHashes) <-
-    partitionEithers
-      <$> ( forM (objHash : deps) $ \depHash -> do
-              (liftIO $ doesFileExist $ storePath </> show depHash) >>= \case
-                True -> pure $ Right depHash
-                False -> pure $ Left depHash
-          )
-  localObjs <-
-    Map.fromList
-      <$> ( forM localHashes $ \h ->
-              (h,) <$> Ops.fetchVCObjectUnsafe h
-          )
-
-  nonLocalObjs <- liftServantClient $ fetchVCObjects nonLocalHashes
-  forM_ (Map.toList nonLocalObjs) $ \(h, o) ->
-    liftIO $ BL.writeFile (storePath </> show h) $ encode o
-  pure $ localObjs `Map.union` nonLocalObjs

--- a/inferno-vc/src/Inferno/VersionControl/Log.hs
+++ b/inferno-vc/src/Inferno/VersionControl/Log.hs
@@ -13,6 +13,7 @@ data VCServerTrace
   | ReadJSON FilePath
   | ReadTxt FilePath
   | DeleteFile FilePath
+  | Running
 
 vcServerTraceToText :: VCServerTrace -> Text
 vcServerTraceToText = \case
@@ -23,3 +24,4 @@ vcServerTraceToText = \case
   ReadTxt fp -> "Reading TXT at: " <> pack fp
   ThrownVCStoreError e -> pack (vcStoreErrorToString e)
   DeleteFile fp -> "Deleting file: " <> pack fp
+  Running -> "running..."

--- a/inferno-vc/src/Inferno/VersionControl/Log.hs
+++ b/inferno-vc/src/Inferno/VersionControl/Log.hs
@@ -1,6 +1,8 @@
+{-# LANGUAGE OverloadedStrings #-}
 module Inferno.VersionControl.Log where
 
 import Inferno.VersionControl.Operations.Error (VCStoreError, vcStoreErrorToString)
+import Data.Text (Text, pack)
 
 data VCServerTrace
   = ThrownVCStoreError VCStoreError
@@ -11,12 +13,12 @@ data VCServerTrace
   | ReadTxt FilePath
   | DeleteFile FilePath
 
-vcServerTraceToString :: VCServerTrace -> String
-vcServerTraceToString = \case
-  WriteJSON fp -> "Writing JSON at: " <> fp
-  WriteTxt fp -> "Writing TXT at: " <> fp
-  AlreadyExistsJSON fp -> "JSON already exists at: " <> fp
-  ReadJSON fp -> "Reading JSON at: " <> fp
-  ReadTxt fp -> "Reading TXT at: " <> fp
-  ThrownVCStoreError e -> vcStoreErrorToString e
-  DeleteFile fp -> "Deleting file: " <> fp
+vcServerTraceToText :: VCServerTrace -> Text
+vcServerTraceToText = \case
+  WriteJSON fp -> "Writing JSON at: " <> pack fp
+  WriteTxt fp -> "Writing TXT at: " <> pack fp
+  AlreadyExistsJSON fp -> "JSON already exists at: " <> pack fp
+  ReadJSON fp -> "Reading JSON at: " <> pack fp
+  ReadTxt fp -> "Reading TXT at: " <> pack fp
+  ThrownVCStoreError e -> pack (vcStoreErrorToString e)
+  DeleteFile fp -> "Deleting file: " <> pack fp

--- a/inferno-vc/src/Inferno/VersionControl/Log.hs
+++ b/inferno-vc/src/Inferno/VersionControl/Log.hs
@@ -13,7 +13,6 @@ data VCServerTrace
   | ReadJSON FilePath
   | ReadTxt FilePath
   | DeleteFile FilePath
-  | Running
 
 vcServerTraceToText :: VCServerTrace -> Text
 vcServerTraceToText = \case
@@ -24,4 +23,3 @@ vcServerTraceToText = \case
   ReadTxt fp -> "Reading TXT at: " <> pack fp
   ThrownVCStoreError e -> pack (vcStoreErrorToString e)
   DeleteFile fp -> "Deleting file: " <> pack fp
-  Running -> "running..."

--- a/inferno-vc/src/Inferno/VersionControl/Log.hs
+++ b/inferno-vc/src/Inferno/VersionControl/Log.hs
@@ -1,8 +1,9 @@
 {-# LANGUAGE OverloadedStrings #-}
+
 module Inferno.VersionControl.Log where
 
-import Inferno.VersionControl.Operations.Error (VCStoreError, vcStoreErrorToString)
 import Data.Text (Text, pack)
+import Inferno.VersionControl.Operations.Error (VCStoreError, vcStoreErrorToString)
 
 data VCServerTrace
   = ThrownVCStoreError VCStoreError

--- a/inferno-vc/src/Inferno/VersionControl/Operations.hs
+++ b/inferno-vc/src/Inferno/VersionControl/Operations.hs
@@ -4,15 +4,7 @@
 -- Module      : Inferno.VersionControl.Operations
 -- Description : Generic operations on the Inferno version control store
 --
--- This module defines operations on the Inferno VC store. The store structure is as follows:
---
--- * `<storePath>` stores the JSON serialised `VCMeta VCObject`s, where the filename is the cryptographic hash (`VCOBjectHash`) of the object's contents
--- * `<storePath>/heads` is a set of current HEAD objects of the store, which can be seen as the roots of the VC tree. Each filename is the hash of an object,
---    and the file's contents are all the predecessors of this object, in chronological order, starting from the time it was created or cloned.
--- * `<storePath>/to_head` is a map from every `VCOBjectHash` to its current HEAD, where the file name is the source hash and the contents of the file are the HEAD hash
--- * `<storePath>/deps` is a map from every `VCOBjectHash` to its (transitive) dependencies, i.e. the file `<storePath>/deps/<hash>` describes the closure of `<hash>`
--- * Deleting `VCMeta VCObject` - Delete is implemented as soft delete. Object is moved to a directory called `removed`. Object's preds are also removed.
---   When an object is removed, its directory structure is preserved so you can undo it easily. i.e. `removed` directory has the same structure as `vc_store` directory.
+-- This module defines operations on the Inferno VC store.
 module Inferno.VersionControl.Operations
   ( InfernoVCOperations (..),
   )
@@ -41,7 +33,6 @@ class (AsType VCStoreError err, MonadError err m) => InfernoVCOperations err m w
   deleteAutosavedVCObject :: VCObjectHash -> m ()
 
   -- | Soft delete script and its history (both predecessors and successors).
-  -- All scripts and their references are moved to "removed" directory
   deleteVCObjects :: VCObjectHash -> m ()
 
   fetchVCObject :: (Deserializable m a, Deserializable m g) => VCObjectHash -> m (VCMeta a g VCObject)
@@ -53,7 +44,7 @@ class (AsType VCStoreError err, MonadError err m) => InfernoVCOperations err m w
 
   -- | Fetch all objects that are public or that belong to the given set of groups.
   -- Note this is a potentially long operation so no locks are held while traversing the
-  -- store and checking every object -- making this operation weakly consistent.
+  -- store and checking every object making this operation weakly consistent.
   -- This means the returned list does not necessarily reflect the state of the store at any
   -- point in time.
   fetchFunctionsForGroups :: (Ord g, Deserializable m a, Deserializable m g) => Set.Set g -> m [VCMeta a g VCObjectHash]

--- a/inferno-vc/src/Inferno/VersionControl/Operations.hs
+++ b/inferno-vc/src/Inferno/VersionControl/Operations.hs
@@ -40,11 +40,6 @@ class (AsType VCStoreError err, MonadError err m) => InfernoVCOperations err m w
   -- and to run tests against unsaved scripts
   deleteAutosavedVCObject :: VCObjectHash -> m ()
 
-  -- | Deletes all stale autosaved objects from the VC.
-  -- As this is a non-critical maintenance operation, we do not hold the lock around the
-  -- entire operation.
-  deleteStaleAutosavedVCObjects :: m ()
-
   -- | Soft delete script and its history (both predecessors and successors).
   -- All scripts and their references are moved to "removed" directory
   deleteVCObjects :: VCObjectHash -> m ()
@@ -52,7 +47,6 @@ class (AsType VCStoreError err, MonadError err m) => InfernoVCOperations err m w
   fetchVCObject :: (Deserializable m a, Deserializable m g) => VCObjectHash -> m (VCMeta a g VCObject)
 
   -- | Fetch all dependencies of an object.
-  -- NOTE: this is done without holding a lock, as dependencies are never modified.
   fetchVCObjectClosureHashes :: VCObjectHash -> m [VCObjectHash]
 
   fetchVCObjectHistory :: (Deserializable m a, Deserializable m g) => VCObjectHash -> m [VCMeta a g VCObjectHash]
@@ -63,3 +57,5 @@ class (AsType VCStoreError err, MonadError err m) => InfernoVCOperations err m w
   -- This means the returned list does not necessarily reflect the state of the store at any
   -- point in time.
   fetchFunctionsForGroups :: (Ord g, Deserializable m a, Deserializable m g) => Set.Set g -> m [VCMeta a g VCObjectHash]
+
+  getAllHeads :: m [VCObjectHash]

--- a/inferno-vc/src/Inferno/VersionControl/Operations.hs
+++ b/inferno-vc/src/Inferno/VersionControl/Operations.hs
@@ -11,10 +11,8 @@ module Inferno.VersionControl.Operations
 where
 
 import Control.Monad.Except (MonadError)
-import Data.Generics.Sum (AsType (..))
 import Data.Kind (Constraint, Type)
 import qualified Data.Set as Set
-import Inferno.VersionControl.Operations.Error (VCStoreError)
 import Inferno.VersionControl.Types
   ( VCHashUpdate,
     VCMeta (..),
@@ -22,7 +20,7 @@ import Inferno.VersionControl.Types
     VCObjectHash (..),
   )
 
-class (AsType VCStoreError err, MonadError err m) => InfernoVCOperations err m where
+class MonadError err m => InfernoVCOperations err m where
   type Serializable m :: Type -> Constraint
   type Deserializable m :: Type -> Constraint
 

--- a/inferno-vc/src/Inferno/VersionControl/Operations.hs
+++ b/inferno-vc/src/Inferno/VersionControl/Operations.hs
@@ -1,11 +1,8 @@
-{-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 
 -- |
 -- Module      : Inferno.VersionControl.Operations
--- Description : Operations on the Inferno version control store
+-- Description : Generic operations on the Inferno version control store
 --
 -- This module defines operations on the Inferno VC store. The store structure is as follows:
 --
@@ -16,424 +13,53 @@
 -- * `<storePath>/deps` is a map from every `VCOBjectHash` to its (transitive) dependencies, i.e. the file `<storePath>/deps/<hash>` describes the closure of `<hash>`
 -- * Deleting `VCMeta VCObject` - Delete is implemented as soft delete. Object is moved to a directory called `removed`. Object's preds are also removed.
 --   When an object is removed, its directory structure is preserved so you can undo it easily. i.e. `removed` directory has the same structure as `vc_store` directory.
-module Inferno.VersionControl.Operations where
+module Inferno.VersionControl.Operations
+  ( InfernoVCOperations (..),
+  )
+where
 
-import Control.Concurrent.FairRWLock (RWLock)
-import qualified Control.Concurrent.FairRWLock as RWL
-import Control.Exception (throwIO)
-import Control.Monad (foldM, forM, forM_)
-import Control.Monad.Catch (MonadMask, bracket_)
-import Control.Monad.Error.Lens (catching, throwing)
 import Control.Monad.Except (MonadError)
-import Control.Monad.IO.Class (MonadIO (..))
-import Control.Monad.Reader (MonadReader (..), asks)
-import Crypto.Hash (digestFromByteString)
-import Data.Aeson (FromJSON, ToJSON, Value, eitherDecode, encode)
-import qualified Data.ByteString as B
-import qualified Data.ByteString.Base64.URL as Base64
-import qualified Data.ByteString.Char8 as Char8
-import qualified Data.ByteString.Lazy as BL
-import Data.Generics.Product (HasType, getTyped)
 import Data.Generics.Sum (AsType (..))
-import qualified Data.Map as Map
+import Data.Kind (Constraint, Type)
 import qualified Data.Set as Set
-import Data.Text (pack)
-import Data.Time.Clock.POSIX (getPOSIXTime)
-import Foreign.C.Types (CTime (..))
-import GHC.Generics (Generic)
-import Inferno.Types.Syntax (Dependencies (..))
-import Inferno.VersionControl.Log (VCServerTrace (..))
-import Inferno.VersionControl.Operations.Error (VCStoreError (..))
+import Inferno.VersionControl.Operations.Error (VCStoreError)
 import Inferno.VersionControl.Types
   ( VCHashUpdate,
     VCMeta (..),
     VCObject (..),
     VCObjectHash (..),
-    VCObjectPred (..),
-    VCObjectVisibility (..),
-    vcHash,
-    vcObjectHashToByteString,
   )
-import Plow.Logging (IOTracer, traceWith)
-import System.Directory (createDirectoryIfMissing, doesFileExist, getDirectoryContents, removeFile, renameFile)
-import System.FilePath.Posix (takeFileName, (</>))
 
-newtype VCStorePath = VCStorePath FilePath deriving (Generic)
+class (AsType VCStoreError err, MonadError err m) => InfernoVCOperations err m where
+  type Serializable m :: Type -> Constraint
+  type Deserializable m :: Type -> Constraint
 
-type VCStoreErrM err m = (AsType VCStoreError err, MonadError err m, MonadIO m)
+  storeVCObject :: (VCHashUpdate a, VCHashUpdate g, Serializable m a, Serializable m g, Deserializable m a, Deserializable m g) => VCMeta a g VCObject -> m VCObjectHash
 
-type VCStoreLogM env m = (HasType (IOTracer VCServerTrace) env, MonadReader env m, MonadIO m)
+  -- | Delete a temporary object from the VC. This is used for autosaved scripts
+  -- and to run tests against unsaved scripts
+  deleteAutosavedVCObject :: VCObjectHash -> m ()
 
-type VCStoreEnvM env m = (HasType VCStorePath env, MonadReader env m, MonadIO m)
+  -- | Deletes all stale autosaved objects from the VC.
+  -- As this is a non-critical maintenance operation, we do not hold the lock around the
+  -- entire operation.
+  deleteStaleAutosavedVCObjects :: m ()
 
-type VCStoreLockM env m = (HasType RWLock env, MonadReader env m, MonadIO m, MonadMask m)
+  -- | Soft delete script and its history (both predecessors and successors).
+  -- All scripts and their references are moved to "removed" directory
+  deleteVCObjects :: VCObjectHash -> m ()
 
-withWrite :: (MonadIO m, MonadMask m) => RWLock -> m a -> m a
-withWrite lock = bracket_ (liftIO $ RWL.acquireWrite lock) (liftIO $ RWL.releaseWrite lock >>= either throwIO return)
+  fetchVCObject :: (Deserializable m a, Deserializable m g) => VCObjectHash -> m (VCMeta a g VCObject)
 
-withRead :: (MonadIO m, MonadMask m) => RWLock -> m a -> m a
-withRead lock = bracket_ (liftIO $ RWL.acquireRead lock) (liftIO $ RWL.releaseRead lock >>= either throwIO return)
+  -- | Fetch all dependencies of an object.
+  -- NOTE: this is done without holding a lock, as dependencies are never modified.
+  fetchVCObjectClosureHashes :: VCObjectHash -> m [VCObjectHash]
 
-trace :: VCStoreLogM env m => VCServerTrace -> m ()
-trace t = do
-  tracer <- getTyped <$> ask
-  traceWith @IOTracer tracer t
+  fetchVCObjectHistory :: (Deserializable m a, Deserializable m g) => VCObjectHash -> m [VCMeta a g VCObjectHash]
 
-throwError :: (VCStoreLogM env m, VCStoreErrM err m) => VCStoreError -> m a
-throwError e = do
-  trace $ ThrownVCStoreError e
-  throwing _Typed e
-
-initVCStore :: VCStoreEnvM env m => m ()
-initVCStore =
-  (getTyped <$> ask) >>= \(VCStorePath storePath) -> liftIO $ do
-    createDirectoryIfMissing True $ storePath </> "heads"
-    createDirectoryIfMissing True $ storePath </> "to_head"
-    createDirectoryIfMissing True $ storePath </> "deps"
-
-initVCCachedClient :: VCStoreEnvM env m => m ()
-initVCCachedClient =
-  (getTyped <$> ask) >>= \(VCStorePath storePath) -> liftIO $ do
-    createDirectoryIfMissing True $ storePath </> "deps"
-
-checkPathExists :: (VCStoreLogM env m, VCStoreErrM err m) => FilePath -> m ()
-checkPathExists fp =
-  liftIO (doesFileExist fp) >>= \case
-    False -> throwError $ CouldNotFindPath fp
-    True -> pure ()
-
-getDepsFromStore :: (VCStoreLogM env m, VCStoreErrM err m) => FilePath -> VCObjectHash -> m BL.ByteString
-getDepsFromStore path h = do
-  let fp = path </> show h
-  checkPathExists fp
-  liftIO $ BL.readFile $ path </> show h
-
-appendBS :: (VCStoreLogM env m) => FilePath -> BL.ByteString -> m ()
-appendBS fp bs = do
-  trace $ WriteTxt fp
-  liftIO $ BL.appendFile fp bs
-
-writeBS :: (VCStoreLogM env m) => FilePath -> BL.ByteString -> m ()
-writeBS fp bs = do
-  trace $ WriteTxt fp
-  liftIO $ BL.writeFile fp bs
-
-writeHashedJSON :: (VCStoreLogM env m, VCHashUpdate obj, ToJSON obj) => FilePath -> obj -> m VCObjectHash
-writeHashedJSON path o = do
-  let h = vcHash o
-  exists <- liftIO $ doesFileExist path
-  if exists
-    then trace $ AlreadyExistsJSON (path </> show h)
-    else do
-      trace $ WriteJSON (path </> show h)
-      liftIO $ BL.writeFile (path </> show h) $ encode o
-  pure h
-
-readVCObjectHashTxt :: (VCStoreLogM env m, VCStoreErrM err m) => FilePath -> m [VCObjectHash]
-readVCObjectHashTxt fp = do
-  checkPathExists fp
-  trace $ ReadTxt fp
-  deps <- filter (not . B.null) . Char8.lines <$> (liftIO $ B.readFile fp)
-  forM deps $ \dep -> do
-    decoded <- either (const $ throwError $ InvalidHash $ Char8.unpack dep) pure $ Base64.decode dep
-    maybe (throwError $ InvalidHash $ Char8.unpack dep) (pure . VCObjectHash) $ digestFromByteString decoded
-
-storeVCObject :: forall env err m a g. (VCStoreLogM env m, VCStoreErrM err m, VCStoreEnvM env m, VCStoreLockM env m, VCHashUpdate a, VCHashUpdate g, ToJSON a, ToJSON g, FromJSON a, FromJSON g) => VCMeta a g VCObject -> m VCObjectHash
-storeVCObject obj@VCMeta {obj = ast, pred = p} = do
-  VCStorePath storePath <- asks getTyped
-  lock <- asks getTyped
-  -- if the new object has a direct predecessor (i.e. is not a clone or an initial commit)
-  --  we need to make sure that the predecessor is currently a HEAD object in the store
-  let maybeCurrentHead = case p of
-        Init -> Nothing
-        CloneOf _ -> Nothing
-        CloneOfRemoved _ -> Nothing
-        CloneOfNotFound _ -> Nothing
-        CompatibleWithPred h -> Just h
-        IncompatibleWithPred h _ -> Just h
-        MarkedBreakingWithPred h -> Just h
-
-  withWrite lock $ do
-    obj_h <- case maybeCurrentHead of
-      Just pred_hash -> do
-        let head_fp = storePath </> "heads" </> show pred_hash
-        -- check to see if pred_hash exists in '<storePath>/heads`
-        exists_head <- liftIO $ doesFileExist head_fp
-        if exists_head
-          then do
-            -- we know that pred_h is currently HEAD, we can therefore store the object and metadata in the store
-            obj_h <- writeHashedJSON storePath obj
-            -- next we make the newly added object the HEAD
-            let new_head_fp = storePath </> "heads" </> show obj_h
-            liftIO $ renameFile head_fp new_head_fp
-            -- we append the previous head hash to the file (this serves as lookup for all the predecessors)
-            appendBS new_head_fp $ BL.fromStrict $ vcObjectHashToByteString pred_hash <> "\n"
-            -- now we need to change all the predecessor mappings in '<storePath>/to_head' to point to the new HEAD
-            -- we also include the new head pointing to itself
-            preds <- readVCObjectHashTxt new_head_fp
-            let obj_h_bs = BL.fromStrict $ vcObjectHashToByteString obj_h
-            forM_ (obj_h : preds) (\pred_h -> writeBS (storePath </> "to_head" </> show pred_h) obj_h_bs)
-
-            pure obj_h
-          else throwError $ TryingToAppendToNonHead pred_hash
-      Nothing -> do
-        obj_h <- writeHashedJSON storePath obj
-        -- as there is no previous HEAD for this object, we simply create a new one
-        let new_head_fp = storePath </> "heads" </> show obj_h
-        appendBS new_head_fp mempty
-
-        -- we again make sure to add a self reference link to the '<storePath>/to_head' map
-        let obj_h_bs = BL.fromStrict $ vcObjectHashToByteString obj_h
-        writeBS (storePath </> "to_head" </> show obj_h) obj_h_bs
-        pure obj_h
-
-    -- finally, we store the dependencies of the commited object by fetching the dependencies from the AST
-    let deps = Set.toList $ getDependencies ast
-    writeBS (storePath </> "deps" </> show obj_h) mempty
-    forM_ deps $ \dep_h -> do
-      -- first we append the direct dependency hash 'dep_h'
-      appendBS (storePath </> "deps" </> show obj_h) $ BL.fromStrict $ vcObjectHashToByteString dep_h <> "\n"
-      -- then we append the transitive dependencies of the given object, pointed to by the hash 'dep_h'
-      appendBS (storePath </> "deps" </> show obj_h) =<< getDepsFromStore (storePath </> "deps") dep_h
-
-    pure obj_h
-
--- | Delete a temporary object from the VC. This is used for autosaved scripts
--- and to run tests against unsaved scripts
-deleteAutosavedVCObject :: (VCStoreLogM env m, VCStoreErrM err m, VCStoreEnvM env m, VCStoreLockM env m) => VCObjectHash -> m ()
-deleteAutosavedVCObject obj_hash = do
-  VCStorePath storePath <- asks getTyped
-  lock <- asks getTyped
-  withWrite lock $ do
-    -- check if object meta exists with hash meta_hash, and get meta
-    (VCMeta {name = obj_name} :: VCMeta Value Value VCObject) <- fetchVCObject obj_hash
-    -- check that it is safe to delete
-    if obj_name == pack "<AUTOSAVE>"
-      then do
-        -- delete object, object meta, head/to_head, and deps
-        deleteFile $ storePath </> show obj_hash
-        deleteFile $ storePath </> "heads" </> show obj_hash
-        deleteFile $ storePath </> "to_head" </> show obj_hash
-        deleteFile $ storePath </> "deps" </> show obj_hash
-      else throwError $ TryingToDeleteNonAutosave obj_name
-  where
-    deleteFile fp = do
-      trace $ DeleteFile fp
-      liftIO $ removeFile fp
-
--- | Deletes all stale autosaved objects from the VC.
--- As this is a non-critical maintenance operation, we do not hold the lock around the
--- entire operation.
-deleteStaleAutosavedVCObjects :: (VCStoreLogM env m, VCStoreErrM err m, VCStoreEnvM env m, VCStoreLockM env m) => m ()
-deleteStaleAutosavedVCObjects = do
-  -- We know that all autosaves must be heads:
-  heads <- getAllHeads
-  forM_
-    heads
-    ( \h -> do
-        -- fetch object, check name and timestamp
-        (VCMeta {name, timestamp} :: VCMeta Value Value VCObject) <- fetchVCObject h
-        now <- liftIO $ CTime . round . toRational <$> getPOSIXTime
-        if name == pack "<AUTOSAVE>" && timestamp < now - 60 * 60
-          then -- delete the stale ones (> 1hr old)
-            deleteAutosavedVCObject h
-          else pure ()
-    )
-
--- | Soft delete script and its history (both predecessors and successors).
--- All scripts and their references are moved to "removed" directory
-deleteVCObjects :: (VCStoreLogM env m, VCStoreErrM err m, VCStoreEnvM env m, VCStoreLockM env m) => VCObjectHash -> m ()
-deleteVCObjects obj_hash = do
-  VCStorePath storePath <- asks getTyped
-  lock <- asks getTyped
-  liftIO $ do
-    createDirectoryIfMissing True $ storePath </> "removed"
-    createDirectoryIfMissing True $ storePath </> "removed" </> "heads"
-    createDirectoryIfMissing True $ storePath </> "removed" </> "to_head"
-    createDirectoryIfMissing True $ storePath </> "removed" </> "deps"
-
-  withWrite lock $ do
-    (metas :: [VCMeta Value Value VCObjectHash]) <- fetchVCObjectHistory obj_hash
-    forM_ metas $ \VCMeta {obj = hash} -> do
-      forM_
-        [ show hash,
-          "heads" </> show hash,
-          "to_head" </> show hash,
-          "deps" </> show hash
-        ]
-        $ \source_fp -> safeRenameFile (storePath </> source_fp) (storePath </> "removed" </> source_fp)
-  where
-    safeRenameFile source target = do
-      liftIO (doesFileExist source) >>= \case
-        False -> pure ()
-        True -> liftIO $ renameFile source target
-
-fetchVCObject :: (VCStoreLogM env m, VCStoreErrM err m, VCStoreEnvM env m, VCStoreLockM env m, FromJSON a, FromJSON g) => VCObjectHash -> m (VCMeta a g VCObject)
-fetchVCObject = fetchVCObject' Nothing
-
--- | Fetch object from removed directory
-fetchRemovedVCObject :: (VCStoreLogM env m, VCStoreErrM err m, VCStoreEnvM env m, VCStoreLockM env m, FromJSON a, FromJSON g) => VCObjectHash -> m (VCMeta a g VCObject)
-fetchRemovedVCObject = fetchVCObject' (Just "removed")
-
-fetchVCObject' :: (VCStoreLogM env m, VCStoreErrM err m, VCStoreEnvM env m, VCStoreLockM env m, FromJSON a, FromJSON g) => Maybe FilePath -> VCObjectHash -> m (VCMeta a g VCObject)
-fetchVCObject' mprefix h = do
-  VCStorePath storePath <- asks getTyped
-  lock <- asks getTyped
-  let fp = case mprefix of
-        Nothing -> storePath </> show h
-        Just prefix -> storePath </> prefix </> show h
-  withRead lock $ do
-    checkPathExists fp
-    trace $ ReadJSON fp
-    either (throwError . CouldNotDecodeObject h) pure =<< liftIO (eitherDecode <$> BL.readFile fp)
-
--- | Fetch an object WITHOUT holding any locks. This is used by the cached client, which
--- is safe since the cache is read only.
-fetchVCObjectUnsafe :: (VCStoreLogM env m, VCStoreErrM err m, VCStoreEnvM env m, FromJSON a, FromJSON g) => VCObjectHash -> m (VCMeta a g VCObject)
-fetchVCObjectUnsafe h = do
-  VCStorePath storePath <- asks getTyped
-  let fp = storePath </> show h
-  checkPathExists fp
-  trace $ ReadJSON fp
-  either (throwError . CouldNotDecodeObject h) pure =<< liftIO (eitherDecode <$> BL.readFile fp)
-
--- | Fetch multiple objects (without locking in between)
-fetchVCObjects :: (VCStoreLogM env m, VCStoreErrM err m, VCStoreEnvM env m, VCStoreLockM env m, FromJSON a, FromJSON g) => [VCObjectHash] -> m (Map.Map VCObjectHash (VCMeta a g VCObject))
-fetchVCObjects hs = do
-  Map.fromList <$> forM hs (\h -> (h,) <$> fetchVCObject h)
-
--- | Fetch all dependencies of an object.
--- NOTE: this is done without holding a lock, as dependencies are never modified.
-fetchVCObjectClosureHashes :: (VCStoreLogM env m, VCStoreErrM err m, VCStoreEnvM env m) => VCObjectHash -> m [VCObjectHash]
-fetchVCObjectClosureHashes h = do
-  VCStorePath storePath <- asks getTyped
-  let fp = storePath </> "deps" </> show h
-  readVCObjectHashTxt fp
-
-fetchVCObjectWithClosure :: (VCStoreLogM env m, VCStoreErrM err m, VCStoreEnvM env m, VCStoreLockM env m, FromJSON a, FromJSON g) => VCObjectHash -> m (Map.Map VCObjectHash (VCMeta a g VCObject))
-fetchVCObjectWithClosure h = do
-  lock <- asks getTyped
-  withRead lock $ do
-    deps <- fetchVCObjectClosureHashes h
-    Map.fromList <$> forM deps (\dep -> (dep,) <$> fetchVCObject dep)
-
-fetchCurrentHead :: (VCStoreLogM env m, VCStoreErrM err m, VCStoreEnvM env m, VCStoreLockM env m) => VCObjectHash -> m VCObjectHash
-fetchCurrentHead h = do
-  VCStorePath storePath <- asks getTyped
-  lock <- asks getTyped
-  let fp = storePath </> "to_head" </> show h
-  withRead lock $ do
-    exists <- liftIO $ doesFileExist fp
-    if exists
-      then
-        readVCObjectHashTxt fp >>= \case
-          [h'] -> pure h'
-          _ -> throwError $ CouldNotFindHead h
-      else throwError $ CouldNotFindHead h
-
-fetchVCObjectHistory :: (VCStoreLogM env m, VCStoreErrM err m, VCStoreEnvM env m, VCStoreLockM env m, FromJSON a, FromJSON g) => VCObjectHash -> m [VCMeta a g VCObjectHash]
-fetchVCObjectHistory h = do
-  VCStorePath storePath <- asks getTyped
-  lock <- asks getTyped
-  history <- withRead lock $ do
-    head_h <- fetchCurrentHead h
-    let head_fp = storePath </> "heads" </> show head_h
-    preds <- readVCObjectHashTxt head_fp
-    -- Order: newest to oldest
-    pure $ head_h : reverse preds
-  -- We recruse through history newest to oldest, and return the history in the same order:
-  getHistory history
-  where
-    -- Recurse through history, newest to oldest, and stop when we find a clone
-    getHistory (hsh : history) = do
-      getObj hsh >>= \case
-        Nothing -> getHistory history
-        Just eObj -> do
-          -- Assuming either the entire history of a script is deleted, or none of it,
-          -- we only care about whether a script has been deleted when we look up the
-          -- source of a clone
-          let obj = either id id eObj
-          case Inferno.VersionControl.Types.pred obj of
-            CloneOf hsh' -> do
-              -- if it is a clone, we would like to prepend source of the cloned script as part of the history.
-              -- it is fine to only do this once since we only show the last source of the clone
-              -- i.e. original -> cloneof orignal = cloned -> cloneof cloned = cloned'
-              -- when viewing cloned' history, it will only show up to cloned.
-              getObj hsh' >>= \case
-                Just (Right ori) ->
-                  pure [obj, ori]
-                Just (Left ori) ->
-                  -- The source of the clone script has been deleted, so we alter its 'pred' field as 'CloneOfRemoved' but
-                  -- with the same hash. This way the upstream system (e.g. onping/frontend) can differentiate between
-                  -- source that is still available and no longer available.
-                  -- This does not change the way the script is persisted in the db, it is still stored as 'CloneOf'.
-                  -- See 'CloneOfRemoved' for details.
-                  pure [obj {Inferno.VersionControl.Types.pred = CloneOfRemoved hsh'}, ori]
-                Nothing ->
-                  -- This script no longer exists even in 'removed' directory. The directory might get cleaned up by accident or something.
-                  -- There are two choices we can make,
-                  -- 1. Return a `VCMeta VCObjectHash` with dummy data
-                  -- 2. Ignore this meta.
-                  -- Approach no. 2 is taken here
-                  getHistory history >>= \res -> pure $ obj : res
-            _ -> getHistory history >>= \res -> pure $ obj : res
-    getHistory [] = pure []
-
-    getObj hsh = do
-      VCStorePath storePath <- asks getTyped
-      existsInRoot <- liftIO $ doesFileExist $ storePath </> show hsh
-      if existsInRoot
-        then do
-          obj <- fmap (const hsh) <$> fetchVCObject hsh
-          pure $ Just $ Right obj
-        else do
-          existsInRemoved <- liftIO $ doesFileExist $ storePath </> "removed" </> show hsh
-          if existsInRemoved
-            then do
-              obj <- fmap (const hsh) <$> fetchRemovedVCObject hsh
-              pure $ Just $ Left obj
-            else pure Nothing
-
-getAllHeads :: (VCStoreLogM env m, VCStoreEnvM env m) => m [VCObjectHash]
-getAllHeads = do
-  VCStorePath storePath <- getTyped <$> ask
-  -- We don't need a lock here because this only lists the heads/ directory, it doesn't
-  -- read any file contents (and I assume the `ls` is atomic)
-  headsRaw <- liftIO $ getDirectoryContents $ storePath </> "heads"
-  pure $
-    foldr
-      ( \hd xs ->
-          case (either (const $ Nothing) Just $ Base64.decode $ Char8.pack hd) >>= digestFromByteString of
-            Just hsh -> (VCObjectHash hsh) : xs
-            Nothing -> xs
-      )
-      []
-      (map takeFileName headsRaw)
-
--- | Fetch all objects that are public or that belong to the given set of groups.
--- Note this is a potentially long operation so no locks are held while traversing the
--- store and checking every object -- making this operation weakly consistent.
--- This means the returned list does not necessarily reflect the state of the store at any
--- point in time.
-fetchFunctionsForGroups :: (VCStoreLogM env m, VCStoreErrM err m, VCStoreEnvM env m, VCStoreLockM env m, Ord g, FromJSON a, FromJSON g) => Set.Set g -> m [VCMeta a g VCObjectHash]
-fetchFunctionsForGroups grps = do
-  heads <- getAllHeads
-  foldM
-    ( \objs hsh ->
-        -- Since we don't hold a lock, some heads might have been deleted in the meantime
-        -- so we catch and ignore CouldNotFindPath errors:
-        catching (_Typed @VCStoreError) (checkGroupAndAdd objs hsh) (ignoreNotFounds objs)
-    )
-    []
-    heads
-  where
-    checkGroupAndAdd objs hsh = do
-      meta@VCMeta {obj, visibility, group} <- fetchVCObject hsh
-      pure $ case obj of
-        VCFunction _ _ ->
-          if visibility == VCObjectPublic || group `Set.member` grps
-            then fmap (const hsh) meta : objs
-            else objs
-        _ -> objs
-    ignoreNotFounds objs (CouldNotFindPath _) = pure objs
-    ignoreNotFounds _ e = throwError e
+  -- | Fetch all objects that are public or that belong to the given set of groups.
+  -- Note this is a potentially long operation so no locks are held while traversing the
+  -- store and checking every object -- making this operation weakly consistent.
+  -- This means the returned list does not necessarily reflect the state of the store at any
+  -- point in time.
+  fetchFunctionsForGroups :: (Ord g, Deserializable m a, Deserializable m g) => Set.Set g -> m [VCMeta a g VCObjectHash]

--- a/inferno-vc/src/Inferno/VersionControl/Operations/Filesystem.hs
+++ b/inferno-vc/src/Inferno/VersionControl/Operations/Filesystem.hs
@@ -91,6 +91,7 @@ runInfernoVCFilesystemM :: InfernoVCFilesystemM err m a -> InfernoVCFilesystemEn
 runInfernoVCFilesystemM (InfernoVCFilesystemM f) = runReaderT f
 
 withEnv ::
+  forall config a.
   HasField "vcPath" config config FilePath FilePath =>
   config ->
   IOTracer Text ->

--- a/inferno-vc/src/Inferno/VersionControl/Operations/Filesystem.hs
+++ b/inferno-vc/src/Inferno/VersionControl/Operations/Filesystem.hs
@@ -95,7 +95,7 @@ initVCStore storePath tracer = do
   createDirectoryIfMissing True $ storePath </> "to_head"
   createDirectoryIfMissing True $ storePath </> "deps"
   lock <- RWL.new
-  pure InfernoVCFilesystemEnv {storePath=VCStorePath storePath, tracer, lock}
+  pure InfernoVCFilesystemEnv {storePath = VCStorePath storePath, tracer, lock}
 
 instance (MonadIO m, MonadMask m, AsType VCStoreError err) => InfernoVCOperations err (InfernoVCFilesystemM err m) where
   type Serializable (InfernoVCFilesystemM err m) = ToJSON
@@ -350,7 +350,6 @@ throwError :: (VCStoreLogM env m, VCStoreErrM err m) => VCStoreError -> m a
 throwError e = do
   trace $ ThrownVCStoreError e
   throwing _Typed e
-
 
 checkPathExists :: (VCStoreLogM env m, VCStoreErrM err m) => FilePath -> m ()
 checkPathExists fp =

--- a/inferno-vc/src/Inferno/VersionControl/Operations/Filesystem.hs
+++ b/inferno-vc/src/Inferno/VersionControl/Operations/Filesystem.hs
@@ -1,0 +1,441 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- |
+-- Module      : Inferno.VersionControl.Operations.Filesystem
+-- Description : InfernoVCOperations implementation that uses the filesystem
+--
+-- This module defines operations on the Inferno VC store. The store structure is as follows:
+--
+-- * `<storePath>` stores the JSON serialised `VCMeta VCObject`s, where the filename is the cryptographic hash (`VCOBjectHash`) of the object's contents
+-- * `<storePath>/heads` is a set of current HEAD objects of the store, which can be seen as the roots of the VC tree. Each filename is the hash of an object,
+--    and the file's contents are all the predecessors of this object, in chronological order, starting from the time it was created or cloned.
+-- * `<storePath>/to_head` is a map from every `VCOBjectHash` to its current HEAD, where the file name is the source hash and the contents of the file are the HEAD hash
+-- * `<storePath>/deps` is a map from every `VCOBjectHash` to its (transitive) dependencies, i.e. the file `<storePath>/deps/<hash>` describes the closure of `<hash>`
+-- * Deleting `VCMeta VCObject` - Delete is implemented as soft delete. Object is moved to a directory called `removed`. Object's preds are also removed.
+--   When an object is removed, its directory structure is preserved so you can undo it easily. i.e. `removed` directory has the same structure as `vc_store` directory.
+module Inferno.VersionControl.Operations.Filesystem
+  ( InfernoVCFilesystemEnv (..),
+    InfernoVCFilesystemM,
+    runInfernoVCFilesystemM,
+    initVCStore,
+  )
+where
+
+import Control.Concurrent.FairRWLock (RWLock)
+import qualified Control.Concurrent.FairRWLock as RWL
+import Control.Exception (throwIO)
+import Control.Monad (foldM, forM, forM_)
+import Control.Monad.Catch (MonadCatch, MonadMask, MonadThrow, bracket_)
+import Control.Monad.Error.Lens (catching, throwing)
+import Control.Monad.Except (ExceptT, MonadError)
+import Control.Monad.IO.Class (MonadIO (..))
+import Control.Monad.Reader (MonadReader (..), ReaderT, asks, runReaderT)
+import Crypto.Hash (digestFromByteString)
+import Data.Aeson (FromJSON, ToJSON, Value, eitherDecode, encode)
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Base64.URL as Base64
+import qualified Data.ByteString.Char8 as Char8
+import qualified Data.ByteString.Lazy as BL
+import Data.Generics.Product (HasType, getTyped)
+import Data.Generics.Sum (AsType (..))
+import qualified Data.Set as Set
+import Data.Text (pack)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import Foreign.C.Types (CTime (..))
+import GHC.Generics (Generic)
+import Inferno.Types.Syntax (Dependencies (..))
+import Inferno.VersionControl.Log (VCServerTrace (..))
+import Inferno.VersionControl.Operations (InfernoVCOperations (..))
+import Inferno.VersionControl.Operations.Error (VCStoreError (..))
+import Inferno.VersionControl.Types
+  ( VCHashUpdate,
+    VCMeta (..),
+    VCObject (..),
+    VCObjectHash (..),
+    VCObjectPred (..),
+    VCObjectVisibility (..),
+    vcHash,
+    vcObjectHashToByteString,
+  )
+import Plow.Logging (IOTracer, traceWith)
+import System.Directory (createDirectoryIfMissing, doesFileExist, getDirectoryContents, removeFile, renameFile)
+import System.FilePath.Posix (takeFileName, (</>))
+
+data InfernoVCFilesystemEnv = InfernoVCFilesystemEnv
+  { storePath :: VCStorePath,
+    tracer :: IOTracer VCServerTrace,
+    lock :: RWLock
+  }
+  deriving (Generic)
+
+newtype InfernoVCFilesystemM err m a = InfernoVCFilesystemM (ReaderT InfernoVCFilesystemEnv (ExceptT err m) a)
+  deriving
+    ( Functor,
+      Applicative,
+      Monad,
+      MonadError err,
+      MonadReader InfernoVCFilesystemEnv,
+      MonadIO,
+      MonadThrow,
+      MonadCatch,
+      MonadMask
+    )
+
+runInfernoVCFilesystemM :: InfernoVCFilesystemM err m a -> InfernoVCFilesystemEnv -> ExceptT err m a
+runInfernoVCFilesystemM (InfernoVCFilesystemM f) = runReaderT f
+
+initVCStore :: FilePath -> IOTracer VCServerTrace -> IO InfernoVCFilesystemEnv
+initVCStore storePath tracer = do
+  createDirectoryIfMissing True $ storePath </> "heads"
+  createDirectoryIfMissing True $ storePath </> "to_head"
+  createDirectoryIfMissing True $ storePath </> "deps"
+  lock <- RWL.new
+  pure InfernoVCFilesystemEnv {storePath=VCStorePath storePath, tracer, lock}
+
+instance (MonadIO m, MonadMask m, AsType VCStoreError err) => InfernoVCOperations err (InfernoVCFilesystemM err m) where
+  type Serializable (InfernoVCFilesystemM err m) = ToJSON
+  type Deserializable (InfernoVCFilesystemM err m) = FromJSON
+
+  storeVCObject obj@VCMeta {obj = ast, pred = p} = do
+    VCStorePath storePath <- asks getTyped
+    lock <- asks getTyped
+    -- if the new object has a direct predecessor (i.e. is not a clone or an initial commit)
+    --  we need to make sure that the predecessor is currently a HEAD object in the store
+    let maybeCurrentHead = case p of
+          Init -> Nothing
+          CloneOf _ -> Nothing
+          CloneOfRemoved _ -> Nothing
+          CloneOfNotFound _ -> Nothing
+          CompatibleWithPred h -> Just h
+          IncompatibleWithPred h _ -> Just h
+          MarkedBreakingWithPred h -> Just h
+
+    withWrite lock $ do
+      obj_h <- case maybeCurrentHead of
+        Just pred_hash -> do
+          let head_fp = storePath </> "heads" </> show pred_hash
+          -- check to see if pred_hash exists in '<storePath>/heads`
+          exists_head <- liftIO $ doesFileExist head_fp
+          if exists_head
+            then do
+              -- we know that pred_h is currently HEAD, we can therefore store the object and metadata in the store
+              obj_h <- writeHashedJSON storePath obj
+              -- next we make the newly added object the HEAD
+              let new_head_fp = storePath </> "heads" </> show obj_h
+              liftIO $ renameFile head_fp new_head_fp
+              -- we append the previous head hash to the file (this serves as lookup for all the predecessors)
+              appendBS new_head_fp $ BL.fromStrict $ vcObjectHashToByteString pred_hash <> "\n"
+              -- now we need to change all the predecessor mappings in '<storePath>/to_head' to point to the new HEAD
+              -- we also include the new head pointing to itself
+              preds <- readVCObjectHashTxt new_head_fp
+              let obj_h_bs = BL.fromStrict $ vcObjectHashToByteString obj_h
+              forM_ (obj_h : preds) (\pred_h -> writeBS (storePath </> "to_head" </> show pred_h) obj_h_bs)
+
+              pure obj_h
+            else throwError $ TryingToAppendToNonHead pred_hash
+        Nothing -> do
+          obj_h <- writeHashedJSON storePath obj
+          -- as there is no previous HEAD for this object, we simply create a new one
+          let new_head_fp = storePath </> "heads" </> show obj_h
+          appendBS new_head_fp mempty
+
+          -- we again make sure to add a self reference link to the '<storePath>/to_head' map
+          let obj_h_bs = BL.fromStrict $ vcObjectHashToByteString obj_h
+          writeBS (storePath </> "to_head" </> show obj_h) obj_h_bs
+          pure obj_h
+
+      -- finally, we store the dependencies of the commited object by fetching the dependencies from the AST
+      let deps = Set.toList $ getDependencies ast
+      writeBS (storePath </> "deps" </> show obj_h) mempty
+      forM_ deps $ \dep_h -> do
+        -- first we append the direct dependency hash 'dep_h'
+        appendBS (storePath </> "deps" </> show obj_h) $ BL.fromStrict $ vcObjectHashToByteString dep_h <> "\n"
+        -- then we append the transitive dependencies of the given object, pointed to by the hash 'dep_h'
+        appendBS (storePath </> "deps" </> show obj_h) =<< getDepsFromStore (storePath </> "deps") dep_h
+
+      pure obj_h
+
+  -- \| Delete a temporary object from the VC. This is used for autosaved scripts
+  -- and to run tests against unsaved scripts
+  deleteAutosavedVCObject obj_hash = do
+    VCStorePath storePath <- asks getTyped
+    lock <- asks getTyped
+    withWrite lock $ do
+      -- check if object meta exists with hash meta_hash, and get meta
+      (VCMeta {name = obj_name} :: VCMeta Value Value VCObject) <- fetchVCObject obj_hash
+      -- check that it is safe to delete
+      if obj_name == pack "<AUTOSAVE>"
+        then do
+          -- delete object, object meta, head/to_head, and deps
+          deleteFile $ storePath </> show obj_hash
+          deleteFile $ storePath </> "heads" </> show obj_hash
+          deleteFile $ storePath </> "to_head" </> show obj_hash
+          deleteFile $ storePath </> "deps" </> show obj_hash
+        else throwError $ TryingToDeleteNonAutosave obj_name
+    where
+      deleteFile fp = do
+        trace $ DeleteFile fp
+        liftIO $ removeFile fp
+
+  -- \| Deletes all stale autosaved objects from the VC.
+  -- As this is a non-critical maintenance operation, we do not hold the lock around the
+  -- entire operation.
+  deleteStaleAutosavedVCObjects = do
+    -- We know that all autosaves must be heads:
+    heads <- getAllHeads
+    forM_
+      heads
+      ( \h -> do
+          -- fetch object, check name and timestamp
+          (VCMeta {name, timestamp} :: VCMeta Value Value VCObject) <- fetchVCObject h
+          now <- liftIO $ CTime . round . toRational <$> getPOSIXTime
+          if name == pack "<AUTOSAVE>" && timestamp < now - 60 * 60
+            then -- delete the stale ones (> 1hr old)
+              deleteAutosavedVCObject h
+            else pure ()
+      )
+
+  -- \| Soft delete script and its history (both predecessors and successors).
+  -- All scripts and their references are moved to "removed" directory
+  deleteVCObjects obj_hash = do
+    VCStorePath storePath <- asks getTyped
+    lock <- asks getTyped
+    liftIO $ do
+      createDirectoryIfMissing True $ storePath </> "removed"
+      createDirectoryIfMissing True $ storePath </> "removed" </> "heads"
+      createDirectoryIfMissing True $ storePath </> "removed" </> "to_head"
+      createDirectoryIfMissing True $ storePath </> "removed" </> "deps"
+
+    withWrite lock $ do
+      (metas :: [VCMeta Value Value VCObjectHash]) <- fetchVCObjectHistory obj_hash
+      forM_ metas $ \VCMeta {obj = hash} -> do
+        forM_
+          [ show hash,
+            "heads" </> show hash,
+            "to_head" </> show hash,
+            "deps" </> show hash
+          ]
+          $ \source_fp -> safeRenameFile (storePath </> source_fp) (storePath </> "removed" </> source_fp)
+    where
+      safeRenameFile source target = do
+        liftIO (doesFileExist source) >>= \case
+          False -> pure ()
+          True -> liftIO $ renameFile source target
+
+  fetchVCObject = fetchVCObject' Nothing
+
+  -- \| Fetch all objects that are public or that belong to the given set of groups.
+  -- Note this is a potentially long operation so no locks are held while traversing the
+  -- store and checking every object -- making this operation weakly consistent.
+  -- This means the returned list does not necessarily reflect the state of the store at any
+  -- point in time.
+  fetchFunctionsForGroups grps = do
+    heads <- getAllHeads
+    foldM
+      ( \objs hsh ->
+          -- Since we don't hold a lock, some heads might have been deleted in the meantime
+          -- so we catch and ignore CouldNotFindPath errors:
+          catching (_Typed @VCStoreError) (checkGroupAndAdd objs hsh) (ignoreNotFounds objs)
+      )
+      []
+      heads
+    where
+      checkGroupAndAdd objs hsh = do
+        meta@VCMeta {obj, visibility, group} <- fetchVCObject hsh
+        pure $ case obj of
+          VCFunction _ _ ->
+            if visibility == VCObjectPublic || group `Set.member` grps
+              then fmap (const hsh) meta : objs
+              else objs
+          _ -> objs
+      ignoreNotFounds objs (CouldNotFindPath _) = pure objs
+      ignoreNotFounds _ e = throwError e
+
+  fetchVCObjectHistory h = do
+    VCStorePath storePath <- asks getTyped
+    lock <- asks getTyped
+    history <- withRead lock $ do
+      head_h <- fetchCurrentHead h
+      let head_fp = storePath </> "heads" </> show head_h
+      preds <- readVCObjectHashTxt head_fp
+      -- Order: newest to oldest
+      pure $ head_h : reverse preds
+    -- We recruse through history newest to oldest, and return the history in the same order:
+    getHistory history
+    where
+      -- Recurse through history, newest to oldest, and stop when we find a clone
+      getHistory (hsh : history) = do
+        getObj hsh >>= \case
+          Nothing -> getHistory history
+          Just eObj -> do
+            -- Assuming either the entire history of a script is deleted, or none of it,
+            -- we only care about whether a script has been deleted when we look up the
+            -- source of a clone
+            let obj = either id id eObj
+            case Inferno.VersionControl.Types.pred obj of
+              CloneOf hsh' -> do
+                -- if it is a clone, we would like to prepend source of the cloned script as part of the history.
+                -- it is fine to only do this once since we only show the last source of the clone
+                -- i.e. original -> cloneof orignal = cloned -> cloneof cloned = cloned'
+                -- when viewing cloned' history, it will only show up to cloned.
+                getObj hsh' >>= \case
+                  Just (Right ori) ->
+                    pure [obj, ori]
+                  Just (Left ori) ->
+                    -- The source of the clone script has been deleted, so we alter its 'pred' field as 'CloneOfRemoved' but
+                    -- with the same hash. This way the upstream system (e.g. onping/frontend) can differentiate between
+                    -- source that is still available and no longer available.
+                    -- This does not change the way the script is persisted in the db, it is still stored as 'CloneOf'.
+                    -- See 'CloneOfRemoved' for details.
+                    pure [obj {Inferno.VersionControl.Types.pred = CloneOfRemoved hsh'}, ori]
+                  Nothing ->
+                    -- This script no longer exists even in 'removed' directory. The directory might get cleaned up by accident or something.
+                    -- There are two choices we can make,
+                    -- 1. Return a `VCMeta VCObjectHash` with dummy data
+                    -- 2. Ignore this meta.
+                    -- Approach no. 2 is taken here
+                    getHistory history >>= \res -> pure $ obj : res
+              _ -> getHistory history >>= \res -> pure $ obj : res
+      getHistory [] = pure []
+
+      getObj hsh = do
+        VCStorePath storePath <- asks getTyped
+        existsInRoot <- liftIO $ doesFileExist $ storePath </> show hsh
+        if existsInRoot
+          then do
+            obj <- fmap (const hsh) <$> fetchVCObject hsh
+            pure $ Just $ Right obj
+          else do
+            existsInRemoved <- liftIO $ doesFileExist $ storePath </> "removed" </> show hsh
+            if existsInRemoved
+              then do
+                obj <- fmap (const hsh) <$> fetchRemovedVCObject hsh
+                pure $ Just $ Left obj
+              else pure Nothing
+
+  -- \| Fetch all dependencies of an object.
+  -- NOTE: this is done without holding a lock, as dependencies are never modified.
+  fetchVCObjectClosureHashes h = do
+    VCStorePath storePath <- asks getTyped
+    let fp = storePath </> "deps" </> show h
+    readVCObjectHashTxt fp
+
+newtype VCStorePath = VCStorePath FilePath deriving (Generic)
+
+type VCStoreErrM err m = (AsType VCStoreError err, MonadError err m, MonadIO m)
+
+type VCStoreLogM env m = (HasType (IOTracer VCServerTrace) env, MonadReader env m, MonadIO m)
+
+type VCStoreEnvM env m = (HasType VCStorePath env, MonadReader env m, MonadIO m)
+
+type VCStoreLockM env m = (HasType RWLock env, MonadReader env m, MonadIO m, MonadMask m)
+
+withWrite :: (MonadIO m, MonadMask m) => RWLock -> m a -> m a
+withWrite lock = bracket_ (liftIO $ RWL.acquireWrite lock) (liftIO $ RWL.releaseWrite lock >>= either throwIO return)
+
+withRead :: (MonadIO m, MonadMask m) => RWLock -> m a -> m a
+withRead lock = bracket_ (liftIO $ RWL.acquireRead lock) (liftIO $ RWL.releaseRead lock >>= either throwIO return)
+
+trace :: VCStoreLogM env m => VCServerTrace -> m ()
+trace t = do
+  tracer <- getTyped <$> ask
+  traceWith @IOTracer tracer t
+
+throwError :: (VCStoreLogM env m, VCStoreErrM err m) => VCStoreError -> m a
+throwError e = do
+  trace $ ThrownVCStoreError e
+  throwing _Typed e
+
+
+checkPathExists :: (VCStoreLogM env m, VCStoreErrM err m) => FilePath -> m ()
+checkPathExists fp =
+  liftIO (doesFileExist fp) >>= \case
+    False -> throwError $ CouldNotFindPath fp
+    True -> pure ()
+
+getDepsFromStore :: (VCStoreLogM env m, VCStoreErrM err m) => FilePath -> VCObjectHash -> m BL.ByteString
+getDepsFromStore path h = do
+  let fp = path </> show h
+  checkPathExists fp
+  liftIO $ BL.readFile $ path </> show h
+
+appendBS :: (VCStoreLogM env m) => FilePath -> BL.ByteString -> m ()
+appendBS fp bs = do
+  trace $ WriteTxt fp
+  liftIO $ BL.appendFile fp bs
+
+writeBS :: (VCStoreLogM env m) => FilePath -> BL.ByteString -> m ()
+writeBS fp bs = do
+  trace $ WriteTxt fp
+  liftIO $ BL.writeFile fp bs
+
+writeHashedJSON :: (VCStoreLogM env m, VCHashUpdate obj, ToJSON obj) => FilePath -> obj -> m VCObjectHash
+writeHashedJSON path o = do
+  let h = vcHash o
+  exists <- liftIO $ doesFileExist path
+  if exists
+    then trace $ AlreadyExistsJSON (path </> show h)
+    else do
+      trace $ WriteJSON (path </> show h)
+      liftIO $ BL.writeFile (path </> show h) $ encode o
+  pure h
+
+readVCObjectHashTxt :: (VCStoreLogM env m, VCStoreErrM err m) => FilePath -> m [VCObjectHash]
+readVCObjectHashTxt fp = do
+  checkPathExists fp
+  trace $ ReadTxt fp
+  deps <- filter (not . B.null) . Char8.lines <$> (liftIO $ B.readFile fp)
+  forM deps $ \dep -> do
+    decoded <- either (const $ throwError $ InvalidHash $ Char8.unpack dep) pure $ Base64.decode dep
+    maybe (throwError $ InvalidHash $ Char8.unpack dep) (pure . VCObjectHash) $ digestFromByteString decoded
+
+-- | Fetch object from removed directory
+fetchRemovedVCObject :: (VCStoreLogM env m, VCStoreErrM err m, VCStoreEnvM env m, VCStoreLockM env m, FromJSON a, FromJSON g) => VCObjectHash -> m (VCMeta a g VCObject)
+fetchRemovedVCObject = fetchVCObject' (Just "removed")
+
+fetchVCObject' :: (VCStoreLogM env m, VCStoreErrM err m, VCStoreEnvM env m, VCStoreLockM env m, FromJSON a, FromJSON g) => Maybe FilePath -> VCObjectHash -> m (VCMeta a g VCObject)
+fetchVCObject' mprefix h = do
+  VCStorePath storePath <- asks getTyped
+  lock <- asks getTyped
+  let fp = case mprefix of
+        Nothing -> storePath </> show h
+        Just prefix -> storePath </> prefix </> show h
+  withRead lock $ do
+    checkPathExists fp
+    trace $ ReadJSON fp
+    either (throwError . CouldNotDecodeObject h) pure =<< liftIO (eitherDecode <$> BL.readFile fp)
+
+fetchCurrentHead :: (VCStoreLogM env m, VCStoreErrM err m, VCStoreEnvM env m, VCStoreLockM env m) => VCObjectHash -> m VCObjectHash
+fetchCurrentHead h = do
+  VCStorePath storePath <- asks getTyped
+  lock <- asks getTyped
+  let fp = storePath </> "to_head" </> show h
+  withRead lock $ do
+    exists <- liftIO $ doesFileExist fp
+    if exists
+      then
+        readVCObjectHashTxt fp >>= \case
+          [h'] -> pure h'
+          _ -> throwError $ CouldNotFindHead h
+      else throwError $ CouldNotFindHead h
+
+getAllHeads :: (VCStoreLogM env m, VCStoreEnvM env m) => m [VCObjectHash]
+getAllHeads = do
+  VCStorePath storePath <- getTyped <$> ask
+  -- We don't need a lock here because this only lists the heads/ directory, it doesn't
+  -- read any file contents (and I assume the `ls` is atomic)
+  headsRaw <- liftIO $ getDirectoryContents $ storePath </> "heads"
+  pure $
+    foldr
+      ( \hd xs ->
+          case (either (const $ Nothing) Just $ Base64.decode $ Char8.pack hd) >>= digestFromByteString of
+            Just hsh -> (VCObjectHash hsh) : xs
+            Nothing -> xs
+      )
+      []
+      (map takeFileName headsRaw)

--- a/inferno-vc/src/Inferno/VersionControl/Server.hs
+++ b/inferno-vc/src/Inferno/VersionControl/Server.hs
@@ -9,7 +9,13 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 
-module Inferno.VersionControl.Server (VCServerError, VersionControlAPI, runServer) where
+module Inferno.VersionControl.Server
+  ( VCServerError,
+    VersionControlAPI,
+    runServer,
+    runServerConfig,
+  )
+where
 
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (link, withAsync)

--- a/inferno-vc/src/Inferno/VersionControl/Server.hs
+++ b/inferno-vc/src/Inferno/VersionControl/Server.hs
@@ -35,7 +35,7 @@ import Foreign.C.Types (CTime (..))
 import GHC.Generics (Generic)
 import Inferno.Types.Syntax (Expr)
 import Inferno.Types.Type (TCScheme)
-import Inferno.VersionControl.Log (VCServerTrace (Running, ThrownVCStoreError), vcServerTraceToText)
+import Inferno.VersionControl.Log (VCServerTrace (ThrownVCStoreError), vcServerTraceToText)
 import qualified Inferno.VersionControl.Operations as Ops
 import qualified Inferno.VersionControl.Operations.Error as Ops
 import Inferno.VersionControl.Server.Types (ServerConfig (..), readServerConfig)
@@ -56,7 +56,7 @@ import Network.Wai.Handler.Warp
     setTimeout,
   )
 import Network.Wai.Middleware.Gzip (def, gzip)
-import Plow.Logging (IOTracer (..), traceWith)
+import Plow.Logging (IOTracer (..), simpleStdOutTracer, traceWith)
 import Servant.API (Capture, JSON, ReqBody, Union, (:<|>) (..), (:>))
 import Servant.Server (Handler, Server, serve)
 import Servant.Typed.Error
@@ -123,7 +123,7 @@ vcServer toHandler =
       Map.fromList <$> (forM hs $ \h -> (h,) <$> Ops.fetchVCObject h)
 
 runServer ::
-  forall proxy m a g.
+  forall proxy m a g env.
   ( VCHashUpdate a,
     VCHashUpdate g,
     FromJSON a,
@@ -139,16 +139,16 @@ runServer ::
   ) =>
   proxy a ->
   proxy g ->
-  IOTracer T.Text ->
-  (forall x. m x -> ExceptT VCServerError IO x) ->
+  (forall x. FilePath -> IOTracer T.Text -> (env -> IO x) -> IO x) ->
+  (forall x. m x -> env -> ExceptT VCServerError IO x) ->
   IO ()
-runServer proxyA proxyG tracer runOp = do
+runServer proxyA proxyG withEnv runOp = do
   readServerConfig "config.yml" >>= \case
-    Left err -> traceWith tracer (T.pack err)
-    Right serverConfig -> runServerConfig proxyA proxyG tracer runOp serverConfig
+    Left err -> putStrLn err
+    Right serverConfig -> runServerConfig proxyA proxyG withEnv runOp serverConfig
 
 runServerConfig ::
-  forall proxy m a g.
+  forall proxy m a g env.
   ( VCHashUpdate a,
     VCHashUpdate g,
     FromJSON a,
@@ -164,31 +164,34 @@ runServerConfig ::
   ) =>
   proxy a ->
   proxy g ->
-  IOTracer T.Text ->
-  (forall x. m x -> ExceptT VCServerError IO x) ->
+  (forall x. FilePath -> IOTracer T.Text -> (env -> IO x) -> IO x) ->
+  (forall x. m x -> env -> ExceptT VCServerError IO x) ->
   ServerConfig ->
   IO ()
-runServerConfig _ _ tracer runOp serverConfig = do
+runServerConfig _ _ withEnv runOp serverConfig = do
   let host = fromString . T.unpack . _serverHost $ serverConfig
       port = _serverPort serverConfig
+      vcPath = _vcPath serverConfig
       settingsWithTimeout = setTimeout 300 defaultSettings
 
-  let serverTracer = contramap vcServerTraceToText tracer
-  let cleanup = do
-        now <- liftIO $ CTime . round . toRational <$> getPOSIXTime
-        runExceptT (runOp (deleteStaleAutosavedVCObjects @a @g now)) >>= \case
-          Left (VCServerError {serverError}) ->
-            traceWith @IOTracer serverTracer (ThrownVCStoreError serverError)
-          Right _ -> pure ()
-  traceWith @IOTracer serverTracer Running
-  -- Cleanup stale autosave scripts in a separate thread every hour:
-  withLinkedAsync_ (forever $ threadDelay 3600000000 >> cleanup) $
-    -- And run the server:
-    runSettings (setPort port $ setHost host settingsWithTimeout) $
-      ungzipRequest $
-        gzip def $
-          serve (Proxy :: Proxy (VersionControlAPI a g)) $
-            vcServer (liftIO . liftTypedError . runOp)
+  let tracer = IOTracer (contramap T.unpack simpleStdOutTracer)
+      serverTracer = contramap vcServerTraceToText tracer
+  withEnv vcPath tracer $ \env -> do
+    let cleanup = do
+          now <- liftIO $ CTime . round . toRational <$> getPOSIXTime
+          runExceptT (runOp (deleteStaleAutosavedVCObjects @a @g now) env) >>= \case
+            Left (VCServerError {serverError}) ->
+              traceWith @IOTracer serverTracer (ThrownVCStoreError serverError)
+            Right _ -> pure ()
+    print ("running..." :: String)
+    -- Cleanup stale autosave scripts in a separate thread every hour:
+    withLinkedAsync_ (forever $ threadDelay 3600000000 >> cleanup) $
+      -- And run the server:
+      runSettings (setPort port $ setHost host settingsWithTimeout) $
+        ungzipRequest $
+          gzip def $
+            serve (Proxy :: Proxy (VersionControlAPI a g)) $
+              vcServer (liftIO . liftTypedError . flip runOp env)
 
 -- | Deletes all stale autosaved objects from the VC.
 -- As this is a non-critical maintenance operation, we do not hold the lock around the

--- a/inferno-vc/src/Inferno/VersionControl/Server.hs
+++ b/inferno-vc/src/Inferno/VersionControl/Server.hs
@@ -10,7 +10,7 @@
 {-# LANGUAGE TypeOperators #-}
 
 module Inferno.VersionControl.Server
-  ( VCServerError,
+  ( VCServerError (..),
     VersionControlAPI,
     runServer,
     runServerConfig,

--- a/inferno-vc/src/Inferno/VersionControl/Server.hs
+++ b/inferno-vc/src/Inferno/VersionControl/Server.hs
@@ -14,8 +14,8 @@ module Inferno.VersionControl.Server (VCServerError, VersionControlAPI, runServe
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (link, withAsync)
 import Control.Monad (forM, forever)
+import Control.Monad.Except (ExceptT, runExceptT, throwError)
 import Control.Monad.IO.Class (liftIO)
-import Control.Monad.Except (runExceptT, throwError, ExceptT)
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Functor.Contravariant (contramap)
 import qualified Data.Map as Map

--- a/inferno-vc/src/Inferno/VersionControl/Server/Types.hs
+++ b/inferno-vc/src/Inferno/VersionControl/Server/Types.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE DeriveGeneric #-}
 
 module Inferno.VersionControl.Server.Types where
 
@@ -6,13 +8,14 @@ import Data.Aeson.Types
 import Data.ByteString (readFile)
 import Data.Text (Text)
 import Data.Yaml
+import GHC.Generics (Generic)
 
 data ServerConfig = ServerConfig
-  { _serverHost :: Text,
-    _serverPort :: Int,
-    _vcPath :: FilePath
+  { serverHost :: Text,
+    serverPort :: Int,
+    vcPath :: FilePath
   }
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Generic)
 
 instance FromJSON ServerConfig where
   parseJSON = withObject "ServerConfig" $ \o -> do
@@ -20,12 +23,12 @@ instance FromJSON ServerConfig where
     serverHost <- server .: "host"
     serverPort <- server .: "port"
     vcPath <- server .: "vcPath"
-
-    return $ ServerConfig serverHost serverPort vcPath
+    pure ServerConfig {serverHost, serverPort, vcPath}
 
 readServerConfig ::
+  FromJSON config =>
   FilePath ->
-  IO (Either String ServerConfig)
+  IO (Either String config)
 readServerConfig fp = do
   f <- Data.ByteString.readFile fp
   return $ either (Left . prettyPrintParseException) Right $ decodeEither' f

--- a/inferno-vc/src/Inferno/VersionControl/Server/Types.hs
+++ b/inferno-vc/src/Inferno/VersionControl/Server/Types.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Inferno.VersionControl.Server.Types where
 

--- a/inferno-vc/src/Inferno/VersionControl/Testing.hs
+++ b/inferno-vc/src/Inferno/VersionControl/Testing.hs
@@ -1,0 +1,191 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Inferno.VersionControl.Testing (vcServerSpec) where
+
+import Control.Monad (forM_)
+import qualified Data.Map as Map
+import qualified Data.Set as Set
+import Data.Time.Clock (getCurrentTime)
+import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
+import Foreign.C (CTime (..))
+import Inferno.Types.Syntax (Expr (Lit), Lit (LDouble), TV (TV))
+import Inferno.Types.Type (ImplType (ImplType), TCScheme (ForallTC), typeDouble)
+import Inferno.VersionControl.Client (ClientMWithVCStoreError, api)
+import Inferno.VersionControl.Operations.Error (VCStoreError (..))
+import Inferno.VersionControl.Server (VCServerError (VCServerError))
+import Inferno.VersionControl.Types (Pinned, VCMeta (..), VCObject (VCFunction), VCObjectHash, VCObjectPred (CloneOf, Init, MarkedBreakingWithPred), VCObjectVisibility (VCObjectPublic))
+import Servant ((:<|>) (..))
+import Servant.Client (ClientEnv, client)
+import Servant.Typed.Error (runTypedClientM, typedClient)
+import Test.Hspec
+import Test.QuickCheck (arbitrary, generate)
+
+fetchFunction :: VCObjectHash -> ClientMWithVCStoreError (VCMeta Int Int (Expr (Pinned VCObjectHash) (), TCScheme))
+fetchFunctionsForGroups :: Set.Set Int -> ClientMWithVCStoreError [VCMeta Int Int VCObjectHash]
+fetchVCObject :: VCObjectHash -> ClientMWithVCStoreError (VCMeta Int Int VCObject)
+fetchVCObjectHistory :: VCObjectHash -> ClientMWithVCStoreError [VCMeta Int Int VCObjectHash]
+fetchVCObjects :: [VCObjectHash] -> ClientMWithVCStoreError (Map.Map VCObjectHash (VCMeta Int Int VCObject))
+fetchVCObjectClosureHashes :: VCObjectHash -> ClientMWithVCStoreError [VCObjectHash]
+pushFunction :: VCMeta Int Int (Expr (Pinned VCObjectHash) (), TCScheme) -> ClientMWithVCStoreError VCObjectHash
+deleteAutosavedFunction :: VCObjectHash -> ClientMWithVCStoreError ()
+deleteVCObject :: VCObjectHash -> ClientMWithVCStoreError ()
+fetchFunction
+  :<|> fetchFunctionsForGroups
+  :<|> fetchVCObject
+  :<|> fetchVCObjectHistory
+  :<|> fetchVCObjects
+  :<|> fetchVCObjectClosureHashes
+  :<|> pushFunction
+  :<|> deleteAutosavedFunction
+  :<|> deleteVCObject = typedClient $ client $ api @Int @Int
+
+runOperation :: ClientEnv -> ClientMWithVCStoreError a -> (a -> IO ()) -> IO ()
+runOperation vcClientEnv op check = do
+  (flip runTypedClientM vcClientEnv op) >>= \case
+    Left err -> do
+      expectationFailure $ show err
+    Right res -> do
+      check res
+
+runOperationFail :: (Show a) => ClientEnv -> ClientMWithVCStoreError a -> (VCServerError -> IO ()) -> IO ()
+runOperationFail vcClientEnv op check = do
+  (flip runTypedClientM vcClientEnv op) >>= \case
+    Left (Right err) -> do
+      check err
+    Left (Left err) -> do
+      expectationFailure $ "Expected VCServerError but failed with " <> show err
+    Right res -> do
+      expectationFailure $ "Expected this operation to fail but it returned " <> show res
+
+createObj :: VCObjectPred -> IO (VCMeta Int Int (Expr (Pinned VCObjectHash) (), TCScheme))
+createObj predecessor = do
+  ctime <- CTime . round . toRational . utcTimeToPOSIXSeconds <$> getCurrentTime
+  d <- generate arbitrary
+  pure
+    VCMeta
+      { timestamp = ctime,
+        author = 432,
+        group = 432,
+        name = "Test",
+        description = "",
+        Inferno.VersionControl.Types.pred = predecessor,
+        visibility = VCObjectPublic,
+        obj = (Lit () (LDouble d), ForallTC [TV 0] mempty $ ImplType mempty typeDouble)
+      }
+
+vcServerSpec :: ClientEnv -> Spec
+vcServerSpec vcClientEnv =
+  describe "inferno-vc server" $ do
+    it "basics" $ do
+      o1 <- createObj Init
+      runOperation vcClientEnv (pushFunction o1) $ \h1 -> do
+        o2 <- createObj $ MarkedBreakingWithPred h1
+        runOperation vcClientEnv (pushFunction o2) $ \h2 -> do
+          o3 <- createObj $ MarkedBreakingWithPred h2
+          runOperation vcClientEnv (pushFunction o3) $ \h3 -> do
+            o4 <- createObj $ MarkedBreakingWithPred h3
+            runOperation vcClientEnv (pushFunction o4) $ \h4 -> do
+              -- Test fetchFunction:
+              forM_ [(o1, h1), (o2, h2), (o3, h3), (o4, h4)] $ \(o, h) ->
+                runOperation vcClientEnv (fetchFunction h) $ \o' -> do
+                  timestamp o' `shouldBe` timestamp o
+                  obj o' `shouldBe` obj o
+
+              -- Test fetchVCObject:
+              forM_ [(o1, h1), (o2, h2), (o3, h3), (o4, h4)] $ \(o, h) ->
+                runOperation vcClientEnv (fetchVCObject h) $ \o' ->
+                  case obj o' of
+                    VCFunction e t -> do
+                      timestamp o' `shouldBe` timestamp o
+                      (e, t) `shouldBe` (obj o)
+                    _ -> expectationFailure "Expected to get a VCFunction"
+
+              -- Test fetchVCObjects:
+              runOperation vcClientEnv (fetchVCObjects [h1, h3, h4]) $ \hashToMeta -> do
+                Set.fromList (Map.keys hashToMeta) `shouldBe` Set.fromList [h1, h3, h4]
+                forM_ [(o1, h1), (o3, h3), (o4, h4)] $ \(o, h) ->
+                  case Map.lookup h hashToMeta of
+                    Just meta ->
+                      timestamp meta `shouldBe` timestamp o
+                    Nothing -> expectationFailure "impossible"
+
+              -- fetchFunctionsForGroups only returns the head h4:
+              runOperation vcClientEnv (fetchFunctionsForGroups (Set.singleton 432)) $ \metas -> do
+                map obj metas `shouldBe` [h4]
+
+              -- The closure of h4 should be empty as it has no dependencies:
+              runOperation vcClientEnv (fetchVCObjectClosureHashes h4) $ \metas -> do
+                metas `shouldBe` []
+
+    it "deletion" $ do
+      o1 <- createObj Init
+      runOperation vcClientEnv (pushFunction o1) $ \h1 -> do
+        o2 <- createObj Init
+        runOperation vcClientEnv (pushFunction o2) $ \h2 -> do
+          o3 <- createObj Init
+          runOperation vcClientEnv (pushFunction o3) $ \h3 -> do
+            o4 <- createObj Init
+            runOperation vcClientEnv (pushFunction o4) $ \h4 -> do
+              runOperation vcClientEnv (deleteVCObject h3) $ \() -> do
+                -- Fetching h3 should fail:
+                runOperationFail vcClientEnv (fetchFunction h3) $ \case
+                  VCServerError (CouldNotFindPath _) -> pure ()
+                  _ -> expectationFailure ""
+                -- Others should fetch:
+                forM_ [(o1, h1), (o2, h2), (o4, h4)] $ \(o, h) ->
+                  runOperation vcClientEnv (fetchFunction h) $ \o' -> do
+                    timestamp o' `shouldBe` timestamp o
+                    obj o' `shouldBe` obj o
+
+    -- -- TODO is fetchFunctionsForGRoups wrong? It is returning deleted scripts:
+    -- runOperation vcClientEnv (fetchFunctionsForGroups (Set.singleton 432)) $ \metas -> do
+    --   Set.fromList (map obj metas) `shouldBe` Set.fromList [h4, h2, h1]
+
+    it "deletion of autosave" $ do
+      o1 <- createObj Init
+      runOperation vcClientEnv (pushFunction o1) $ \h1 -> do
+        o2 <- createObj Init
+        runOperation vcClientEnv (pushFunction (o2 {name = "<AUTOSAVE>"})) $ \h2 -> do
+          -- h1 isn't an autosave so can't delete it:
+          runOperationFail vcClientEnv (deleteAutosavedFunction h1) $ \case
+            VCServerError (TryingToDeleteNonAutosave _) -> pure ()
+            _ -> expectationFailure ""
+          -- h2 is an autosave so it's fine
+          runOperation vcClientEnv (deleteAutosavedFunction h2) $ \() -> pure ()
+
+    it "history" $ do
+      o1 <- createObj Init
+      runOperation vcClientEnv (pushFunction o1) $ \h1 -> do
+        o2 <- createObj $ MarkedBreakingWithPred h1
+        runOperation vcClientEnv (pushFunction o2) $ \h2 -> do
+          o3 <- createObj $ MarkedBreakingWithPred h2
+          runOperation vcClientEnv (pushFunction o3) $ \h3 -> do
+            o4 <- createObj $ MarkedBreakingWithPred h3
+            runOperation vcClientEnv (pushFunction o4) $ \h4 -> do
+              runOperation vcClientEnv (fetchVCObjectHistory h4) $ \metas ->
+                (map obj metas) `shouldBe` [h4, h3, h2, h1]
+
+    it "history of clone" $ do
+      o1 <- createObj Init
+      runOperation vcClientEnv (pushFunction o1) $ \h1 -> do
+        o2 <- createObj $ MarkedBreakingWithPred h1
+        runOperation vcClientEnv (pushFunction o2) $ \h2 -> do
+          o3 <- createObj $ CloneOf h2
+          runOperation vcClientEnv (pushFunction o3) $ \h3 -> do
+            o4 <- createObj $ MarkedBreakingWithPred h3
+            runOperation vcClientEnv (pushFunction o4) $ \h4 -> do
+              runOperation vcClientEnv (fetchVCObjectHistory h4) $ \metas ->
+                (map obj metas) `shouldBe` [h4, h3, h2]
+
+    it "history of clone of clone" $ do
+      o1 <- createObj Init
+      runOperation vcClientEnv (pushFunction o1) $ \h1 -> do
+        o2 <- createObj $ CloneOf h1
+        runOperation vcClientEnv (pushFunction o2) $ \h2 -> do
+          o3 <- createObj $ CloneOf h2
+          runOperation vcClientEnv (pushFunction o3) $ \h3 -> do
+            o4 <- createObj $ MarkedBreakingWithPred h3
+            runOperation vcClientEnv (pushFunction o4) $ \h4 -> do
+              runOperation vcClientEnv (fetchVCObjectHistory h4) $ \metas ->
+                (map obj metas) `shouldBe` [h4, h3, h2]

--- a/inferno-vc/test/Spec.hs
+++ b/inferno-vc/test/Spec.hs
@@ -4,14 +4,11 @@
 module Main (main) where
 
 import Control.Concurrent (forkIO)
-import Data.Functor.Contravariant (contramap)
 import Data.Proxy (Proxy (..))
-import qualified Data.Text as T
 import qualified Inferno.VersionControl.Operations.Filesystem as FSOps
 import Inferno.VersionControl.Server (runServerConfig)
 import Inferno.VersionControl.Server.Types (ServerConfig (..))
 import Inferno.VersionControl.Testing (vcServerSpec)
-import Plow.Logging (IOTracer (..), simpleStdOutTracer)
 import Servant.Client (BaseUrl (..), Scheme (..))
 import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec
@@ -22,20 +19,18 @@ main =
     putStrLn $ "Store is at: " ++ (show vcPath)
 
     putStr "Starting Inferno VC..."
-    let txtTracer = IOTracer $ contramap T.unpack simpleStdOutTracer
     _ <-
       forkIO $
-        FSOps.withEnv vcPath txtTracer $ \env ->
-          runServerConfig
-            (Proxy :: Proxy Int)
-            (Proxy :: Proxy Int)
-            txtTracer
-            (flip FSOps.runInfernoVCFilesystemM env)
-            ServerConfig
-              { _serverHost = "127.0.0.1",
-                _serverPort = 13077,
-                _vcPath = vcPath
-              }
+        runServerConfig
+          (Proxy :: Proxy Int)
+          (Proxy :: Proxy Int)
+          FSOps.withEnv
+          FSOps.runInfernoVCFilesystemM
+          ServerConfig
+            { _serverHost = "127.0.0.1",
+              _serverPort = 13077,
+              _vcPath = vcPath
+            }
     putStrLn "  Done."
 
     hspec $

--- a/inferno-vc/test/Spec.hs
+++ b/inferno-vc/test/Spec.hs
@@ -5,12 +5,10 @@ module Main (main) where
 
 import Control.Concurrent (forkIO)
 import Data.Proxy (Proxy (..))
-import Inferno.VersionControl.Client (mkVCClientEnv)
 import qualified Inferno.VersionControl.Operations.Filesystem as FSOps
 import Inferno.VersionControl.Server (runServerConfig)
 import Inferno.VersionControl.Server.Types (ServerConfig (..))
 import Inferno.VersionControl.Testing (vcServerSpec)
-import Network.HTTP.Client (defaultManagerSettings, newManager)
 import Servant.Client (BaseUrl (..), Scheme (..))
 import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec
@@ -33,15 +31,13 @@ main =
               _serverPort = 13077,
               _vcPath = vcPath
             }
-    man <- newManager defaultManagerSettings
-    let vcClientEnv =
-          mkVCClientEnv man $
-            BaseUrl
-              { baseUrlScheme = Http,
-                baseUrlHost = "127.0.0.1",
-                baseUrlPort = 13077,
-                baseUrlPath = []
-              }
     putStrLn "  Done."
 
-    hspec $ vcServerSpec vcClientEnv
+    hspec $
+      vcServerSpec
+        BaseUrl
+          { baseUrlScheme = Http,
+            baseUrlHost = "127.0.0.1",
+            baseUrlPort = 13077,
+            baseUrlPath = []
+          }

--- a/inferno-vc/test/Spec.hs
+++ b/inferno-vc/test/Spec.hs
@@ -27,9 +27,9 @@ main =
           FSOps.withEnv
           FSOps.runInfernoVCFilesystemM
           ServerConfig
-            { _serverHost = "127.0.0.1",
-              _serverPort = 13077,
-              _vcPath = vcPath
+            { serverHost = "127.0.0.1",
+              serverPort = 13077,
+              vcPath = vcPath
             }
     putStrLn "  Done."
 

--- a/inferno-vc/test/Spec.hs
+++ b/inferno-vc/test/Spec.hs
@@ -15,6 +15,7 @@ import Inferno.Types.Syntax (Expr (Lit), Lit (LDouble), TV (TV))
 import Inferno.Types.Type (ImplType (ImplType), TCScheme (ForallTC), typeDouble)
 import Inferno.VersionControl.Client (ClientMWithVCStoreError, api, mkVCClientEnv)
 import Inferno.VersionControl.Operations.Error (VCStoreError (..))
+import qualified Inferno.VersionControl.Operations.Filesystem as FSOps
 import Inferno.VersionControl.Server (VCServerError (VCServerError), runServerConfig)
 import Inferno.VersionControl.Server.Types (ServerConfig (..))
 import Inferno.VersionControl.Types (Pinned, VCMeta (..), VCObject (VCFunction), VCObjectHash, VCObjectPred (CloneOf, Init, MarkedBreakingWithPred), VCObjectVisibility (VCObjectPublic))
@@ -76,7 +77,7 @@ createObj predecessor = do
         description = "",
         Inferno.VersionControl.Types.pred = predecessor,
         visibility = VCObjectPublic,
-        obj = (Lit () (LDouble d), ForallTC [TV 0] mempty $ ImplType mempty $ typeDouble)
+        obj = (Lit () (LDouble d), ForallTC [TV 0] mempty $ ImplType mempty typeDouble)
       }
 
 spec :: ClientEnv -> Spec
@@ -206,6 +207,8 @@ main =
         runServerConfig
           (Proxy :: Proxy Int)
           (Proxy :: Proxy Int)
+          FSOps.initVCStore
+          FSOps.runInfernoVCFilesystemM
           ServerConfig
             { _serverHost = "127.0.0.1",
               _serverPort = 13077,

--- a/inferno-vc/test/Spec.hs
+++ b/inferno-vc/test/Spec.hs
@@ -4,11 +4,14 @@
 module Main (main) where
 
 import Control.Concurrent (forkIO)
+import Data.Functor.Contravariant (contramap)
 import Data.Proxy (Proxy (..))
+import qualified Data.Text as T
 import qualified Inferno.VersionControl.Operations.Filesystem as FSOps
 import Inferno.VersionControl.Server (runServerConfig)
 import Inferno.VersionControl.Server.Types (ServerConfig (..))
 import Inferno.VersionControl.Testing (vcServerSpec)
+import Plow.Logging (IOTracer (..), simpleStdOutTracer)
 import Servant.Client (BaseUrl (..), Scheme (..))
 import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec
@@ -19,18 +22,20 @@ main =
     putStrLn $ "Store is at: " ++ (show vcPath)
 
     putStr "Starting Inferno VC..."
+    let txtTracer = IOTracer $ contramap T.unpack simpleStdOutTracer
     _ <-
       forkIO $
-        runServerConfig
-          (Proxy :: Proxy Int)
-          (Proxy :: Proxy Int)
-          FSOps.withEnv
-          FSOps.runInfernoVCFilesystemM
-          ServerConfig
-            { _serverHost = "127.0.0.1",
-              _serverPort = 13077,
-              _vcPath = vcPath
-            }
+        FSOps.withEnv vcPath txtTracer $ \env ->
+          runServerConfig
+            (Proxy :: Proxy Int)
+            (Proxy :: Proxy Int)
+            txtTracer
+            (flip FSOps.runInfernoVCFilesystemM env)
+            ServerConfig
+              { _serverHost = "127.0.0.1",
+                _serverPort = 13077,
+                _vcPath = vcPath
+              }
     putStrLn "  Done."
 
     hspec $

--- a/inferno-vc/test/Spec.hs
+++ b/inferno-vc/test/Spec.hs
@@ -24,7 +24,7 @@ main =
         runServerConfig
           (Proxy :: Proxy Int)
           (Proxy :: Proxy Int)
-          FSOps.initVCStore
+          FSOps.withEnv
           FSOps.runInfernoVCFilesystemM
           ServerConfig
             { _serverHost = "127.0.0.1",

--- a/inferno-vc/test/Spec.hs
+++ b/inferno-vc/test/Spec.hs
@@ -4,197 +4,16 @@
 module Main (main) where
 
 import Control.Concurrent (forkIO)
-import Control.Monad (forM_)
-import qualified Data.Map as Map
 import Data.Proxy (Proxy (..))
-import qualified Data.Set as Set
-import Data.Time.Clock (getCurrentTime)
-import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
-import Foreign.C (CTime (..))
-import Inferno.Types.Syntax (Expr (Lit), Lit (LDouble), TV (TV))
-import Inferno.Types.Type (ImplType (ImplType), TCScheme (ForallTC), typeDouble)
-import Inferno.VersionControl.Client (ClientMWithVCStoreError, api, mkVCClientEnv)
-import Inferno.VersionControl.Operations.Error (VCStoreError (..))
+import Inferno.VersionControl.Client (mkVCClientEnv)
 import qualified Inferno.VersionControl.Operations.Filesystem as FSOps
-import Inferno.VersionControl.Server (VCServerError (VCServerError), runServerConfig)
+import Inferno.VersionControl.Server (runServerConfig)
 import Inferno.VersionControl.Server.Types (ServerConfig (..))
-import Inferno.VersionControl.Types (Pinned, VCMeta (..), VCObject (VCFunction), VCObjectHash, VCObjectPred (CloneOf, Init, MarkedBreakingWithPred), VCObjectVisibility (VCObjectPublic))
+import Inferno.VersionControl.Testing (vcServerSpec)
 import Network.HTTP.Client (defaultManagerSettings, newManager)
-import Servant ((:<|>) (..))
-import Servant.Client (BaseUrl (..), ClientEnv, Scheme (..), client)
-import Servant.Typed.Error (runTypedClientM, typedClient)
+import Servant.Client (BaseUrl (..), Scheme (..))
 import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec
-import Test.QuickCheck (arbitrary, generate)
-
-fetchFunction :: VCObjectHash -> ClientMWithVCStoreError (VCMeta Int Int (Expr (Pinned VCObjectHash) (), TCScheme))
-fetchFunctionsForGroups :: Set.Set Int -> ClientMWithVCStoreError [VCMeta Int Int VCObjectHash]
-fetchVCObject :: VCObjectHash -> ClientMWithVCStoreError (VCMeta Int Int VCObject)
-fetchVCObjectHistory :: VCObjectHash -> ClientMWithVCStoreError [VCMeta Int Int VCObjectHash]
-fetchVCObjects :: [VCObjectHash] -> ClientMWithVCStoreError (Map.Map VCObjectHash (VCMeta Int Int VCObject))
-fetchVCObjectClosureHashes :: VCObjectHash -> ClientMWithVCStoreError [VCObjectHash]
-pushFunction :: VCMeta Int Int (Expr (Pinned VCObjectHash) (), TCScheme) -> ClientMWithVCStoreError VCObjectHash
-deleteAutosavedFunction :: VCObjectHash -> ClientMWithVCStoreError ()
-deleteVCObject :: VCObjectHash -> ClientMWithVCStoreError ()
-fetchFunction
-  :<|> fetchFunctionsForGroups
-  :<|> fetchVCObject
-  :<|> fetchVCObjectHistory
-  :<|> fetchVCObjects
-  :<|> fetchVCObjectClosureHashes
-  :<|> pushFunction
-  :<|> deleteAutosavedFunction
-  :<|> deleteVCObject = typedClient $ client $ api @Int @Int
-
-runOperation :: ClientEnv -> ClientMWithVCStoreError a -> (a -> IO ()) -> IO ()
-runOperation vcClientEnv op check = do
-  (flip runTypedClientM vcClientEnv op) >>= \case
-    Left err -> do
-      expectationFailure $ show err
-    Right res -> do
-      check res
-
-runOperationFail :: (Show a) => ClientEnv -> ClientMWithVCStoreError a -> (VCServerError -> IO ()) -> IO ()
-runOperationFail vcClientEnv op check = do
-  (flip runTypedClientM vcClientEnv op) >>= \case
-    Left (Right err) -> do
-      check err
-    Left (Left err) -> do
-      expectationFailure $ "Expected VCServerError but failed with " <> show err
-    Right res -> do
-      expectationFailure $ "Expected this operation to fail but it returned " <> show res
-
-createObj :: VCObjectPred -> IO (VCMeta Int Int (Expr (Pinned VCObjectHash) (), TCScheme))
-createObj predecessor = do
-  ctime <- CTime . round . toRational . utcTimeToPOSIXSeconds <$> getCurrentTime
-  d <- generate arbitrary
-  pure
-    VCMeta
-      { timestamp = ctime,
-        author = 432,
-        group = 432,
-        name = "Test",
-        description = "",
-        Inferno.VersionControl.Types.pred = predecessor,
-        visibility = VCObjectPublic,
-        obj = (Lit () (LDouble d), ForallTC [TV 0] mempty $ ImplType mempty typeDouble)
-      }
-
-spec :: ClientEnv -> Spec
-spec vcClientEnv =
-  describe "inferno-vc server" $ do
-    it "basics" $ do
-      o1 <- createObj Init
-      runOperation vcClientEnv (pushFunction o1) $ \h1 -> do
-        o2 <- createObj $ MarkedBreakingWithPred h1
-        runOperation vcClientEnv (pushFunction o2) $ \h2 -> do
-          o3 <- createObj $ MarkedBreakingWithPred h2
-          runOperation vcClientEnv (pushFunction o3) $ \h3 -> do
-            o4 <- createObj $ MarkedBreakingWithPred h3
-            runOperation vcClientEnv (pushFunction o4) $ \h4 -> do
-              -- Test fetchFunction:
-              forM_ [(o1, h1), (o2, h2), (o3, h3), (o4, h4)] $ \(o, h) ->
-                runOperation vcClientEnv (fetchFunction h) $ \o' -> do
-                  timestamp o' `shouldBe` timestamp o
-                  obj o' `shouldBe` obj o
-
-              -- Test fetchVCObject:
-              forM_ [(o1, h1), (o2, h2), (o3, h3), (o4, h4)] $ \(o, h) ->
-                runOperation vcClientEnv (fetchVCObject h) $ \o' ->
-                  case obj o' of
-                    VCFunction e t -> do
-                      timestamp o' `shouldBe` timestamp o
-                      (e, t) `shouldBe` (obj o)
-                    _ -> expectationFailure "Expected to get a VCFunction"
-
-              -- Test fetchVCObjects:
-              runOperation vcClientEnv (fetchVCObjects [h1, h3, h4]) $ \hashToMeta -> do
-                Set.fromList (Map.keys hashToMeta) `shouldBe` Set.fromList [h1, h3, h4]
-                forM_ [(o1, h1), (o3, h3), (o4, h4)] $ \(o, h) ->
-                  case Map.lookup h hashToMeta of
-                    Just meta ->
-                      timestamp meta `shouldBe` timestamp o
-                    Nothing -> expectationFailure "impossible"
-
-              -- fetchFunctionsForGroups only returns the head h4:
-              runOperation vcClientEnv (fetchFunctionsForGroups (Set.singleton 432)) $ \metas -> do
-                map obj metas `shouldBe` [h4]
-
-              -- The closure of h4 should be empty as it has no dependencies:
-              runOperation vcClientEnv (fetchVCObjectClosureHashes h4) $ \metas -> do
-                metas `shouldBe` []
-
-    it "deletion" $ do
-      o1 <- createObj Init
-      runOperation vcClientEnv (pushFunction o1) $ \h1 -> do
-        o2 <- createObj Init
-        runOperation vcClientEnv (pushFunction o2) $ \h2 -> do
-          o3 <- createObj Init
-          runOperation vcClientEnv (pushFunction o3) $ \h3 -> do
-            o4 <- createObj Init
-            runOperation vcClientEnv (pushFunction o4) $ \h4 -> do
-              runOperation vcClientEnv (deleteVCObject h3) $ \() -> do
-                -- Fetching h3 should fail:
-                runOperationFail vcClientEnv (fetchFunction h3) $ \case
-                  VCServerError (CouldNotFindPath _) -> pure ()
-                  _ -> expectationFailure ""
-                -- Others should fetch:
-                forM_ [(o1, h1), (o2, h2), (o4, h4)] $ \(o, h) ->
-                  runOperation vcClientEnv (fetchFunction h) $ \o' -> do
-                    timestamp o' `shouldBe` timestamp o
-                    obj o' `shouldBe` obj o
-
-    -- -- TODO is fetchFunctionsForGRoups wrong? It is returning deleted scripts:
-    -- runOperation vcClientEnv (fetchFunctionsForGroups (Set.singleton 432)) $ \metas -> do
-    --   Set.fromList (map obj metas) `shouldBe` Set.fromList [h4, h2, h1]
-
-    it "deletion of autosave" $ do
-      o1 <- createObj Init
-      runOperation vcClientEnv (pushFunction o1) $ \h1 -> do
-        o2 <- createObj Init
-        runOperation vcClientEnv (pushFunction (o2 {name = "<AUTOSAVE>"})) $ \h2 -> do
-          -- h1 isn't an autosave so can't delete it:
-          runOperationFail vcClientEnv (deleteAutosavedFunction h1) $ \case
-            VCServerError (TryingToDeleteNonAutosave _) -> pure ()
-            _ -> expectationFailure ""
-          -- h2 is an autosave so it's fine
-          runOperation vcClientEnv (deleteAutosavedFunction h2) $ \() -> pure ()
-
-    it "history" $ do
-      o1 <- createObj Init
-      runOperation vcClientEnv (pushFunction o1) $ \h1 -> do
-        o2 <- createObj $ MarkedBreakingWithPred h1
-        runOperation vcClientEnv (pushFunction o2) $ \h2 -> do
-          o3 <- createObj $ MarkedBreakingWithPred h2
-          runOperation vcClientEnv (pushFunction o3) $ \h3 -> do
-            o4 <- createObj $ MarkedBreakingWithPred h3
-            runOperation vcClientEnv (pushFunction o4) $ \h4 -> do
-              runOperation vcClientEnv (fetchVCObjectHistory h4) $ \metas ->
-                (map obj metas) `shouldBe` [h4, h3, h2, h1]
-
-    it "history of clone" $ do
-      o1 <- createObj Init
-      runOperation vcClientEnv (pushFunction o1) $ \h1 -> do
-        o2 <- createObj $ MarkedBreakingWithPred h1
-        runOperation vcClientEnv (pushFunction o2) $ \h2 -> do
-          o3 <- createObj $ CloneOf h2
-          runOperation vcClientEnv (pushFunction o3) $ \h3 -> do
-            o4 <- createObj $ MarkedBreakingWithPred h3
-            runOperation vcClientEnv (pushFunction o4) $ \h4 -> do
-              runOperation vcClientEnv (fetchVCObjectHistory h4) $ \metas ->
-                (map obj metas) `shouldBe` [h4, h3, h2]
-
-    it "history of clone of clone" $ do
-      o1 <- createObj Init
-      runOperation vcClientEnv (pushFunction o1) $ \h1 -> do
-        o2 <- createObj $ CloneOf h1
-        runOperation vcClientEnv (pushFunction o2) $ \h2 -> do
-          o3 <- createObj $ CloneOf h2
-          runOperation vcClientEnv (pushFunction o3) $ \h3 -> do
-            o4 <- createObj $ MarkedBreakingWithPred h3
-            runOperation vcClientEnv (pushFunction o4) $ \h4 -> do
-              runOperation vcClientEnv (fetchVCObjectHistory h4) $ \metas ->
-                (map obj metas) `shouldBe` [h4, h3, h2]
 
 main :: IO ()
 main =
@@ -225,4 +44,4 @@ main =
               }
     putStrLn "  Done."
 
-    hspec $ spec vcClientEnv
+    hspec $ vcServerSpec vcClientEnv


### PR DESCRIPTION
Refactors `Inferno.VersionControl.Operations` into a type-class, moving the existing implementation to an instance in `Inferno.VersionControl.Operations.Filesystem`.

No behavior-modifying changes should have been introduced except using `atomicWriteFile` (from `atomic-write`) in `Inferno.VersionControl.Client.Cached` because it looks like it can help avoiding corruption if two threads are caching the same deps file concurrently.
