### PR TITLE
Defer evaluating prelude expr defs until runtime

### DIFF
--- a/inferno-core/CHANGELOG.md
+++ b/inferno-core/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Revision History for inferno-core
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.10.0.0 -- 2024-01-29
+* Modify `TermEnv` to defer evaluating prelude `Expr` definitions till runtime. Should reduce memory consumption
+
 ## 0.9.0.0 -- 2023-11-21
 * Breaking change: Fix Array primitive type signatures. Add Option.join
 

--- a/inferno-core/app/Main.hs
+++ b/inferno-core/app/Main.hs
@@ -22,7 +22,7 @@ main = do
     Left err -> do
       hPutStrLn stderr $ show err
       exitFailure
-    Right ast ->
+    Right ast -> do
       evalExpr defaultEnv Map.empty ast >>= \case
         Left err -> do
           hPutStrLn stderr $ show err

--- a/inferno-core/inferno-core.cabal
+++ b/inferno-core/inferno-core.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                inferno-core
-version:             0.9.0.0
+version:             0.10.0.0
 synopsis:            A statically-typed functional scripting language
 description:         Parser, type inference, and interpreter for a statically-typed functional scripting language
 category:            DSL,Scripting

--- a/inferno-core/src/Inferno/Core.hs
+++ b/inferno-core/src/Inferno/Core.hs
@@ -13,7 +13,7 @@ import Data.List.NonEmpty (NonEmpty)
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import Data.Text (Text)
-import Inferno.Eval (TermEnv, eval, runEvalM)
+import Inferno.Eval (TermEnv, runEvalM)
 import Inferno.Eval.Error (EvalError)
 import Inferno.Infer (TypeError, inferExpr, inferTypeReps)
 import Inferno.Infer.Error (Location)
