### PR TITLE
[inferno-vc] Simplified InfernoVCOperations typeclass usage

### DIFF
--- a/inferno-vc/src/Inferno/VersionControl/Operations.hs
+++ b/inferno-vc/src/Inferno/VersionControl/Operations.hs
@@ -24,10 +24,10 @@ import Inferno.VersionControl.Types
   )
 
 class
-  ( Ord (Group m),
-    VCHashUpdate (Author m),
+  ( Ord (Group m), -- This constraint is for fetchFunctionsForGroups's Set argument
+    VCHashUpdate (Author m), -- These ones so we can hash a VCMeta
     VCHashUpdate (Group m),
-    MonadError err m,
+    MonadError err m, -- These so implementors can throw VCStoreError when appropiate
     AsType VCStoreError err
   ) =>
   InfernoVCOperations err m
@@ -36,7 +36,7 @@ class
   type Author m :: Type
 
   -- | Store an object and return its hash. hash is the object's primary key
-  --   The following always holds:
+  --   The following always holds (modulo errors):
   --   @
   --     x' <- storeVCObject x >>= fetchVCObject
   --     x == x'
@@ -52,7 +52,7 @@ class
 
   -- | Fetch an object by its hash.
   --
-  --   The following always holds:
+  --   The following always holds (modulo errors):
   --   @
   --     x' <- storeVCObject x >>= fetchVCObject
   --     x == x'
@@ -63,7 +63,7 @@ class
   fetchVCObjectClosureHashes :: VCObjectHash -> m [VCObjectHash]
 
   -- | Retrieves the full history of the chain which the given hash belongs to.
-  -- History is given from newest (head) to oldest
+  -- History is given from newest (head) to oldest (root)
   fetchVCObjectHistory :: VCObjectHash -> m [VCMeta (Author m) (Group m) VCObjectHash]
 
   -- | Fetch all objects that are public or that belong to the given set of groups.

--- a/inferno-vc/src/Inferno/VersionControl/Operations/Filesystem.hs
+++ b/inferno-vc/src/Inferno/VersionControl/Operations/Filesystem.hs
@@ -38,7 +38,7 @@ import Control.Monad.Except (ExceptT, MonadError)
 import Control.Monad.IO.Class (MonadIO (..))
 import Control.Monad.Reader (MonadReader (..), ReaderT, asks, runReaderT)
 import Crypto.Hash (digestFromByteString)
-import Data.Aeson (FromJSON, ToJSON, Value, eitherDecode, encode)
+import Data.Aeson (FromJSON, ToJSON, eitherDecode, encode)
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Base64.URL as Base64
 import qualified Data.ByteString.Char8 as Char8
@@ -48,6 +48,7 @@ import Data.Generics.Product (HasField, HasType, getTyped, the)
 import Data.Generics.Sum (AsType (..))
 import qualified Data.Set as Set
 import Data.Text (Text, pack)
+import Foreign.C.Types (CTime (..))
 import GHC.Generics (Generic)
 import Inferno.Types.Syntax (Dependencies (..))
 import Inferno.VersionControl.Log (VCServerTrace (..), vcServerTraceToText)
@@ -74,7 +75,7 @@ data InfernoVCFilesystemEnv = InfernoVCFilesystemEnv
   }
   deriving (Generic)
 
