### PR TITLE
Revert "Add some primitives; speed up tests (#81)"

### DIFF
--- a/inferno-core/CHANGELOG.md
+++ b/inferno-core/CHANGELOG.md
@@ -1,9 +1,6 @@
 # Revision History for inferno-core
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
-## 0.5.1.0 -- 2023-09-19
-* Add function composition, pipe, fst, snd, and zip
-
 ## 0.5.0.0 -- 2023-09-18
 * Breaking change: new Interpreter API that pre-computes and shares prelude
 

--- a/inferno-core/inferno-core.cabal
+++ b/inferno-core/inferno-core.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                inferno-core
-version:             0.5.1.0
+version:             0.5.0.0
 synopsis:            A statically-typed functional scripting language
 description:         Parser, type inference, and interpreter for a statically-typed functional scripting language
 category:            DSL,Scripting

--- a/inferno-core/src/Inferno/Module/Prelude.hs
+++ b/inferno-core/src/Inferno/Module/Prelude.hs
@@ -114,7 +114,6 @@ import Inferno.Module.Prelude.Defs
     yearFun,
     yearsBeforeFun,
     zeroFun,
-    zipFun,
   )
 import Inferno.Parse (OpsTable)
 import Inferno.Types.Syntax (ModuleName, Scoped (..))
@@ -616,15 +615,6 @@ module Base
   infix 19 ..;
   infix 5 ?;
 
-  infixl 12 <<;
-  infixl 12 |>;
-
-  @doc Function composition. `(f << g) x == f (g x)`;
-  (<<) : forall 'a 'b 'c. ('b -> 'c) -> ('a -> 'b) -> 'a -> 'c := fun f g x -> f (g x);
-
-  @doc The pipe operator. `x |> f |> g == g (f x)`;
-  (|>) : forall 'a 'b 'c. 'a -> ('a -> 'b) -> 'b := fun x f -> f x;
-
   (..) := ###enumFromToInt64###;
 
   define order on int;
@@ -686,14 +676,5 @@ module Base
       | Some a -> a
       | None -> default
     };
-
-  @doc Gets the first component of a tuple: `fst (x, y) == x`;
-  fst : forall 'a 'b. ('a, 'b) -> 'a := fun t -> match t with { (x, y) -> x };
-
-  @doc Gets the second component of a tuple: `snd (x, y) == y`;
-  snd : forall 'a 'b. ('a, 'b) -> 'b := fun t -> match t with { (x, y) -> y };
-
-  @doc Zip two arrays into a array of tuples/pairs. If one input array is shorter than the other, excess elements of the longer array are discarded. `zip [1, 2] ['a', 'b'] == [(1,'a'),(2,'b')]`;
-  zip : forall 'a 'b. array of 'a -> array of 'b -> array of ('a, 'b) := ###!zipFun###;
 
 |]

--- a/inferno-core/src/Inferno/Module/Prelude/Defs.hs
+++ b/inferno-core/src/Inferno/Module/Prelude/Defs.hs
@@ -434,15 +434,6 @@ zeroFun = VFun $ \case
   VTypeRep ty -> throwM $ RuntimeError $ "zeroFun: unexpected runtimeRep " <> show ty
   _ -> throwM $ RuntimeError "zeroFun: expecting a runtimeRep"
 
-zipFun :: (MonadThrow m) => Value c m
-zipFun = VFun $ \case
-  VArray xs ->
-    return $ VFun $ \case
-      VArray ys ->
-        return $ VArray $ map (\(v1, v2) -> VTuple [v1, v2]) $ zip xs ys
-      _ -> throwM $ RuntimeError "zip: expecting an array"
-  _ -> throwM $ RuntimeError "zip: expecting an array"
-
 lengthFun :: (MonadThrow m) => Value c m
 lengthFun =
   VFun $ \case

--- a/inferno-core/test/Eval/Spec.hs
+++ b/inferno-core/test/Eval/Spec.hs
@@ -361,17 +361,7 @@ evalTests = describe "evaluate" $
     shouldEvaluateTo "match [1, 3] with { | [1, _] -> 2 | _ -> 3 }" $ VDouble 2
     shouldEvaluateTo "match [1.2, 3, 3] with { | [x, y, z] -> 2*x+3*y+z | _ -> 3 }" $ VDouble 14.4
     shouldEvaluateTo "(fun a -> match a with { | [x, y, z] -> truncateTo x 1.1 | _ -> 3 }) [1, 2, 3]" $ VDouble 1.1
-    -- Tuple
-    shouldEvaluateTo "fst (1, 0) == snd (0, 1)" $ vTrue
-    shouldEvaluateTo "zip [1, 2, 3] [4, 5] == [(1, 4), (2, 5)]" $ vTrue
-    shouldEvaluateTo "zip [1, 2] [\"a\", \"b\"] == [(1,\"a\"),(2,\"b\")]" $ vTrue
-    shouldEvaluateTo "zip [1] [\"a\", \"b\"] == [(1,\"a\")]" $ vTrue
-    shouldEvaluateTo "zip [1, 2] [\"a\"] == [(1,\"a\")]" $ vTrue
-    shouldEvaluateTo "zip [] [1, 2] == []" $ vTrue
-    shouldEvaluateTo "zip [1, 2] [] == []" $ vTrue
     -- Miscellaneous
-    shouldEvaluateTo "Array.map ((Text.append \"a\") << (Text.append \"b\")) [\"0\", \"1\"] == [\"ab0\", \"ab1\"]" $ vTrue
-    shouldEvaluateTo "\"0\" |> Text.append \"a\" |> Text.append \"b\" == \"ba0\"" $ vTrue
     shouldEvaluateTo "\"hello world\"" $ VText "hello world"
     shouldEvaluateInEnvTo
       (Map.fromList [(ExtIdent $ Right "x", VInt 5)])


### PR DESCRIPTION
This reverts commit a164c3e3c58b16f4e05037fbe1b360be9cf0a0d1 until we can figure out how to share the prelude evaluation in downstream users of Inferno.