### PR TITLE
Add magic cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           name: inferno
           authToken: "${{ secrets.CACHIX_TOKEN }}"
+      - uses: DeterminateSystems/magic-nix-cache-action@main
       - run: |
           nix build -L .#
 


### PR DESCRIPTION
I was working on an ad-hoc solution for #78 and then I found that there's an existing GH action that does basically the same thing. I've triggered several (expected) rebuilds on a different branch with the same actions config and haven't experienced any rebuilds of dependencies. It appears to work fine with Cachix as well

One advantage to also using this is that if an external contributor ever wanted to open a PR, the Cachix cache wouldn't work because it always requires a secret, which are unavailable for PRs from forks

Note that the `magic-cache-action` uses the built-in GH cache as a substituter (rather than mounting a cache as the Nix store), so dependencies will still be downloaded in any event