### PR TITLE
Run Interpreter in custom monad `m`

### DIFF
--- a/inferno-core/CHANGELOG.md
+++ b/inferno-core/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Revision History for inferno-core
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.6.0.0 -- 2023-10-03
+* Breaking change: Interpreter API is parametric on monad to run in
+
 ## 0.5.0.1 -- 2023-09-25
 * Add NFData EvalError instance.
 

--- a/inferno-core/app/Main.hs
+++ b/inferno-core/app/Main.hs
@@ -17,7 +17,7 @@ main = do
   file <- head <$> getArgs
   src <- Text.readFile file
   Interpreter {evalExpr, defaultEnv, parseAndInferTypeReps} <-
-    mkInferno builtinModules :: IO (Interpreter ())
+    mkInferno builtinModules :: IO (Interpreter IO ())
   case parseAndInferTypeReps src of
     Left err -> do
       hPutStrLn stderr $ show err

--- a/inferno-core/inferno-core.cabal
+++ b/inferno-core/inferno-core.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                inferno-core
-version:             0.5.0.1
+version:             0.6.0.0
 synopsis:            A statically-typed functional scripting language
 description:         Parser, type inference, and interpreter for a statically-typed functional scripting language
 category:            DSL,Scripting
@@ -100,6 +100,7 @@ test-suite inferno-tests
   build-depends:
       base >=4.7 && <5
     , containers
+    , exceptions
     , hspec
     , hspec-golden-aeson
     , hspec-golden-cereal
@@ -107,6 +108,7 @@ test-suite inferno-tests
     , inferno-core
     , inferno-types
     , inferno-vc
+    , mtl
     , pretty-simple
     , QuickCheck
     , recursion-schemes

--- a/inferno-core/src/Inferno/Eval.hs
+++ b/inferno-core/src/Inferno/Eval.hs
@@ -3,7 +3,7 @@
 
 module Inferno.Eval where
 
-import Control.Monad.Catch (MonadThrow (throwM), try)
+import Control.Monad.Catch (MonadCatch, MonadThrow (throwM), try)
 import Control.Monad.Except (forM)
 import Control.Monad.Reader (ask, local)
 import Data.Foldable (foldrM)
@@ -263,14 +263,14 @@ eval env@(localEnv, pinnedEnv) expr = case expr of
 -- | Evaluate an expression with the provided environments.
 --   If an 'EvalError' exception is thrown during evaluation, it will be
 --   caught and a 'Left' result will be returned.
-runEvalIO ::
-  Pretty c =>
+runEvalM ::
+  (MonadThrow m, MonadCatch m, Pretty c) =>
   -- | Environment.
-  TermEnv VCObjectHash c (ImplEnvM IO c) ->
+  TermEnv VCObjectHash c (ImplEnvM m c) ->
   -- | Implicit environment.
-  Map.Map ExtIdent (Value c (ImplEnvM IO c)) ->
+  Map.Map ExtIdent (Value c (ImplEnvM m c)) ->
   -- | Expression to evaluate.
   Expr (Maybe VCObjectHash) a ->
-  IO (Either EvalError (Value c (ImplEnvM IO c)))
-runEvalIO env implicitEnv ex =
+  m (Either EvalError (Value c (ImplEnvM m c)))
+runEvalM env implicitEnv ex =
   try $ runImplEnvM implicitEnv $ eval env ex

--- a/inferno-core/test/Infer/Spec.hs
+++ b/inferno-core/test/Infer/Spec.hs
@@ -39,7 +39,7 @@ inferTests = describe "infer" $
     let repTC ts = makeTCs "rep" ts
     let makeType numTypeVars typeClassList t = ForallTC (map (\i -> TV {unTV = i}) [0 .. numTypeVars]) (Set.fromList typeClassList) (ImplType mempty t)
 
-    inferno <- runIO $ (mkInferno Prelude.builtinModules :: IO (Interpreter ()))
+    inferno <- runIO $ (mkInferno Prelude.builtinModules :: IO (Interpreter IO ()))
     let shouldInferTypeFor str t =
           it ("should infer type of \"" <> unpack str <> "\"") $
             case parseAndInfer inferno str of

--- a/inferno-lsp/CHANGELOG.md
+++ b/inferno-lsp/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Revision History for inferno-lsp
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.1.11 -- 2023-10-03
+* Update inferno-core version
+
 ## 0.1.10 -- 2023-09-18
 * Update inferno-core version
 

--- a/inferno-lsp/inferno-lsp.cabal
+++ b/inferno-lsp/inferno-lsp.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                inferno-lsp
-version:             0.1.10
+version:             0.1.11
 synopsis:            LSP for Inferno
 description:         A language server protocol implementation for the Inferno language
 category:            IDE,DSL,Scripting
@@ -33,7 +33,7 @@ library
     , co-log-core                        >= 0.3.1 && < 0.4
     , containers                         >= 0.6.2 && < 0.7
     , exceptions                         >= 0.10.4 && < 0.11
