### PR TITLE
Add some primitives; speed up tests

### DIFF
--- a/inferno-core/CHANGELOG.md
+++ b/inferno-core/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Revision History for inferno-core
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.4.1.0 -- 2023-09-11
+* Add function composition, pipe, fst, snd, and zip
+
 ## 0.4.0.0 -- 2023-08-15
 * Pass environments directly, instead of functions (breaking change).
 

--- a/inferno-core/inferno-core.cabal
+++ b/inferno-core/inferno-core.cabal
@@ -120,7 +120,7 @@ test-suite inferno-tests
     , OverloadedStrings
     , TupleSections
     , RecordWildCards
-  ghc-options: -Wall -Wunused-packages -Wincomplete-uni-patterns -Wincomplete-record-updates
+  ghc-options: -Wall -Wunused-packages -Wincomplete-uni-patterns -Wincomplete-record-updates -O2
 
 executable inferno
   main-is: Main.hs

--- a/inferno-core/inferno-core.cabal
+++ b/inferno-core/inferno-core.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                inferno-core
-version:             0.4.0.0
+version:             0.4.1.0
 synopsis:            A statically-typed functional scripting language
 description:         Parser, type inference, and interpreter for a statically-typed functional scripting language
 category:            DSL,Scripting

--- a/inferno-core/src/Inferno/Core.hs
+++ b/inferno-core/src/Inferno/Core.hs
@@ -35,15 +35,18 @@ data InfernoError
 
 -- | Public API for the Inferno interpreter. @c@ is the custom value type.
 data Interpreter c = Interpreter
