### PR TITLE
Make some Array functions total by returning options

### DIFF
--- a/inferno-core/CHANGELOG.md
+++ b/inferno-core/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Revision History for inferno-core
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.7.0.0 -- 2023-10-09
+* Breaking change: Make some Array functions total by returning options
+
 ## 0.6.1.0 -- 2023-10-03
 * Add function composition, pipe, fst, snd, and zip
 

--- a/inferno-core/inferno-core.cabal
+++ b/inferno-core/inferno-core.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                inferno-core
-version:             0.6.1.0
+version:             0.7.0.0
 synopsis:            A statically-typed functional scripting language
 description:         Parser, type inference, and interpreter for a statically-typed functional scripting language
 category:            DSL,Scripting

--- a/inferno-core/src/Inferno/Module/Prelude.hs
+++ b/inferno-core/src/Inferno/Module/Prelude.hs
@@ -387,8 +387,8 @@ module Array
 
   length : forall 'a. array of 'a -> int := ###!lengthFun###;
 
-  @doc The minimum value in an array (or 0.0 for empty arrays);
-  minimum: forall 'a. array of 'a -> double := ###!minimumFun###;
+  @doc The minimum value in an array, or `None` if empty;
+  minimum: forall 'a. array of 'a -> option of double := ###!minimumFun###;
 
   @doc The maximum value in an array, or `None` if empty;
   maximum: forall 'a. array of 'a -> option of double := ###!maximumFun###;

--- a/inferno-core/src/Inferno/Module/Prelude.hs
+++ b/inferno-core/src/Inferno/Module/Prelude.hs
@@ -387,20 +387,20 @@ module Array
 
   length : forall 'a. array of 'a -> int := ###!lengthFun###;
 
-  @doc The minimum value in an array;
+  @doc The minimum value in an array (or 0.0 for empty arrays);
   minimum: forall 'a. array of 'a -> double := ###!minimumFun###;
 
-  @doc The maximum value in an array;
+  @doc The maximum value in an array, or `None` if empty;
   maximum: forall 'a. array of 'a -> option of double := ###!maximumFun###;
 
-  @doc The average of the values in an array;
-  average: forall 'a. array of 'a -> double := ###!averageFun###;
+  @doc The average of the values in an array, or `None` if empty;
+  average: forall 'a. array of 'a -> option of double := ###!averageFun###;
 
-  @doc The index of the minimum value in an array;
-  argmin: forall 'a. array of 'a -> int := ###!argminFun###;
+  @doc The index of the minimum value in an array, or `None` if empty;
+  argmin: forall 'a. array of 'a -> option of int := ###!argminFun###;
 
-  @doc The index of the maximum value in an array;
-  argmax: forall 'a. array of 'a -> int := ###!argmaxFun###;
+  @doc The index of the maximum value in an array, or `None` if empty;
+  argmax: forall 'a. array of 'a -> option of int := ###!argmaxFun###;
 
   @doc Returns the indices that would sort an array;
   argsort: forall 'a. array of 'a -> array of int := ###!argsortFun###;

--- a/inferno-core/src/Inferno/Module/Prelude.hs
+++ b/inferno-core/src/Inferno/Module/Prelude.hs
@@ -391,7 +391,7 @@ module Array
   minimum: forall 'a. array of 'a -> double := ###!minimumFun###;
 
   @doc The maximum value in an array;
-  maximum: forall 'a. array of 'a -> double := ###!maximumFun###;
+  maximum: forall 'a. array of 'a -> option of double := ###!maximumFun###;
 
   @doc The average of the values in an array;
   average: forall 'a. array of 'a -> double := ###!averageFun###;

--- a/inferno-core/src/Inferno/Module/Prelude/Defs.hs
+++ b/inferno-core/src/Inferno/Module/Prelude/Defs.hs
@@ -463,7 +463,7 @@ keepNumberValues =
 minimumFun :: (MonadThrow m) => Value c m
 minimumFun =
   VFun $ \case
-    VArray [] -> throwM $ RuntimeError "minimum: expecting a non-empty array"
+    VArray [] -> pure $ VDouble 0
     VArray xs -> return $ fst $ minimumBy (comparing snd) $ keepNumberValues xs
     _ -> throwM $ RuntimeError "minimum: expecting an array"
 
@@ -477,8 +477,8 @@ maximumFun =
 averageFun :: (MonadThrow m) => Value c m
 averageFun =
   VFun $ \case
-    VArray [] -> throwM $ RuntimeError "average: expecting a non-empty array"
-    VArray xs -> return $ VDouble $ sum (mapMaybe toDouble xs) / fromIntegral (length xs)
+    VArray [] -> pure VEmpty
+    VArray xs -> pure $ VOne $ VDouble $ sum (mapMaybe toDouble xs) / fromIntegral (length xs)
     _ -> throwM $ RuntimeError "average: expecting an array"
   where
     toDouble :: Value c m -> Maybe Double
@@ -490,7 +490,8 @@ averageFun =
 argminFun :: (MonadThrow m) => Value c m
 argminFun =
   VFun $ \case
-    VArray xs -> pure $ VInt $ fromIntegral $ argMin' $ map snd $ keepNumberValues xs
+    VArray [] -> pure VEmpty
+    VArray xs -> pure $ VOne $ VInt $ fromIntegral $ argMin' $ map snd $ keepNumberValues xs
     _ -> throwM $ RuntimeError "argmin: expecting an array"
   where
     argMin' :: [Double] -> Int
@@ -499,7 +500,8 @@ argminFun =
 argmaxFun :: (MonadThrow m) => Value c m
 argmaxFun =
   VFun $ \case