@@ -130,11 +130,8 @@ mkInferno prelude customTypes = do
           foldM
             ( \env (hash, obj) -> case obj of
                 VCFunction expr _ -> do
-                  eval
-                    (localEnv, pinnedEnv')
-                    (bimap pinnedToMaybe id expr)
-                    >>= \val ->
-                      pure $ Map.insert hash (Right val) env
+                  let expr' = bimap pinnedToMaybe id expr
+                  pure $ Map.insert hash (Left expr') env
                 _ -> pure env
             )
             preludePinnedEnv

--- a/inferno-core/src/Inferno/Core.hs
+++ b/inferno-core/src/Inferno/Core.hs
@@ -24,7 +24,7 @@ import Inferno.Module.Prelude (ModuleMap, baseOpsTable, builtinModulesOpsTable, 
 import Inferno.Parse (InfernoParsingError, parseExpr)
 import Inferno.Types.Syntax (Comment, CustomType, Expr (App, TypeRep), ExtIdent, ModuleName, Namespace, SourcePos, TypeClass, TypeMetadata, collectArrs)
 import Inferno.Types.Type (ImplType (ImplType), TCScheme (ForallTC))
-import Inferno.Types.Value (ImplEnvM, Value, runImplEnvM)
+import Inferno.Types.Value (ImplEnvM, Value)
 import Inferno.Types.VersionControl (Pinned, VCObjectHash, pinnedToMaybe)
 import Inferno.VersionControl.Types (VCObject (VCFunction))
 import Prettyprinter (Pretty)
@@ -75,7 +75,7 @@ mkInferno :: forall m c. (MonadThrow m, MonadCatch m, MonadFix m, Eq c, Pretty c
 mkInferno prelude customTypes = do
   -- We pre-compute envs that only depend on the prelude so that they can be
   -- shared among evaluations of different scripts
-  (preludeIdentEnv, preludePinnedEnv) <- runImplEnvM Map.empty $ builtinModulesTerms prelude
+  let (preludeIdentEnv, preludePinnedEnv) = builtinModulesTerms prelude
   return $
     Interpreter
       { evalExpr = runEvalM,

--- a/inferno-core/src/Inferno/Module.hs
+++ b/inferno-core/src/Inferno/Module.hs
@@ -127,10 +127,11 @@ buildPinnedQQModules modules =
                   hsh' = vcHash $ BuiltinFunHash (sigVarToExpr LocalScope name, sig)
                   finalExpr = (bimap pinnedToMaybe (const ()) pinnedExpr')
                in case mSig of
-                Just sig'' | sig' /= sig'' ->
-                  error $ "Type of " <> show name <> " does not matched inferred type " <> show sig'
-                _ ->
-                  (sig', ns', hsh', (\(local, pinned) -> (local, Map.insert hsh (Left finalExpr) pinned)) <$> mTrmEnv)
+                    Just sig''
+                      | sig' /= sig'' ->
+                          error $ "Type of " <> show name <> " does not matched inferred type " <> show sig'
+                    _ ->
+                      (sig', ns', hsh', (\(local, pinned) -> (local, Map.insert hsh (Left finalExpr) pinned)) <$> mTrmEnv)
        in buildModule alreadyPinnedModulesMap alreadyBuiltModules xs $
             m
               { moduleObjects =

--- a/inferno-core/src/Inferno/Module/Cast.hs
+++ b/inferno-core/src/Inferno/Module/Cast.hs
@@ -35,11 +35,11 @@ type Either6 a b c d e f = Either a (Either5 b c d e f)
 
 type Either7 a b c d e f g = Either a (Either6 b c d e f g)
 
--- | Types that can be converted to script values, allowing IO in the process.
+-- | Types that can be converted to script values.
 class ToValue c m a where
-  toValue :: MonadThrow m => a -> m (Value c m)
+  toValue :: a -> Value c m
 
--- | Class of types that can be converted from script values.
+-- | Class of types that can be converted from script values, allowing IO in the process.
 class FromValue c m a where
   fromValue :: MonadThrow m => (Value c m) -> m a
 
@@ -58,25 +58,26 @@ couldNotCast v =
         <> " to "
         <> (show $ typeRep (Proxy :: Proxy a))
 
-instance ToValue c m (m (Value c m)) where
-  toValue = id
+-- TODO not possible anymore
+-- instance ToValue c m (m (Value c m)) where
+--   toValue = pure
 
 instance ToValue c m (Value c m) where
-  toValue = pure
+  toValue = id
 
 instance FromValue c m (Value c m) where
   fromValue = pure
 
 instance ToValue c m Lit where
-  toValue l = pure $ case l of
+  toValue l = case l of
     LInt i -> VInt i
     LDouble x -> VDouble x
     LText t -> VText t
     LHex w -> VWord64 w
 
 instance ToValue c m Bool where
-  toValue True = pure $ VEnum enumBoolHash "true"
-  toValue False = pure $ VEnum enumBoolHash "false"
+  toValue True = VEnum enumBoolHash "true"
+  toValue False = VEnum enumBoolHash "false"
 
 instance Pretty c => FromValue c m Bool where
   fromValue (VEnum hash ident) =
@@ -89,7 +90,7 @@ instance Pretty c => FromValue c m Bool where
   fromValue v = couldNotCast v
 
 instance ToValue c m Double where
-  toValue = pure . VDouble
+  toValue = VDouble
 
 instance Pretty c => FromValue c m Double where
   fromValue (VDouble x) = pure x
@@ -97,7 +98,7 @@ instance Pretty c => FromValue c m Double where
   fromValue v = couldNotCast v
 
 instance ToValue c m Int64 where
-  toValue = pure . VInt
+  toValue = VInt
 
 instance Pretty c => FromValue c m Int64 where
   fromValue (VInt x) = pure x
@@ -114,49 +115,49 @@ instance (Pretty c) => FromValue c m Int where
   fromValue v = couldNotCast v
 
 instance ToValue c m Integer where
-  toValue = pure . VInt . fromInteger
+  toValue = VInt . fromInteger
 
 instance Pretty c => FromValue c m Integer where
   fromValue (VInt x) = pure $ fromIntegral x
   fromValue v = couldNotCast v
 
 instance ToValue c m Word16 where
-  toValue = pure . VWord16
+  toValue = VWord16
 
 instance Pretty c => FromValue c m Word16 where
   fromValue (VWord16 w) = pure w
   fromValue v = couldNotCast v
 
 instance ToValue c m Word32 where
-  toValue = pure . VWord32
+  toValue = VWord32
 
 instance Pretty c => FromValue c m Word32 where
   fromValue (VWord32 w) = pure w
   fromValue v = couldNotCast v
 
 instance ToValue c m Word64 where
-  toValue = pure . VWord64
+  toValue = VWord64
 
 instance Pretty c => FromValue c m Word64 where
   fromValue (VWord64 w) = pure w
   fromValue v = couldNotCast v
 
 instance ToValue c m () where
-  toValue _ = pure $ VTuple []
+  toValue _ = VTuple []
 
 instance Pretty c => FromValue c m () where
   fromValue (VTuple []) = pure ()
   fromValue v = couldNotCast v
 
 instance ToValue c m CTime where
-  toValue = pure . VEpochTime
+  toValue = VEpochTime
 
 instance Pretty c => FromValue c m CTime where
   fromValue (VEpochTime t) = pure t
   fromValue v = couldNotCast v
 
 instance ToValue c m Text where
-  toValue = pure . VText
+  toValue = VText
 
 instance Pretty c => FromValue c m Text where
   fromValue (VText t) = pure t
@@ -204,14 +205,14 @@ instance (Kind0 a, Kind0 b) => Kind0 (a -> b) where
 instance (Kind0 a) => Kind0 [a] where
   toType _ = TArray (toType (Proxy :: Proxy a))
 
-instance (FromValue c m a, ToValue c m b) => ToValue c m (a -> b) where
-  toValue f = pure $
+instance (MonadThrow m, FromValue c m a, ToValue c m b) => ToValue c m (a -> b) where
+  toValue f =
     VFun $ \v -> do
       x <- fromValue v
-      toValue $ f x
+      pure $ toValue $ f x
 
-instance (Monad m, FromValue c (ImplEnvM m c) a1, FromValue c (ImplEnvM m c) a2, ToValue c (ImplEnvM m c) a3, KnownSymbol lbl) => ToValue c (ImplEnvM m c) (ImplicitCast lbl a1 a2 a3) where
-  toValue (ImplicitCast f) = pure $
+instance (MonadThrow m, FromValue c (ImplEnvM m c) a1, FromValue c (ImplEnvM m c) a2, ToValue c (ImplEnvM m c) a3, KnownSymbol lbl) => ToValue c (ImplEnvM m c) (ImplicitCast lbl a1 a2 a3) where
+  toValue (ImplicitCast f) =
     VFun $ \b' -> do
       impl <- ask
       let i = ExtIdent $ Right $ pack $ symbolVal (Proxy :: Proxy lbl)
@@ -219,7 +220,7 @@ instance (Monad m, FromValue c (ImplEnvM m c) a1, FromValue c (ImplEnvM m c) a2,
         Just v -> do
           x <- fromValue v
           b <- fromValue b'
-          toValue $ f x b
+          pure $ toValue $ f x b
         Nothing -> throwM $ NotFoundInImplicitEnv i
 
 -- | In this instance, the 'IO' in the type is ignored.
@@ -227,8 +228,8 @@ instance Kind0 a => Kind0 (IO a) where
   toType _ = toType (Proxy :: Proxy a)
 
 instance ToValue c m a => ToValue c m (Maybe a) where
-  toValue (Just x) = VOne <$> toValue x
-  toValue _ = pure VEmpty
+  toValue (Just x) = VOne $ toValue x
+  toValue _ = VEmpty
 
 instance (Typeable a, FromValue c m a, Pretty c) => FromValue c m (Maybe a) where
   fromValue VEmpty = pure Nothing
@@ -243,7 +244,7 @@ instance (ToValue c m a, ToValue c m b) => ToValue c m (Either a b) where
   toValue (Right x) = toValue x
 
 instance ToValue c m a => ToValue c m [a] where
-  toValue xs = VArray <$> (mapM toValue xs)
+  toValue xs = VArray $ map toValue xs
 
 instance (Typeable a, FromValue c m a, Pretty c) => FromValue c m [a] where
   fromValue (VArray vs) = mapM fromValue vs

--- a/inferno-core/src/Inferno/Module/Prelude.hs
+++ b/inferno-core/src/Inferno/Module/Prelude.hs
@@ -125,7 +125,7 @@ import Inferno.Types.VersionControl (Pinned (..), VCObjectHash)
 import Inferno.Utils.QQ.Module (infernoModules)
 import Prettyprinter (Pretty)
 
-type ModuleMap m c = Map.Map ModuleName (PinnedModule (ImplEnvM m c (TermEnv VCObjectHash c (ImplEnvM m c))))
+type ModuleMap m c = Map.Map ModuleName (PinnedModule (ImplEnvM m c (TermEnv VCObjectHash c (ImplEnvM m c) ())))
 
 baseOpsTable :: forall m c. (MonadThrow m, Pretty c, Eq c) => ModuleMap m c -> OpsTable
 baseOpsTable moduleMap =
@@ -142,7 +142,7 @@ builtinModulesPinMap moduleMap =
       Map.foldrWithKey Pinned.insertHardcodedModule mempty $
         Map.map (Map.map Builtin . pinnedModuleNameToHash) moduleMap
 
-builtinModulesTerms :: forall m c. (MonadThrow m, Pretty c, Eq c) => ModuleMap m c -> ImplEnvM m c (TermEnv VCObjectHash c (ImplEnvM m c))
+builtinModulesTerms :: forall m c. (MonadThrow m, Pretty c, Eq c) => ModuleMap m c -> ImplEnvM m c (TermEnv VCObjectHash c (ImplEnvM m c) ())
 builtinModulesTerms = combineTermEnvs
 
 preludeNameToTypeMap :: forall m c. (MonadThrow m, Pretty c, Eq c) => ModuleMap m c -> Map.Map (Maybe ModuleName, Namespace) (TypeMetadata TCScheme)

--- a/inferno-core/src/Inferno/Module/Prelude.hs
+++ b/inferno-core/src/Inferno/Module/Prelude.hs
@@ -125,7 +125,7 @@ import Inferno.Types.VersionControl (Pinned (..), VCObjectHash)
 import Inferno.Utils.QQ.Module (infernoModules)
 import Prettyprinter (Pretty)
 
-type ModuleMap m c = Map.Map ModuleName (PinnedModule (ImplEnvM m c (TermEnv VCObjectHash c (ImplEnvM m c) ())))
+type ModuleMap m c = Map.Map ModuleName (PinnedModule (TermEnv VCObjectHash c (ImplEnvM m c) ()))
 
 baseOpsTable :: forall m c. (MonadThrow m, Pretty c, Eq c) => ModuleMap m c -> OpsTable
 baseOpsTable moduleMap =
@@ -142,7 +142,7 @@ builtinModulesPinMap moduleMap =
       Map.foldrWithKey Pinned.insertHardcodedModule mempty $
         Map.map (Map.map Builtin . pinnedModuleNameToHash) moduleMap
 
-builtinModulesTerms :: forall m c. (MonadThrow m, Pretty c, Eq c) => ModuleMap m c -> ImplEnvM m c (TermEnv VCObjectHash c (ImplEnvM m c) ())
+builtinModulesTerms :: forall m c. (MonadThrow m, Pretty c, Eq c) => ModuleMap m c -> TermEnv VCObjectHash c (ImplEnvM m c) ()
 builtinModulesTerms = combineTermEnvs
 
 preludeNameToTypeMap :: forall m c. (MonadThrow m, Pretty c, Eq c) => ModuleMap m c -> Map.Map (Maybe ModuleName, Namespace) (TypeMetadata TCScheme)

--- a/inferno-core/src/Inferno/Utils/QQ/Module.hs
+++ b/inferno-core/src/Inferno/Utils/QQ/Module.hs
@@ -44,7 +44,7 @@ metaToValue = \case
   (Just sch, QQToValueDef x) -> Just [|Left ($(dataToExpQ (\a -> liftText <$> cast a) sch), toValue $(TH.varE (mkName x)))|]
   (Nothing, QQToValueDef x) ->
     Just [|Left (closeOverType (toType (mkProxy $(TH.varE (mkName x)))), toValue $(TH.varE (mkName x)))|]
-  (Just sch, QQRawDef x) -> Just [|Left ($(dataToExpQ (\a -> liftText <$> cast a) sch), pure $(TH.varE (mkName x)))|]
+  (Just sch, QQRawDef x) -> Just [|Left ($(dataToExpQ (\a -> liftText <$> cast a) sch), $(TH.varE (mkName x)))|]
   (Nothing, QQRawDef _) -> error "QQRawDef must have an explicit type"
   (sch, InlineDef e) ->
     Just [|Right ($(dataToExpQ (\a -> liftText <$> cast a) sch), $(dataToExpQ (\a -> liftText <$> cast a) e))|]

--- a/inferno-lsp/CHANGELOG.md
+++ b/inferno-lsp/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Revision History for inferno-lsp
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.2.2.0 -- 2024-01-29
+* Update inferno-core version
+
 ## 0.2.1.0 -- 2023-11-01
 * Update inferno-types version
 

--- a/inferno-lsp/inferno-lsp.cabal
+++ b/inferno-lsp/inferno-lsp.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                inferno-lsp
-version:             0.2.1.0
+version:             0.2.2.0
 synopsis:            LSP for Inferno
 description:         A language server protocol implementation for the Inferno language
 category:            IDE,DSL,Scripting
@@ -32,7 +32,7 @@ library
     , bytestring                         >= 0.10.10 && < 0.12
     , co-log-core                        >= 0.3.1 && < 0.4
     , containers                         >= 0.6.2 && < 0.7
-    , inferno-core                       >= 0.8.0 && < 0.10
+    , inferno-core                       >= 0.8.0 && < 0.11
     , inferno-types                      >= 0.2.0 && < 0.4
     , inferno-vc                         >= 0.3.0 && < 0.4
     , lsp                                >= 1.6.0 && < 1.7

--- a/inferno-ml/CHANGELOG.md
+++ b/inferno-ml/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Revision History for inferno-ml
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.1.2.2 -- 2024-01-29
+* Update to use changed TermEnv type
+
 ## 0.1.2.1 -- 2023-10-24
 * Update to use changed Interpreter API type
 

--- a/inferno-ml/CHANGELOG.md
+++ b/inferno-ml/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Revision History for inferno-ml
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
-## 0.1.2.2 -- 2024-01-29
-* Update to use changed TermEnv type
+## 0.2.0.0 -- 2024-01-29
+* Update inferno-core version and types of prelude and ToValue
 
 ## 0.1.2.1 -- 2023-10-24
 * Update to use changed Interpreter API type

--- a/inferno-ml/inferno-ml.cabal
+++ b/inferno-ml/inferno-ml.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                inferno-ml
-version:             0.1.2.1
+version:             0.1.2.2
 synopsis:            Machine Learning primitives for Inferno
 description:         Machine Learning primitives for Inferno
 homepage:            https://github.com/plow-technologies/inferno.git#readme

--- a/inferno-ml/inferno-ml.cabal
+++ b/inferno-ml/inferno-ml.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                inferno-ml
-version:             0.1.2.2
+version:             0.2.0.0
 synopsis:            Machine Learning primitives for Inferno
 description:         Machine Learning primitives for Inferno
 homepage:            https://github.com/plow-technologies/inferno.git#readme

--- a/inferno-ml/src/Inferno/ML/Module/Prelude.hs
+++ b/inferno-ml/src/Inferno/ML/Module/Prelude.hs
@@ -209,7 +209,7 @@ module ML
 
 |]
 
-mlPrelude :: Map.Map ModuleName (PinnedModule (ImplEnvM IO MlValue (Eval.TermEnv VCObjectHash MlValue (ImplEnvM IO MlValue))))
+mlPrelude :: Map.Map ModuleName (PinnedModule (ImplEnvM IO MlValue (Eval.TermEnv VCObjectHash MlValue (ImplEnvM IO MlValue) ())))
 mlPrelude =
   Map.unionWith
     (error "Duplicate module name in builtinModules")

--- a/inferno-ml/src/Inferno/ML/Types/Value.hs
+++ b/inferno-ml/src/Inferno/ML/Types/Value.hs
@@ -23,14 +23,14 @@ instance Pretty MlValue where
     VModel m -> align (pretty $ Text.pack $ show m)
 
 instance ToValue MlValue m T.Tensor where
-  toValue = pure . VCustom . VTensor
+  toValue = VCustom . VTensor
 
 instance FromValue MlValue m T.Tensor where
   fromValue (VCustom (VTensor t)) = pure t
   fromValue v = couldNotCast v
 
 instance ToValue MlValue m T.ScriptModule where
-  toValue = pure . VCustom . VModel
+  toValue = VCustom . VModel
 
 instance FromValue MlValue m T.ScriptModule where
   fromValue (VCustom (VModel t)) = pure t


### PR DESCRIPTION
This PR aims to reduce the memory consumption of inferno, by storing prelude functions that are defined as inferno `Expr`s as `Expr`s in the prelude and not evaluating the expressions until runtime. You can think of this as though we're inlining any such primitives to the script.

Because of this, prelude evaluation no longer needs to be within the `ImplEnvM` monad, so that has been removed as well. This has meant we changed the type of `toValue` to no longer be under a monad too.

This should reduce the memory consumption significantly, but might increase runtime slightly. I don't expect the increase to be too much because most primitive definitions are functions, so they can't be fully evaluated at compile time anyway, which is why they were being stored in memory as huge thunks.