-  { evalInEnv ::
+  { -- | Evaluates an Expr in a given (local) pinned env and implicit env
+    evalInEnv ::
       forall a.
       Map.Map ExtIdent (Value c (ImplEnvM IO c)) ->
       Map.Map ExtIdent (Value c (ImplEnvM IO c)) ->
       Expr (Maybe VCObjectHash) a ->
       IO (Either EvalError (Value c (ImplEnvM IO c))),
+    -- | Evaluates an Expr in an empty pinned and implicit env. This will be
+    -- much faster than @evalInEnv Map.empty Map.empty@ as it reuses the
+    -- evaluation of the prelude.
     evalInEmptyEnv ::
       forall a.
-      Map.Map ExtIdent (Value c (ImplEnvM IO c)) ->
       Expr (Maybe VCObjectHash) a ->
       IO (Either EvalError (Value c (ImplEnvM IO c))),
     evalInImplEnvM ::
@@ -73,9 +76,7 @@ mkInferno prelude = do
         \localEnv env expr ->
           mkTermEnv localEnv
             >>= \lenv -> runEvalIO lenv env expr,
-      evalInEmptyEnv =
-        \env expr ->
-          runEvalIO emptyTermEnv env expr,
+      evalInEmptyEnv = runEvalIO emptyTermEnv Map.empty,
       evalInImplEnvM = runEvalIO,
       parseAndInferTypeReps = parseAndInferTypeReps,
       parseAndInfer = parseAndInfer,

--- a/inferno-core/src/Inferno/Module/Prelude.hs
+++ b/inferno-core/src/Inferno/Module/Prelude.hs
@@ -616,11 +616,11 @@ module Base
   infix 19 ..;
   infix 5 ?;
 
-  infixl 12 .;
+  infixl 12 <<;
   infixl 12 |>;
 
-  @doc Function composition. `(f . g) x == f (g x)`;
-  (.) : forall 'a 'b 'c. ('b -> 'c) -> ('a -> 'b) -> 'a -> 'c := fun f g x -> f (g x);
+  @doc Function composition. `(f << g) x == f (g x)`;
+  (<<) : forall 'a 'b 'c. ('b -> 'c) -> ('a -> 'b) -> 'a -> 'c := fun f g x -> f (g x);
 
   @doc The pipe operator. `x |> f |> g == g (f x)`;
   (|>) : forall 'a 'b 'c. 'a -> ('a -> 'b) -> 'b := fun x f -> f x;

--- a/inferno-core/src/Inferno/Module/Prelude/Defs.hs
+++ b/inferno-core/src/Inferno/Module/Prelude/Defs.hs
@@ -434,6 +434,15 @@ zeroFun = VFun $ \case
   VTypeRep ty -> throwM $ RuntimeError $ "zeroFun: unexpected runtimeRep " <> show ty
   _ -> throwM $ RuntimeError "zeroFun: expecting a runtimeRep"
 
+zipFun :: (MonadThrow m) => Value c m
+zipFun = VFun $ \case
+  VArray xs ->
+    return $ VFun $ \case
+      VArray ys ->
+        return $ VArray $ map (\(v1, v2) -> VTuple [v1, v2]) $ zip xs ys
+      _ -> throwM $ RuntimeError "zip: expecting an array"
+  _ -> throwM $ RuntimeError "zip: expecting an array"
+
 lengthFun :: (MonadThrow m) => Value c m
 lengthFun =
   VFun $ \case

--- a/inferno-core/test/Eval/Spec.hs
+++ b/inferno-core/test/Eval/Spec.hs
@@ -7,7 +7,7 @@ import Data.Bifunctor (bimap)
 import Data.Int (Int64)
 import qualified Data.Map as Map
 import Data.Text (unpack)
-import Inferno.Core (Interpreter (evalInEnv, parseAndInfer, parseAndInferTypeReps), mkInferno)
+import Inferno.Core (Interpreter (evalInEnv, parseAndInfer, parseAndInferTypeReps, evalInEmptyEnv), mkInferno)
 import Inferno.Eval.Error (EvalError (..))
 import Inferno.Module.Builtin (enumBoolHash)
 import qualified Inferno.Module.Prelude as Prelude
@@ -15,12 +15,12 @@ import Inferno.Types.Syntax (BaseType (..), Expr (..), ExtIdent (..), Ident (..)
 import Inferno.Types.Value (Value (..))
 import Inferno.Types.VersionControl (pinnedToMaybe)
 import Inferno.Utils.Prettyprinter (renderPretty)
-import Test.Hspec (Spec, describe, expectationFailure, it, shouldBe)
+import Test.Hspec (Spec, describe, expectationFailure, it, shouldBe, runIO)
 
 type TestCustomValue = ()
 
-runtimeTypeRepsTests :: Spec
-runtimeTypeRepsTests = describe "runtime type reps" $ do
+runtimeTypeRepsTests :: Interpreter TestCustomValue -> Spec
+runtimeTypeRepsTests inferno = describe "runtime type reps" $ do
   let expr_3 =
         case parseAndInfer inferno "3" of
           Left err ->
@@ -38,7 +38,6 @@ runtimeTypeRepsTests = describe "runtime type reps" $ do
     let expr_3_double = App expr (TypeRep () (TBase TDouble))
     shouldEvaluateTo expr_3_double (VDouble 3)
   where
-    inferno = mkInferno Prelude.builtinModules :: Interpreter TestCustomValue
     shouldEvaluateTo expr (v :: Value TestCustomValue IO) = do
       evalInEnv inferno Map.empty Map.empty expr >>= \case
         Left err -> expectationFailure $ "Failed eval with: " <> show err
@@ -47,6 +46,36 @@ runtimeTypeRepsTests = describe "runtime type reps" $ do
 evalTests :: Spec
 evalTests = describe "evaluate" $
   do
+    inferno <- runIO $ (mkInferno Prelude.builtinModules :: IO (Interpreter TestCustomValue))
+    let shouldEvaluateInEnvTo localEnv implEnv str (v :: Value TestCustomValue IO) =
+          it ("\"" <> unpack str <> "\" should evaluate to " <> (unpack $ renderPretty v)) $ do
+            case parseAndInferTypeReps inferno str of
+              Left err -> expectationFailure $ show err
+              Right ast ->
+                evalInEnv inferno localEnv implEnv ast >>= \case
+                  Left err -> expectationFailure $ "Failed eval with: " <> show err
+                  Right v' -> (renderPretty v') `shouldBe` (renderPretty v)
+    let shouldEvaluateTo str (v :: Value TestCustomValue IO) =
+          it ("\"" <> unpack str <> "\" should evaluate to " <> (unpack $ renderPretty v)) $ do
+            case parseAndInferTypeReps inferno str of
+              Left err -> expectationFailure $ show err
+              Right ast ->
+                evalInEmptyEnv inferno Map.empty ast >>= \case
+                  Left err -> expectationFailure $ "Failed eval with: " <> show err
+                  Right v' -> (renderPretty v') `shouldBe` (renderPretty v)
+    let shouldThrowRuntimeError str merr =
+          it ("\"" <> unpack str <> "\" should throw a runtime error") $ do
+            case parseAndInferTypeReps inferno str of
+              Left err -> expectationFailure $ show err
+              Right ast ->
+                -- TODO fix implicit Env to empty too?
+                evalInEmptyEnv inferno Map.empty ast >>= \case
+                  Left err' -> case merr of
+                    Nothing -> pure ()
+                    Just err -> err' `shouldBe` err
+                  Right _ -> expectationFailure $ "Should not evaluate."
+
+
     shouldEvaluateTo "3" $ VDouble 3
     shouldEvaluateTo "-3" $ VDouble (-3)
     shouldEvaluateTo "-(-3)" $ VDouble 3
@@ -376,27 +405,7 @@ evalTests = describe "evaluate" $
     shouldThrowRuntimeError "assert #false in ()" $ Just AssertionFailed
     shouldEvaluateTo "assert #true in ()" $ VTuple []
 
-    runtimeTypeRepsTests
+    runtimeTypeRepsTests inferno
   where
     vTrue = VEnum enumBoolHash (Ident "true")
     vFalse = VEnum enumBoolHash (Ident "false")
-    inferno = mkInferno Prelude.builtinModules :: Interpreter TestCustomValue
-    shouldEvaluateInEnvTo localEnv implEnv str (v :: Value TestCustomValue IO) =
-      it ("\"" <> unpack str <> "\" should evaluate to " <> (unpack $ renderPretty v)) $ do
-        case parseAndInferTypeReps inferno str of
-          Left err -> expectationFailure $ show err
-          Right ast ->
-            evalInEnv inferno localEnv implEnv ast >>= \case
-              Left err -> expectationFailure $ "Failed eval with: " <> show err
-              Right v' -> (renderPretty v') `shouldBe` (renderPretty v)
-    shouldEvaluateTo = shouldEvaluateInEnvTo Map.empty Map.empty
-    shouldThrowRuntimeError str merr =
-      it ("\"" <> unpack str <> "\" should throw a runtime error") $ do
-        case parseAndInferTypeReps inferno str of
-          Left err -> expectationFailure $ show err
-          Right ast ->
-            evalInEnv inferno Map.empty Map.empty ast >>= \case
-              Left err' -> case merr of
-                Nothing -> pure ()
-                Just err -> err' `shouldBe` err
-              Right _ -> expectationFailure $ "Should not evaluate."