-    VArray xs -> pure $ VInt $ fromIntegral $ argMax' $ map snd $ keepNumberValues xs
+    VArray [] -> pure VEmpty
+    VArray xs -> pure $ VOne $ VInt $ fromIntegral $ argMax' $ map snd $ keepNumberValues xs
     _ -> throwM $ RuntimeError "argmax: expecting an array"
   where
     argMax' :: [Double] -> Int

--- a/inferno-core/src/Inferno/Module/Prelude/Defs.hs
+++ b/inferno-core/src/Inferno/Module/Prelude/Defs.hs
@@ -463,8 +463,8 @@ keepNumberValues =
 minimumFun :: (MonadThrow m) => Value c m
 minimumFun =
   VFun $ \case
-    VArray [] -> pure $ VDouble 0
-    VArray xs -> return $ fst $ minimumBy (comparing snd) $ keepNumberValues xs
+    VArray [] -> pure VEmpty
+    VArray xs -> pure $ VOne $ fst $ minimumBy (comparing snd) $ keepNumberValues xs
     _ -> throwM $ RuntimeError "minimum: expecting an array"
 
 maximumFun :: (MonadThrow m) => Value c m

--- a/inferno-core/src/Inferno/Module/Prelude/Defs.hs
+++ b/inferno-core/src/Inferno/Module/Prelude/Defs.hs
@@ -470,8 +470,8 @@ minimumFun =
 maximumFun :: (MonadThrow m) => Value c m
 maximumFun =
   VFun $ \case
-    VArray [] -> throwM $ RuntimeError "maximum: expecting a non-empty array"
-    VArray xs -> return $ fst $ maximumBy (comparing snd) $ keepNumberValues xs
+    VArray [] -> pure VEmpty
+    VArray xs -> pure $ VOne $ fst $ maximumBy (comparing snd) $ keepNumberValues xs
     _ -> throwM $ RuntimeError "maximum: expecting an array"
 
 averageFun :: (MonadThrow m) => Value c m

--- a/inferno-core/test/Eval/Spec.hs
+++ b/inferno-core/test/Eval/Spec.hs
@@ -244,10 +244,10 @@ evalTests = describe "evaluate" $
     shouldEvaluateTo "Array.length []" $ VInt 0
     shouldEvaluateTo "Array.length [3.0, 4.0]" $ VInt 2
     shouldEvaluateTo "Array.minimum [3.0, 4.0]" $ VDouble 3.0
-    shouldEvaluateTo "Array.maximum [3.0, 4.0]" $ VDouble 4.0
-    shouldEvaluateTo "Array.average [0.0, 1.0]" $ VDouble 0.5
-    shouldEvaluateTo "Array.argmin [3.0, 4.0]" $ VInt 0
-    shouldEvaluateTo "Array.argmax [3.0, 4.0]" $ VInt 1
+    shouldEvaluateTo "Array.maximum [3.0, 4.0] ? 999" $ VDouble 4.0
+    shouldEvaluateTo "Array.average [0.0, 1.0] ? 0" $ VDouble 0.5
+    shouldEvaluateTo "Array.argmin [3.0, 4.0] ? 1" $ VInt 0
+    shouldEvaluateTo "Array.argmax [3.0, 4.0] ? 0" $ VInt 1
     shouldEvaluateTo "Array.argsort [3.0, 1.0, 2.0]" $ VArray [VInt 1, VInt 2, VInt 0]
     shouldEvaluateTo "Array.magnitude [1.0, 2.0, 3.0]" $ VDouble (sqrt (1.0 + 4.0 + 9.0))
     shouldEvaluateTo "Array.norm [1.0, -2.0, 3.0]" $ VDouble (sqrt (1.0 + 4.0 + 9.0))

--- a/inferno-core/test/Eval/Spec.hs
+++ b/inferno-core/test/Eval/Spec.hs
@@ -243,7 +243,7 @@ evalTests = describe "evaluate" $
     shouldEvaluateTo "Array.singleton 3.14" $ VArray [VDouble 3.14]
     shouldEvaluateTo "Array.length []" $ VInt 0
     shouldEvaluateTo "Array.length [3.0, 4.0]" $ VInt 2
-    shouldEvaluateTo "Array.minimum [3.0, 4.0]" $ VDouble 3.0
+    shouldEvaluateTo "Array.minimum [3.0, 4.0] ? -999" $ VDouble 3.0
     shouldEvaluateTo "Array.maximum [3.0, 4.0] ? 999" $ VDouble 4.0
     shouldEvaluateTo "Array.average [0.0, 1.0] ? 0" $ VDouble 0.5
     shouldEvaluateTo "Array.argmin [3.0, 4.0] ? 1" $ VInt 0

--- a/inferno-lsp/CHANGELOG.md
+++ b/inferno-lsp/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Revision History for inferno-lsp
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.1.12 -- 2023-10-09
+* Update inferno-core version
+
 ## 0.1.11 -- 2023-10-03
 * Update inferno-core version
 

--- a/inferno-lsp/inferno-lsp.cabal
+++ b/inferno-lsp/inferno-lsp.cabal
@@ -33,7 +33,7 @@ library
     , co-log-core                        >= 0.3.1 && < 0.4
     , containers                         >= 0.6.2 && < 0.7
     , exceptions                         >= 0.10.4 && < 0.11
-    , inferno-core                       >= 0.3.0 && < 0.7
+    , inferno-core                       >= 0.3.0 && < 0.8
     , inferno-types                      >= 0.2.0 && < 0.3
     , inferno-vc                         >= 0.3.0 && < 0.4
     , lsp                                >= 1.6.0 && < 1.7


### PR DESCRIPTION
This PR makes the following Array functions total by returning `option` values instead of throwing runtime errors when the input array is empty:
`minimum, maximum, average, argmin, argmax`