-    , inferno-core                       >= 0.3.0 && < 0.6
+    , inferno-core                       >= 0.3.0 && < 0.7
     , inferno-types                      >= 0.2.0 && < 0.3
     , inferno-vc                         >= 0.3.0 && < 0.4
     , lsp                                >= 1.6.0 && < 1.7

--- a/inferno-ml-remote/CHANGELOG.md
+++ b/inferno-ml-remote/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Revision History for inferno-ml-remote
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.1.2.0 -- 2023-10-03
+* Update to use new Interpreter API parametric on the monad
+
 ## 0.1.1.0 -- 2023-09-18
 * Update to use new Interpreter API that pre-computes and shares prelude
 

--- a/inferno-ml-remote/inferno-ml-remote.cabal
+++ b/inferno-ml-remote/inferno-ml-remote.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               inferno-ml-remote
-version:            0.1.1
+version:            0.1.2
 synopsis:           Server for Inferno ML
 description:        Server for Inferno ML
 homepage:           https://github.com/plow-technologies/inferno.git#readme

--- a/inferno-ml-remote/src/Inferno/ML/Remote/Handler.hs
+++ b/inferno-ml-remote/src/Inferno/ML/Remote/Handler.hs
@@ -45,7 +45,7 @@ import System.Directory
     setCurrentDirectory,
   )
 
-runInferenceHandler :: Interpreter MlValue -> Script -> InfernoMlRemoteM EvalResult
+runInferenceHandler :: Interpreter IO MlValue -> Script -> InfernoMlRemoteM EvalResult
 runInferenceHandler interpreter src = do
   ast <- liftEither500 $ mkFinalAst interpreter src
   cwd <- liftIO getCurrentDirectory
@@ -74,7 +74,7 @@ runInferenceHandler interpreter src = do
         $ runEval interpreter ast
   where
     runEval ::
-      Interpreter MlValue ->
+      Interpreter IO MlValue ->
       Expr (Maybe VCObjectHash) SourcePos ->
       InfernoMlRemoteM EvalResult
     runEval Interpreter {evalExpr, defaultEnv} ast =

--- a/inferno-ml-remote/src/Inferno/ML/Remote/Server.hs
+++ b/inferno-ml-remote/src/Inferno/ML/Remote/Server.hs
@@ -52,13 +52,13 @@ main = runServer =<< mkOptions
         mkEnv :: InfernoMlRemoteEnv
         mkEnv = InfernoMlRemoteEnv $ options ^. #modelCache
 
-infernoMlRemote :: Interpreter MlValue -> InfernoMlRemoteEnv -> Application
+infernoMlRemote :: Interpreter IO MlValue -> InfernoMlRemoteEnv -> Application
 infernoMlRemote interpreter env =
   serve api $ hoistServer api (`runReaderT` env) (server interpreter)
 
 api :: Proxy InfernoMlRemoteAPI
 api = Proxy
 
-server :: Interpreter MlValue -> ServerT InfernoMlRemoteAPI InfernoMlRemoteM
+server :: Interpreter IO MlValue -> ServerT InfernoMlRemoteAPI InfernoMlRemoteM
 server interpreter =
   runInferenceHandler interpreter

--- a/inferno-ml-remote/src/Inferno/ML/Remote/Utils.hs
+++ b/inferno-ml-remote/src/Inferno/ML/Remote/Utils.hs
@@ -61,7 +61,7 @@ import System.IO.Temp (createTempDirectory)
 import System.Process.Typed (proc, runProcess)
 
 mkFinalAst ::
-  Interpreter MlValue ->
+  Interpreter IO MlValue ->
   Script ->
   Either
     SomeInfernoError

--- a/inferno-ml-remote/test/Main.hs
+++ b/inferno-ml-remote/test/Main.hs
@@ -54,7 +54,7 @@ main = Hspec.hspec $ do
     collectModelsSpec interpreter *> cacheModelsSpec
 
 -- Tests `/inference` endpoint with various Inferno scripts with ML features
-inferenceSpec :: Interpreter MlValue -> Spec
+inferenceSpec :: Interpreter IO MlValue -> Spec
 inferenceSpec interpreter = do
   baseUrl <- Hspec.runIO $ parseBaseUrl "http://localhost"
   manager <- Hspec.runIO $ newManager defaultManagerSettings
@@ -90,7 +90,7 @@ inferenceSpec interpreter = do
     Hspec.describe "POST /inference (compressed)" $ do
       mkEvalTest "../inferno-ml/test/mnist.inferno" "()"
 
-collectModelsSpec :: Interpreter MlValue -> Spec
+collectModelsSpec :: Interpreter IO MlValue -> Spec
 collectModelsSpec interpreter = Hspec.describe "collectModelNames" $ do
   Hspec.it "extracts models from script" $ do
     mkAstTest "../inferno-ml/test/mnist.inferno" $