--- a/inferno-core/test/Eval/Spec.hs
+++ b/inferno-core/test/Eval/Spec.hs
@@ -60,7 +60,7 @@ evalTests = describe "evaluate" $
             case parseAndInferTypeReps inferno str of
               Left err -> expectationFailure $ show err
               Right ast ->
-                evalInEmptyEnv inferno Map.empty ast >>= \case
+                evalInEmptyEnv inferno ast >>= \case
                   Left err -> expectationFailure $ "Failed eval with: " <> show err
                   Right v' -> (renderPretty v') `shouldBe` (renderPretty v)
     let shouldThrowRuntimeError str merr =
@@ -68,8 +68,7 @@ evalTests = describe "evaluate" $
             case parseAndInferTypeReps inferno str of
               Left err -> expectationFailure $ show err
               Right ast ->
-                -- TODO fix implicit Env to empty too?
-                evalInEmptyEnv inferno Map.empty ast >>= \case
+                evalInEmptyEnv inferno ast >>= \case
                   Left err' -> case merr of
                     Nothing -> pure ()
                     Just err -> err' `shouldBe` err

--- a/inferno-core/test/Eval/Spec.hs
+++ b/inferno-core/test/Eval/Spec.hs
@@ -339,7 +339,17 @@ evalTests = describe "evaluate" $
     shouldEvaluateTo "match [1, 3] with { | [1, _] -> 2 | _ -> 3 }" $ VDouble 2
     shouldEvaluateTo "match [1.2, 3, 3] with { | [x, y, z] -> 2*x+3*y+z | _ -> 3 }" $ VDouble 14.4
     shouldEvaluateTo "(fun a -> match a with { | [x, y, z] -> truncateTo x 1.1 | _ -> 3 }) [1, 2, 3]" $ VDouble 1.1