-newtype InfernoVCFilesystemM err m a = InfernoVCFilesystemM (ReaderT InfernoVCFilesystemEnv (ExceptT err m) a)
+newtype InfernoVCFilesystemM g a err m x = InfernoVCFilesystemM (ReaderT InfernoVCFilesystemEnv (ExceptT err m) x)
   deriving
     ( Functor,
       Applicative,
@@ -87,7 +88,7 @@ newtype InfernoVCFilesystemM err m a = InfernoVCFilesystemM (ReaderT InfernoVCFi
       MonadMask
     )
 
-runInfernoVCFilesystemM :: InfernoVCFilesystemM err m a -> InfernoVCFilesystemEnv -> ExceptT err m a
+runInfernoVCFilesystemM :: forall g a err m x. InfernoVCFilesystemM g a err m x -> InfernoVCFilesystemEnv -> ExceptT err m x
 runInfernoVCFilesystemM (InfernoVCFilesystemM f) = runReaderT f
 
 withEnv ::
@@ -107,9 +108,22 @@ withEnv config txtTracer f = do
   where
     storePath = config ^. the @"vcPath"
 
-instance (MonadIO m, MonadMask m, AsType VCStoreError err) => InfernoVCOperations err (InfernoVCFilesystemM err m) where
-  type Serializable (InfernoVCFilesystemM err m) = ToJSON
-  type Deserializable (InfernoVCFilesystemM err m) = FromJSON
+instance
+  ( MonadIO m,
+    MonadMask m,
+    AsType VCStoreError err,
+    Ord g,
+    VCHashUpdate g,
+    VCHashUpdate a,
+    ToJSON g,
+    ToJSON a,
+    FromJSON a,
+    FromJSON g
+  ) =>
+  InfernoVCOperations err (InfernoVCFilesystemM g a err m)
+  where
+  type Author (InfernoVCFilesystemM g a err m) = a
+  type Group (InfernoVCFilesystemM g a err m) = g
 
   storeVCObject obj@VCMeta {obj = ast, pred = p} = do
     VCStorePath storePath <- asks getTyped
@@ -177,7 +191,7 @@ instance (MonadIO m, MonadMask m, AsType VCStoreError err) => InfernoVCOperation
     lock <- asks getTyped
     withWrite lock $ do
       -- check if object meta exists with hash meta_hash, and get meta
-      (VCMeta {name = obj_name} :: VCMeta Value Value VCObject) <- fetchVCObject obj_hash
+      VCMeta {name = obj_name} <- fetchVCObject obj_hash
       -- check that it is safe to delete
       if obj_name == pack "<AUTOSAVE>"
         then do
@@ -204,7 +218,7 @@ instance (MonadIO m, MonadMask m, AsType VCStoreError err) => InfernoVCOperation
       createDirectoryIfMissing True $ storePath </> "removed" </> "deps"
 
     withWrite lock $ do
-      (metas :: [VCMeta Value Value VCObjectHash]) <- fetchVCObjectHistory obj_hash
+      metas <- fetchVCObjectHistory obj_hash
       forM_ metas $ \VCMeta {obj = hash} -> do
         forM_
           [ show hash,
@@ -316,20 +330,35 @@ instance (MonadIO m, MonadMask m, AsType VCStoreError err) => InfernoVCOperation
     let fp = storePath </> "deps" </> show h
     readVCObjectHashTxt fp
 
-  getAllHeads = do
-    VCStorePath storePath <- getTyped <$> ask
-    -- We don't need a lock here because this only lists the heads/ directory, it doesn't
-    -- read any file contents (and I assume the `ls` is atomic)
-    headsRaw <- liftIO $ getDirectoryContents $ storePath </> "heads"
-    pure $
-      foldr
-        ( \hd xs ->
-            case (either (const Nothing) Just $ Base64.decode $ Char8.pack hd) >>= digestFromByteString of
-              Just hsh -> (VCObjectHash hsh) : xs
-              Nothing -> xs
-        )
-        []
-        (map takeFileName headsRaw)
+  deleteAutosavedVCObjectsOlderThan t = do
+    -- We know that all autosaves must be heads:
+    heads <- getAllHeads
+    forM_
+      heads
+      ( \h -> do
+          -- fetch object, check name and timestamp
+          (VCMeta {name, timestamp} :: VCMeta a g VCObject) <- fetchVCObject h
+          if name == "<AUTOSAVE>" && timestamp < CTime (truncate t)
+            then -- delete the stale ones (> t old)
+              deleteAutosavedVCObject h
+            else pure ()
+      )
+
+getAllHeads :: VCStoreEnvM err m => m [VCObjectHash]
+getAllHeads = do
+  VCStorePath storePath <- getTyped <$> ask
+  -- We don't need a lock here because this only lists the heads/ directory, it doesn't
+  -- read any file contents (and I assume the `ls` is atomic)
+  headsRaw <- liftIO $ getDirectoryContents $ storePath </> "heads"
+  pure $
+    foldr
+      ( \hd xs ->
+          case (either (const Nothing) Just $ Base64.decode $ Char8.pack hd) >>= digestFromByteString of
+            Just hsh -> (VCObjectHash hsh) : xs
+            Nothing -> xs
+      )
+      []
+      (map takeFileName headsRaw)
 
 fetchCurrentHead ::
   ( MonadError err m,

--- a/inferno-vc/src/Inferno/VersionControl/Server.hs
+++ b/inferno-vc/src/Inferno/VersionControl/Server.hs
@@ -144,10 +144,8 @@ runServerConfig ::
   forall m env config.
   ( HasField "serverHost" config config T.Text T.Text,
     HasField "serverPort" config config Int Int,
-    FromJSON config,
     VCHashUpdate (Ops.Author m),
     VCHashUpdate (Ops.Group m),
-    FromJSON config,
     FromJSON (Ops.Author m),
     FromJSON (Ops.Group m),
     ToJSON (Ops.Author m),

--- a/inferno-vc/src/Inferno/VersionControl/Server.hs
+++ b/inferno-vc/src/Inferno/VersionControl/Server.hs
@@ -167,8 +167,9 @@ runServerConfig withEnv runOp serverConfig = do
       serverTracer = contramap vcServerTraceToText tracer
   withEnv serverConfig tracer $ \env -> do
     let cleanup = do
-          now <- liftIO getPOSIXTime
-          runExceptT (runOp (Ops.deleteAutosavedVCObjectsOlderThan now) env) >>= \case
+          -- cutoff is an hour ago
+          cutoff <- subtract (60 * 60) <$> liftIO getPOSIXTime
+          runExceptT (runOp (Ops.deleteAutosavedVCObjectsOlderThan cutoff) env) >>= \case
             Left (VCServerError {serverError}) ->
               traceWith @IOTracer serverTracer (ThrownVCStoreError serverError)
             Right _ -> pure ()

--- a/inferno-vc/src/Inferno/VersionControl/Server.hs
+++ b/inferno-vc/src/Inferno/VersionControl/Server.hs
@@ -21,7 +21,7 @@ where
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (link, withAsync)
 import Control.Lens (to, (^.))
-import Control.Monad (forM, forM_, forever)
+import Control.Monad (forM, forever)
 import Control.Monad.Except (ExceptT, runExceptT, throwError)
 import Control.Monad.IO.Class (liftIO)
 import Data.Aeson (FromJSON, ToJSON)
@@ -33,7 +33,6 @@ import Data.Set (Set)
 import Data.String (fromString)
 import qualified Data.Text as T
 import Data.Time.Clock.POSIX (getPOSIXTime)
-import Foreign.C.Types (CTime (..))
 import GHC.Generics (Generic)
 import Inferno.Types.Syntax (Expr)
 import Inferno.Types.Type (TCScheme)
@@ -91,17 +90,13 @@ type VersionControlAPI a g =
     :<|> "delete" :> "scripts" :> Capture "hash" VCObjectHash :> DeleteThrowingVCStoreError '[JSON] ()
 
 vcServer ::
-  ( VCHashUpdate a,
-    VCHashUpdate g,
+  ( VCHashUpdate (Ops.Author m),
+    VCHashUpdate (Ops.Group m),
     Ops.InfernoVCOperations VCServerError m,
-    Ops.Deserializable m a,
-    Ops.Deserializable m g,
-    Ops.Serializable m a,
-    Ops.Serializable m g,
-    Ord g
+    Ord (Ops.Group m)
   ) =>
   (forall x. m x -> Handler (Union (WithError VCServerError x))) ->
-  Server (VersionControlAPI a g)
+  Server (VersionControlAPI (Ops.Author m) (Ops.Group m))
 vcServer toHandler =
   toHandler . fetchFunctionH
     :<|> toHandler . Ops.fetchFunctionsForGroups
@@ -125,58 +120,45 @@ vcServer toHandler =
       Map.fromList <$> (forM hs $ \h -> (h,) <$> Ops.fetchVCObject h)
 
 runServer ::
-  forall proxy m a g env config.
+  forall m env config.
   ( HasField "serverHost" config config T.Text T.Text,
     HasField "serverPort" config config Int Int,
-    VCHashUpdate a,
-    VCHashUpdate g,
+    VCHashUpdate (Ops.Author m),
+    VCHashUpdate (Ops.Group m),
     FromJSON config,
-    FromJSON a,
-    FromJSON g,
-    ToJSON a,
-    ToJSON g,
-    Ops.Deserializable m a,
-    Ops.Deserializable m g,
-    Ops.Serializable m a,
-    Ops.Serializable m g,
-    Ops.InfernoVCOperations VCServerError m,
-    Ord g
+    FromJSON (Ops.Author m),
+    FromJSON (Ops.Group m),
+    ToJSON (Ops.Author m),
+    ToJSON (Ops.Group m),
+    Ops.InfernoVCOperations VCServerError m
   ) =>
-  proxy a ->
-  proxy g ->
   (forall x. config -> IOTracer T.Text -> (env -> IO x) -> IO x) ->
   (forall x. m x -> env -> ExceptT VCServerError IO x) ->
   IO ()
-runServer proxyA proxyG withEnv runOp = do
+runServer withEnv runOp = do
   readServerConfig "config.yml" >>= \case
     Left err -> putStrLn err
-    Right serverConfig -> runServerConfig proxyA proxyG withEnv runOp serverConfig
+    Right serverConfig -> runServerConfig withEnv runOp serverConfig
 
 runServerConfig ::
-  forall proxy m a g env config.
+  forall m env config.
   ( HasField "serverHost" config config T.Text T.Text,
     HasField "serverPort" config config Int Int,
     FromJSON config,
-    VCHashUpdate a,
-    VCHashUpdate g,
-    FromJSON a,
-    FromJSON g,
-    ToJSON a,
-    ToJSON g,
-    Ops.Deserializable m a,
-    Ops.Deserializable m g,
-    Ops.Serializable m a,
-    Ops.Serializable m g,
-    Ops.InfernoVCOperations VCServerError m,
-    Ord g
+    VCHashUpdate (Ops.Author m),
+    VCHashUpdate (Ops.Group m),
+    FromJSON config,
+    FromJSON (Ops.Author m),
+    FromJSON (Ops.Group m),
+    ToJSON (Ops.Author m),
+    ToJSON (Ops.Group m),
+    Ops.InfernoVCOperations VCServerError m
   ) =>
-  proxy a ->
-  proxy g ->
   (forall x. config -> IOTracer T.Text -> (env -> IO x) -> IO x) ->
   (forall x. m x -> env -> ExceptT VCServerError IO x) ->
   config ->
   IO ()
-runServerConfig _ _ withEnv runOp serverConfig = do
+runServerConfig withEnv runOp serverConfig = do
   let host = serverConfig ^. the @"serverHost" . to T.unpack . to fromString
       port = serverConfig ^. the @"serverPort"
       settingsWithTimeout = setTimeout 300 defaultSettings
@@ -185,8 +167,8 @@ runServerConfig _ _ withEnv runOp serverConfig = do
       serverTracer = contramap vcServerTraceToText tracer
   withEnv serverConfig tracer $ \env -> do
     let cleanup = do
-          now <- liftIO $ CTime . round . toRational <$> getPOSIXTime
-          runExceptT (runOp (deleteStaleAutosavedVCObjects @a @g now) env) >>= \case
+          now <- liftIO getPOSIXTime
+          runExceptT (runOp (Ops.deleteAutosavedVCObjectsOlderThan now) env) >>= \case
             Left (VCServerError {serverError}) ->
               traceWith @IOTracer serverTracer (ThrownVCStoreError serverError)
             Right _ -> pure ()
@@ -199,31 +181,6 @@ runServerConfig _ _ withEnv runOp serverConfig = do
           gzip def $
             serve (Proxy :: Proxy (VersionControlAPI a g)) $
               vcServer (liftIO . liftTypedError . flip runOp env)
-
--- | Deletes all stale autosaved objects from the VC.
--- As this is a non-critical maintenance operation, we do not hold the lock around the
--- entire operation.
-deleteStaleAutosavedVCObjects ::
-  forall a g m err.
-  ( Ops.InfernoVCOperations err m,
-    Ops.Deserializable m a,
-    Ops.Deserializable m g
-  ) =>
-  CTime ->
-  m ()
-deleteStaleAutosavedVCObjects now = do
-  -- We know that all autosaves must be heads:
-  heads <- Ops.getAllHeads
-  forM_
-    heads
-    ( \h -> do
-        -- fetch object, check name and timestamp
-        (VCMeta {name, timestamp} :: VCMeta a g VCObject) <- Ops.fetchVCObject h
-        if name == T.pack "<AUTOSAVE>" && timestamp < now - 60 * 60
-          then -- delete the stale ones (> 1hr old)
-            Ops.deleteAutosavedVCObject h
-          else pure ()
-    )
 
 withLinkedAsync_ :: IO a -> IO b -> IO b
 withLinkedAsync_ f g = withAsync f $ \h -> link h >> g

--- a/inferno-vc/src/Inferno/VersionControl/Testing.hs
+++ b/inferno-vc/src/Inferno/VersionControl/Testing.hs
@@ -85,7 +85,7 @@ createObjForGroup group predecessor = do
       }
 
 vcServerSpec ::
-  forall a g.
+  forall g a.
   ( Arbitrary a,
     Show a,
     FromJSON a,

--- a/inferno-vc/src/Inferno/VersionControl/Testing.hs
+++ b/inferno-vc/src/Inferno/VersionControl/Testing.hs
@@ -232,6 +232,9 @@ vcServerSpec url = do
       (map obj metas) `shouldBe` [h4, h3, h2]
       let o3' = metas !! 1
       Inferno.VersionControl.Types.pred o3' `shouldBe` CloneOfRemoved h2
+      -- Original object is not deleted
+      metas' <- runOperation vcClientEnv (fetchVCObjectHistory h1)
+      (map obj metas') `shouldBe` [h1]
 
     it "history of clone of deleted (clone is head)" $ do
       o1 <- createObj Init

--- a/inferno-vc/src/Inferno/VersionControl/Testing.hs
+++ b/inferno-vc/src/Inferno/VersionControl/Testing.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -113,16 +113,16 @@ vcServerSpec url = do
       h3 <- runOperation vcClientEnv (pushFunction o3)
       o4 <- createObjForGroup g $ MarkedBreakingWithPred h3
       h4 <- runOperation vcClientEnv (pushFunction o4)
-      
+
       -- Test fetchFunction:
       forM_ [(o1, h1), (o2, h2), (o3, h3), (o4, h4)] $ \(o, h) -> do
-        o' <-  runOperation vcClientEnv (fetchFunction h)
+        o' <- runOperation vcClientEnv (fetchFunction h)
         timestamp o' `shouldBe` timestamp o
         obj o' `shouldBe` obj o
 
       -- Test fetchVCObject:
       forM_ [(o1, h1), (o2, h2), (o3, h3), (o4, h4)] $ \(o, h) -> do
-        o' <-  runOperation vcClientEnv (fetchVCObject h)
+        o' <- runOperation vcClientEnv (fetchVCObject h)
         case obj o' of
           VCFunction e t -> do
             timestamp o' `shouldBe` timestamp o
@@ -257,8 +257,6 @@ vcServerSpec url = do
       runOperationFail vcClientEnv (pushFunction o3) >>= \case
         VCServerError (TryingToAppendToNonHead _) -> pure ()
         _ -> expectationFailure ""
-
-
   where
     fetchFunction :: VCObjectHash -> ClientMWithVCStoreError (VCMeta a g (Expr (Pinned VCObjectHash) (), TCScheme))
     fetchFunctionsForGroups :: Set.Set g -> ClientMWithVCStoreError [VCMeta a g VCObjectHash]

--- a/inferno-vc/test/Spec.hs
+++ b/inferno-vc/test/Spec.hs
@@ -31,7 +31,7 @@ main =
     putStrLn "  Done."
 
     hspec $
-      vcServerSpec
+      vcServerSpec @Int @Int
         BaseUrl
           { baseUrlScheme = Http,
             baseUrlHost = "127.0.0.1",

--- a/inferno-vc/test/Spec.hs
+++ b/inferno-vc/test/Spec.hs
@@ -4,7 +4,6 @@
 module Main (main) where
 
 import Control.Concurrent (forkIO)
-import Data.Proxy (Proxy (..))
 import qualified Inferno.VersionControl.Operations.Filesystem as FSOps
 import Inferno.VersionControl.Server (runServerConfig)
 import Inferno.VersionControl.Server.Types (ServerConfig (..))
@@ -22,10 +21,8 @@ main =
     _ <-
       forkIO $
         runServerConfig
-          (Proxy :: Proxy Int)
-          (Proxy :: Proxy Int)
           FSOps.withEnv
-          FSOps.runInfernoVCFilesystemM
+          (FSOps.runInfernoVCFilesystemM @Int @Int)
           ServerConfig
             { serverHost = "127.0.0.1",
               serverPort = 13077,


### PR DESCRIPTION
Also removed `getAllHeads` and added `deleteAutosavedVCObjectsOlderThan` instead to allow for more efficient implementations.

The changes to the class that make the usage simpler are:

 - Removed the `De/Serializable` associated constraints which were applied on the `group` and `author` type variables of `VCMeta` and added a `Group` and `Author` associated types instead. See the changes in `runServer` and `runServerConfig` call sites.
  This change is not only cosmetic, it also gives knowledge of `author` and `group` to all type-class method which can use it to deserialise stuff without resorting to AmbiguousTypes or Proxies (which moves the burden of keeping track of the type witnesses to the call-sites)

- Made the constraint `AsType err VCStoreError` that `runServer/Config` requires explicit on the type-class. This is so implementors don't assume they can ignore it until they're faced with it when attempting to make the call-sites compile.


Removing `getAllHeads` is motivated by the fact that the only caller was `Inferno.VersionControl.deleteStaleAutosavedVCObjects`. This function used an implementation that can be made much more efficient if the backend knows that what is actually meant is "give me all the heads _so I can purge some auto-saved objects_" so it has been moved to the typeclass in its place