@@ -141,7 +141,7 @@ cacheModelsSpec =
         cacheAndUseModel "mnist.ts.pt" (mkCacheOption fp 10)
 
 withTestAppAndEnv ::
-  Interpreter MlValue -> (FilePath -> Word64 -> ModelCacheOption) -> (Int -> IO ()) -> IO ()
+  Interpreter IO MlValue -> (FilePath -> Word64 -> ModelCacheOption) -> (Int -> IO ()) -> IO ()
 withTestAppAndEnv interpreter g f =
   withTempDir $
     (`testApp` f)
@@ -162,7 +162,7 @@ mkCompressedCacheOption fp = CompressedPaths "./test" . ModelCache fp
 withTempDir :: (FilePath -> IO ()) -> IO ()
 withTempDir = withSystemTempDirectory "inferno-ml-remote-tests"
 
-withTestApp :: Interpreter MlValue -> InfernoMlRemoteEnv -> (Int -> IO ()) -> IO ()
+withTestApp :: Interpreter IO MlValue -> InfernoMlRemoteEnv -> (Int -> IO ()) -> IO ()
 withTestApp interpreter = testWithApplication . pure . infernoMlRemote interpreter
 
 readScript :: MonadIO m => FilePath -> m Script

--- a/inferno-ml/CHANGELOG.md
+++ b/inferno-ml/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Revision History for inferno-ml
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.1.2.0 -- 2023-10-03
+* Update to use new Interpreter API parametric on the monad
+
 ## 0.1.1.0 -- 2023-09-18
 * Update to use new Interpreter API that pre-computes and shares prelude
 

--- a/inferno-ml/app/Main.hs
+++ b/inferno-ml/app/Main.hs
@@ -16,7 +16,7 @@ main = do
   file <- head <$> getArgs
   src <- Text.readFile file
   Interpreter {evalExpr, defaultEnv, parseAndInferTypeReps} <-
-    mkInferno mlPrelude :: IO (Interpreter MlValue)
+    mkInferno mlPrelude :: IO (Interpreter IO MlValue)
   case parseAndInferTypeReps src of
     Left err -> print err
     Right ast ->

--- a/inferno-ml/inferno-ml.cabal
+++ b/inferno-ml/inferno-ml.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                inferno-ml
-version:             0.1.1
+version:             0.1.2
 synopsis:            Machine Learning primitives for Inferno
 description:         Machine Learning primitives for Inferno
 homepage:            https://github.com/plow-technologies/inferno.git#readme

--- a/inferno-ml/test/Spec.hs
+++ b/inferno-ml/test/Spec.hs
@@ -46,7 +46,7 @@ evalTests :: Spec
 evalTests = describe "evaluate" $
   do
     Interpreter {evalExpr, defaultEnv, parseAndInfer, parseAndInferTypeReps} <-
-      runIO $ (mkInferno mlPrelude :: IO (Interpreter MlValue))
+      runIO $ (mkInferno mlPrelude :: IO (Interpreter IO MlValue))
     let shouldEvaluateInEnvTo implEnv str (v :: Value MlValue IO) =
           it ("\"" <> unpack str <> "\" should evaluate to " <> (unpack $ renderPretty v)) $ do
             case parseAndInferTypeReps str of

--- a/inferno-types/CHANGELOG.md
+++ b/inferno-types/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Revision History for inferno-types
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.2.3.0 -- 2023-10-03
+* Add liftImplEnvM
+
 ## 0.2.2.0 -- 2023-09-20
 * Add NFData Value instance.
 

--- a/inferno-types/inferno-types.cabal
+++ b/inferno-types/inferno-types.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                inferno-types
-version:             0.2.2.0
+version:             0.2.3.0
 synopsis:            Core types for Inferno
 description:         Core types for the Inferno language
 category:            DSL,Scripting

--- a/inferno-types/src/Inferno/Types/Value.hs
+++ b/inferno-types/src/Inferno/Types/Value.hs
@@ -110,6 +110,9 @@ instance MonadCatch m => MonadCatch (ImplEnvM m c) where
   catch (ImplEnvM (ReaderT m)) c = ImplEnvM $ ReaderT $ \env ->
     m env `catch` \e -> runImplEnvM env (c e)
 
+liftImplEnvM :: Monad m => m a -> ImplEnvM m c a
+liftImplEnvM = ImplEnvM . lift
+
 runImplEnvM :: Map.Map ExtIdent (Value c (ImplEnvM m c)) -> ImplEnvM m c a -> m a
 runImplEnvM env = flip runReaderT env . unImplEnvM
 


### PR DESCRIPTION
This PR generalizes the `Interpreter` API to run in a user supplied monad `m` instead of `IO`. This can be used to run the interpreter in some context, see the `inferno-core/test/Eval/Spec.hs` test for an example.