+    -- Tuple
+    shouldEvaluateTo "fst (1, 0) == snd (0, 1)" $ vTrue
+    shouldEvaluateTo "zip [1, 2, 3] [4, 5] == [(1, 4), (2, 5)]" $ vTrue
+    shouldEvaluateTo "zip [1, 2] [\"a\", \"b\"] == [(1,\"a\"),(2,\"b\")]" $ vTrue
+    shouldEvaluateTo "zip [1] [\"a\", \"b\"] == [(1,\"a\")]" $ vTrue
+    shouldEvaluateTo "zip [1, 2] [\"a\"] == [(1,\"a\")]" $ vTrue
+    shouldEvaluateTo "zip [] [1, 2] == []" $ vTrue
+    shouldEvaluateTo "zip [1, 2] [] == []" $ vTrue
     -- Miscellaneous
+    shouldEvaluateTo "Array.map ((Text.append \"a\") . (Text.append \"b\")) [\"0\", \"1\"] == [\"ab0\", \"ab1\"]" $ vTrue
+    shouldEvaluateTo "\"0\" |> Text.append \"a\" |> Text.append \"b\" == \"ba0\"" $ vTrue
     shouldEvaluateTo "\"hello world\"" $ VText "hello world"
     shouldEvaluateInEnvTo
       Map.empty

--- a/inferno-core/test/Eval/Spec.hs
+++ b/inferno-core/test/Eval/Spec.hs
@@ -348,7 +348,7 @@ evalTests = describe "evaluate" $
     shouldEvaluateTo "zip [] [1, 2] == []" $ vTrue
     shouldEvaluateTo "zip [1, 2] [] == []" $ vTrue
     -- Miscellaneous
-    shouldEvaluateTo "Array.map ((Text.append \"a\") . (Text.append \"b\")) [\"0\", \"1\"] == [\"ab0\", \"ab1\"]" $ vTrue
+    shouldEvaluateTo "Array.map ((Text.append \"a\") << (Text.append \"b\")) [\"0\", \"1\"] == [\"ab0\", \"ab1\"]" $ vTrue
     shouldEvaluateTo "\"0\" |> Text.append \"a\" |> Text.append \"b\" == \"ba0\"" $ vTrue
     shouldEvaluateTo "\"hello world\"" $ VText "hello world"
     shouldEvaluateInEnvTo

--- a/inferno-core/test/Infer/Spec.hs
+++ b/inferno-core/test/Infer/Spec.hs
@@ -22,7 +22,7 @@ import qualified Inferno.Module.Prelude as Prelude
 import Inferno.Types.Syntax (ExtIdent (..), Ident (..))
 import Inferno.Types.Type (ImplType (..), InfernoType (..), TCScheme (..), TV (..), TypeClass (..), typeBool, typeDouble, typeInt, typeWord64)
 import Inferno.Types.VersionControl (vcHash)
-import Test.Hspec (Spec, describe, expectationFailure, it, shouldBe, shouldNotBe)
+import Test.Hspec (Spec, describe, expectationFailure, it, shouldBe, shouldNotBe, runIO)
 
 inferTests :: Spec
 inferTests = describe "infer" $
@@ -38,6 +38,22 @@ inferTests = describe "infer" $
     let ordTC ts = makeTCs "order" ts
     let repTC ts = makeTCs "rep" ts
     let makeType numTypeVars typeClassList t = ForallTC (map (\i -> TV {unTV = i}) [0 .. numTypeVars]) (Set.fromList typeClassList) (ImplType mempty t)
+
+    inferno <- runIO $ (mkInferno Prelude.builtinModules :: IO (Interpreter ()))
+    let shouldInferTypeFor str t =
+          it ("should infer type of \"" <> unpack str <> "\"") $
+            case parseAndInfer inferno str of
+              Left err -> expectationFailure $ show err
+              Right (_ast, t') -> t' `shouldBe` t
+
+    let shouldFailToInferTypeFor str =
+          it ("should fail to infer type of \"" <> unpack str <> "\"") $
+            case parseAndInfer inferno str of
+              Left (ParseError err) -> expectationFailure err
+              Left (PinError _err) -> pure ()
+              Left (InferenceError _err) -> pure ()
+              Right _ -> expectationFailure $ "Should fail to infer a type"
+
 
     shouldInferTypeFor "3" $
       makeType 0 [numTC [tv 0], repTC [tv 0]] (TVar $ TV {unTV = 0})
@@ -164,21 +180,6 @@ inferTests = describe "infer" $
   where
     t_hash = vcHash ("true" :: Ident, enumBoolHash)
     f_hash = vcHash ("false" :: Ident, enumBoolHash)
-    inferno = mkInferno Prelude.builtinModules :: Interpreter ()
-
-    shouldInferTypeFor str t =
-      it ("should infer type of \"" <> unpack str <> "\"") $
-        case parseAndInfer inferno str of
-          Left err -> expectationFailure $ show err
-          Right (_ast, t') -> t' `shouldBe` t
-
-    shouldFailToInferTypeFor str =
-      it ("should fail to infer type of \"" <> unpack str <> "\"") $
-        case parseAndInfer inferno str of
-          Left (ParseError err) -> expectationFailure err
-          Left (PinError _err) -> pure ()
-          Left (InferenceError _err) -> pure ()
-          Right _ -> expectationFailure $ "Should fail to infer a type"
 
     enum_sigs =
       Map.fromList


### PR DESCRIPTION
This PR adds some (long awaited) primitives to Inferno. :)

```ocaml
// Function composition with `<<`, `.` creates parsing issues
assert Array.map ((Text.append "a") << (Text.append "b")) ["0", "1"] == ["ab0", "ab1"] in
// Pipe operator `|>`
assert "0" |> Text.append "a" |> Text.append "b" == "ba0" in
// Some tuple stuff:
assert fst (1, 0) == snd (0, 1) in
assert zip [1, 2, 3] [4, 5] == [(1, 4), (2, 5)] in
assert zip [1, 2] ["a", "b"] == [(1,"a"),(2,"b")] in
assert zip [1] ["a", "b"] == [(1,"a")] in
assert zip [1, 2] ["a"] == [(1,"a")] in
assert zip [] [1, 2] == [] in
assert zip [1, 2] [] == [] in
0
```

While adding these, I noticed that the Eval tests were very slow because they were re-evaluating the prelude for each test. This PR also adds a new function `evalInEmptyEnv` that shares this computation and speeds up the tests by 3x. Before:

```
HSPEC_PRINT_SLOW_ITEMS=10 cabal test inferno-tests  --test-option=--match --test-option="evaluate" --test-show-details=direct
...
Finished in 16.6665 seconds
262 examples, 0 failures

Slow spec items:
  test/Eval/Spec.hs:375:7: /evaluate/"match [1.2, 3, 3] with { | [x, y, z] -> 2*x+3*y+z | _ -> 3 }" should evaluate to 14.4/ (80ms)
  test/Eval/Spec.hs:375:7: /evaluate/"(Array.reduce (fun x y -> x + max 0 y) 0 ((-3) .. 3)) == (Array.reduceRight (fun x y -> y + max 0 x) 0 ((-3) .. 3))" should evaluate to #true/ (80ms)
  test/Eval/Spec.hs:375:7: /evaluate/"open Time in let ?now = toTime (seconds 4000) in intervalEvery (seconds 4) ?now (?now + seconds 10)" should evaluate to [4000s,4004s,4008s]/ (79ms)
  test/Eval/Spec.hs:375:7: /evaluate/"open Time in let ?now = (toTime (weeks 66666)) in weeksBefore ?now 44 == ?now - (weeks 44)" should evaluate to #true/ (77ms)
  test/Eval/Spec.hs:375:7: /evaluate/"[x | x <- 1 .. 10]" should evaluate to [1,2,3,4,5,6,7,8,9,10]/ (75ms)
  test/Eval/Spec.hs:375:7: /evaluate/"open Time in let ?now = (toTime (hours 66666)) in hoursBefore ?now 44 == ?now - (hours 44)" should evaluate to #true/ (75ms)
  test/Eval/Spec.hs:375:7: /evaluate/"open Time in let ?now = (toTime (minutes 66666)) in minutesBefore ?now 44 == ?now - (minutes 44)" should evaluate to #true/ (75ms)
  test/Eval/Spec.hs:375:7: /evaluate/"Array.findFirstAndLastSome [None, Some 3.0, None, Some 4.0]" should evaluate to Some (3.0, 4.0)/ (75ms)
  test/Eval/Spec.hs:375:7: /evaluate/"open Time in let ?now = (toTime (seconds 66666)) in secondsBefore ?now 44 == ?now - (seconds 44)" should evaluate to #true/ (74ms)
  test/Eval/Spec.hs:375:7: /evaluate/"open Time in day (toTime (days 3 + hours 22)) == toTime (days 3)" should evaluate to #true/ (74ms)
Test suite inferno-tests: PASS
```
After:
```
HSPEC_PRINT_SLOW_ITEMS=10 cabal test inferno-tests  --test-option=--match --test-option="evaluate" --test-show-details=direct
...
Finished in 5.7441 seconds
271 examples, 0 failures

Slow spec items:
  test/Eval/Spec.hs:51:11: /evaluate/"?x + 2" should evaluate to 7.0/ (1058ms)
  test/Eval/Spec.hs:31:3: /evaluate/runtime type reps/test int type rep/ (1037ms)
  test/Eval/Spec.hs:51:11: /evaluate/"let f = fun x -> ?x + 2 in f 0" should evaluate to 7.0/ (1037ms)
  test/Eval/Spec.hs:36:3: /evaluate/runtime type reps/test double type rep/ (1017ms)
  test/Eval/Spec.hs:59:11: /evaluate/"Option.reduce (fun d -> d + 2) 0 (Some 4.0)" should evaluate to 6.0/ (61ms)
  test/Eval/Spec.hs:59:11: /evaluate/"Array.getOpt [0, 1, 2] (-9)" should evaluate to None/ (59ms)
  test/Eval/Spec.hs:59:11: /evaluate/"Array.average [0.0, 1.0]" should evaluate to 0.5/ (58ms)
  test/Eval/Spec.hs:59:11: /evaluate/"zip [1, 2] ["a", "b"] == [(1,"a"),(2,"b")]" should evaluate to #true/ (26ms)
  test/Eval/Spec.hs:59:11: /evaluate/"zip [1, 2, 3] [4, 5] == [(1, 4), (2, 5)]" should evaluate to #true/ (24ms)
  test/Eval/Spec.hs:59:11: /evaluate/"zip [1, 2] ["a"] == [(1,"a")]" should evaluate to #true/ (21ms)
Test suite inferno-tests: PASS
```

Note that the test `/evaluate/"?x + 2"` is taking much longer than before, this is because it uses a non-empty implicit env so cannot benefit from the `evaluateInEmptyEnv` speedup. We need to profile this execution and see why adding these primitives makes the prelude evaluation so much slower.