### PR TITLE
HLint everything and add to CI

### DIFF
--- a/.github/hlint.json
+++ b/.github/hlint.json
@@ -1,0 +1,19 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "hlint",
+      "pattern": [
+        {
+          "regexp": "^hlint\\t(?<file>[^\\t]*)\\t(?<fromPath>[^\\t]*)\\t(?<line>[^\\t]*)\\t(?<column>[^\\t]*)\\t(?<severity>[^\\t]*)\\t(?<code>[^\\t]*)\\t(?<message>[^\\t]*)$",
+          "file": 1,
+          "fromPath": 2,
+          "line": 3,
+          "column": 4,
+          "severity": 5,
+          "code": 6,
+          "message": 7
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       MNIST_FNAME: /tmp/mnist/mnist.ts.pt
       MNIST_COMMIT: 94b288a631362aa44edc219eb8f54a7c39891169
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # Lint code with HLint
       - name: Set up HLint
@@ -30,7 +30,7 @@ jobs:
         uses: haskell-actions/hlint-run@v2
         with:
           path: '["inferno-core/", "inferno-lsp/", "inferno-ml/", "inferno-ml-server-types/", "inferno-types/", "inferno-vc/"]'
-          fail-on: warning
+          fail-on: error
 
       - uses: cachix/install-nix-action@v18
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Run HLint
         uses: haskell-actions/hlint-run@v2
         with:
-          path: src/
+          path: '["inferno-core/", "inferno-lsp/", "inferno-ml/", "inferno-ml-server-types/", "inferno-types/", "inferno-vc/"]'
           fail-on: warning
 
       - uses: cachix/install-nix-action@v18

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,18 @@ jobs:
       MNIST_COMMIT: 94b288a631362aa44edc219eb8f54a7c39891169
     steps:
       - uses: actions/checkout@v3
+
+      # Lint code with HLint
+      - name: Set up HLint
+        uses: haskell-actions/hlint-setup@v2
+        with:
+          version: "3.8"
+      - name: Run HLint
+        uses: haskell-actions/hlint-run@v2
+        with:
+          path: src/
+          fail-on: warning
+
       - uses: cachix/install-nix-action@v18
         with:
           install_url: https://releases.nixos.org/nix/nix-2.13.3/install
@@ -32,6 +44,8 @@ jobs:
           name: inferno
           authToken: "${{ secrets.CACHIX_TOKEN }}"
       - uses: DeterminateSystems/magic-nix-cache-action@main
+
+      # Build inferno and run all tests
       - run: |
           nix build -L .#
 

--- a/inferno-core/CHANGELOG.md
+++ b/inferno-core/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Revision History for inferno-core
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.11.1.0 -- 2024-03-18
+* HLint everything
+
 ## 0.11.0.0 -- 2024-03-12
 * Add records to the Inferno language
 

--- a/inferno-core/inferno-core.cabal
+++ b/inferno-core/inferno-core.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                inferno-core
-version:             0.11.0.0
+version:             0.11.1.0
 synopsis:            A statically-typed functional scripting language
 description:         Parser, type inference, and interpreter for a statically-typed functional scripting language
 category:            DSL,Scripting

--- a/inferno-core/src/Inferno/Core.hs
+++ b/inferno-core/src/Inferno/Core.hs
@@ -1,14 +1,13 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecursiveDo #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 
 module Inferno.Core where
 
 import Control.Monad (foldM)
 import Control.Monad.Catch (MonadCatch, MonadThrow)
 import Control.Monad.Except (MonadFix)
-import Data.Bifunctor (bimap)
+import Data.Bifunctor (bimap, first)
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.Map as Map
 import qualified Data.Set as Set
@@ -130,7 +129,7 @@ mkInferno prelude customTypes = do
           foldM
             ( \env (hash, obj) -> case obj of
                 VCFunction expr _ -> do
-                  let expr' = bimap pinnedToMaybe id expr
+                  let expr' = first pinnedToMaybe expr
                   pure $ Map.insert hash (Left expr') env
                 _ -> pure env
             )

--- a/inferno-core/src/Inferno/Eval.hs
+++ b/inferno-core/src/Inferno/Eval.hs
@@ -7,6 +7,7 @@ import Control.Monad.Catch (MonadCatch, MonadThrow (throwM), try)
 import Control.Monad.Except (forM)
 import Control.Monad.Reader (ask, local)
 import Data.Foldable (foldrM)
+import Data.Functor ((<&>))
 import Data.List.NonEmpty (NonEmpty (..), toList)
 import qualified Data.Map as Map
 import Data.Maybe (catMaybes)
@@ -67,7 +68,7 @@ eval env@(localEnv, pinnedEnv) expr = case expr of
       toText (VText t) = t
       toText e = renderStrict $ layoutPretty (LayoutOptions Unbounded) $ pretty e
   Array_ es ->
-    foldrM (\(e, _) vs -> eval env e >>= return . (: vs)) [] es >>= return . VArray
+    foldrM (\(e, _) vs -> eval env e <&> (: vs)) [] es <&> VArray
   ArrayComp_ e srcs mCond -> do
     vals <- sequence' env srcs
     VArray <$> case mCond of
@@ -76,19 +77,21 @@ eval env@(localEnv, pinnedEnv) expr = case expr of
           let nenv = foldr (uncurry Map.insert) localEnv vs in eval (nenv, pinnedEnv) e
       Just (_, cond) ->
         catMaybes
-          <$> ( forM vals $ \vs -> do
-                  let nenv = foldr (uncurry Map.insert) localEnv vs
-                  eval (nenv, pinnedEnv) cond >>= \case
-                    VEnum hash "true" ->
-                      if hash == enumBoolHash
-                        then Just <$> (eval (nenv, pinnedEnv) e)
-                        else throwM $ RuntimeError "failed to match with a bool"
-                    VEnum hash "false" ->
-                      if hash == enumBoolHash
-                        then return Nothing
-                        else throwM $ RuntimeError "failed to match with a bool"
-                    _ -> throwM $ RuntimeError "failed to match with a bool"
-              )
+          <$> forM
+            vals
+            ( \vs -> do
+                let nenv = foldr (uncurry Map.insert) localEnv vs
+                eval (nenv, pinnedEnv) cond >>= \case
+                  VEnum hash "true" ->
+                    if hash == enumBoolHash
+                      then Just <$> eval (nenv, pinnedEnv) e
+                      else throwM $ RuntimeError "failed to match with a bool"
+                  VEnum hash "false" ->
+                    if hash == enumBoolHash
+                      then return Nothing
+                      else throwM $ RuntimeError "failed to match with a bool"
+                  _ -> throwM $ RuntimeError "failed to match with a bool"
+            )
     where
       sequence' :: (MonadThrow m, Pretty c) => TermEnv VCObjectHash c (ImplEnvM m c) a -> NonEmpty (a, Ident, a, Expr (Maybe VCObjectHash) a, Maybe a) -> ImplEnvM m c [[(ExtIdent, Value c (ImplEnvM m c))]]
       sequence' env'@(localEnv', pinnedEnv') = \case
@@ -100,10 +103,12 @@ eval env@(localEnv, pinnedEnv) expr = case expr of
           eval env' e_s >>= \case
             VArray vals ->
               concat
-                <$> ( forM vals $ \v -> do
-                        res <- sequence' (Map.insert (ExtIdent $ Right x) v localEnv', pinnedEnv') (r :| rs)
-                        return $ map ((ExtIdent $ Right x, v) :) res
-                    )
+                <$> forM
+                  vals
+                  ( \v -> do
+                      res <- sequence' (Map.insert (ExtIdent $ Right x) v localEnv', pinnedEnv') (r :| rs)
+                      return $ map ((ExtIdent $ Right x, v) :) res
+                  )
             _ -> throwM $ RuntimeError "failed to match with an array"
   Enum_ (Just hash) _ i -> return $ VEnum hash i
   Enum_ Nothing _ _ -> throwM $ RuntimeError "All enums must be pinned"
@@ -162,7 +167,7 @@ eval env@(localEnv, pinnedEnv) expr = case expr of
         (_, Just x) : xs ->
           return $ VFun $ \arg -> go (Map.insert x arg nenv) xs
         (_, Nothing) : xs -> return $ VFun $ \_arg -> go nenv xs
-  App_ fun arg -> do
+  App_ fun arg ->
     eval env fun >>= \case
       VFun f -> do
         argv <- eval env arg
@@ -178,7 +183,7 @@ eval env@(localEnv, pinnedEnv) expr = case expr of
     eval (nenv, pinnedEnv) body
   Let_ (Impl x) e body -> do
     e' <- eval env e
-    local (\impEnv -> Map.insert x e' impEnv) $ eval env body
+    local (Map.insert x e') $ eval env body
   If_ cond tr fl ->
     eval env cond >>= \case
       VEnum hash "true" ->
@@ -191,7 +196,7 @@ eval env@(localEnv, pinnedEnv) expr = case expr of
           else throwM $ RuntimeError "failed to match with a bool"
       _ -> throwM $ RuntimeError "failed to match with a bool"
   Tuple_ es ->
-    foldrM (\(e, _) vs -> eval env e >>= return . (: vs)) [] (tListToList es) >>= return . VTuple
+    foldrM (\(e, _) vs -> eval env e <&> (: vs)) [] (tListToList es) <&> VTuple
   Record_ fs -> do
     valMap <- foldrM (\(f, e, _) vs -> eval env e >>= \v -> return ((f, v) : vs)) [] fs
     return $ VRecord $ Map.fromList valMap
@@ -203,8 +208,8 @@ eval env@(localEnv, pinnedEnv) expr = case expr of
           Nothing -> throwM $ RuntimeError "record field not found"
       Just _ -> throwM $ RuntimeError "failed to match with a record"
       Nothing -> throwM $ RuntimeError $ show (ExtIdent $ Right r) <> " not found in the unpinned env"
-  One_ e -> eval env e >>= return . VOne
-  Empty_ -> return $ VEmpty
+  One_ e -> eval env e <&> VOne
+  Empty_ -> return VEmpty
   Assert_ cond e ->
     eval env cond >>= \case
       VEnum hash "false" ->
@@ -224,13 +229,13 @@ eval env@(localEnv, pinnedEnv) expr = case expr of
         Just nenv ->
           -- (<>) is left biased so this will correctly override any shadowed vars from nenv onto env
           eval (nenv <> env) body
-        Nothing -> throwM $ RuntimeError $ "non-exhaustive patterns in case detected in " <> (Text.unpack $ renderPretty v)
+        Nothing -> throwM $ RuntimeError $ "non-exhaustive patterns in case detected in " <> Text.unpack (renderPretty v)
       matchAny v ((_, p, _, body) :| (r : rs)) = case match v p of
         Just nenv -> eval (nenv <> env) body
         Nothing -> matchAny v (r :| rs)
 
       match v p = case (v, p) of
-        (_, PVar _ (Just (Ident x))) -> Just $ (Map.singleton (ExtIdent $ Right x) v, mempty)
+        (_, PVar _ (Just (Ident x))) -> Just (Map.singleton (ExtIdent $ Right x) v, mempty)
         (_, PVar _ Nothing) -> Just mempty
         (VEnum h1 i1, PEnum _ (Just h2) _ i2) ->
           if h1 == h2 && i1 == i2

--- a/inferno-core/src/Inferno/Infer/Env.hs
+++ b/inferno-core/src/Inferno/Infer/Env.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-
 module Inferno.Infer.Env
   ( Env (..),
     Namespace (..),
@@ -130,7 +128,7 @@ fv (TBase _) = []
 fv (TArray t) = fv t
 fv (TSeries t) = fv t
 fv (TOptional t) = fv t
-fv (TTuple ts) = foldr ((++) . fv) [] ts
+fv (TTuple ts) = concatMap fv ts
 fv (TRecord ts RowAbsent) = concatMap fv ts
 fv (TRecord ts (RowVar a)) = foldr ((++) . fv) [a] ts
 fv (TRep t) = fv t
@@ -169,7 +167,7 @@ normalize (ForallTC _ tcs (ImplType impl body)) =
 generalize :: Set.Set TypeClass -> ImplType -> TCScheme
 generalize tcs t = ForallTC as tcs t
   where
-    as = Set.toList $ ((ftv t) `Set.union` (Set.unions $ Set.elems $ Set.map ftv tcs))
+    as = Set.toList (ftv t `Set.union` Set.unions (Set.elems $ Set.map ftv tcs))
 
 -- | Canonicalize and return the polymorphic toplevel type.
 closeOver :: Set.Set TypeClass -> ImplType -> TCScheme

--- a/inferno-core/src/Inferno/Infer/Error.hs
+++ b/inferno-core/src/Inferno/Infer/Error.hs
@@ -1,6 +1,4 @@
-
 {-# LANGUAGE DeriveTraversable #-}
-
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 

--- a/inferno-core/src/Inferno/Infer/Error.hs
+++ b/inferno-core/src/Inferno/Infer/Error.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE DeriveFoldable #-}
+
 {-# LANGUAGE DeriveTraversable #-}
-{-# LANGUAGE KindSignatures #-}
+
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -92,4 +92,4 @@ getTypeClassFromErr = \case
   _ -> mempty
 
 getTypeClassFromErrs :: [TypeError a] -> Set.Set TypeClass
-getTypeClassFromErrs = foldr Set.union mempty . map getTypeClassFromErr
+getTypeClassFromErrs = foldr (Set.union . getTypeClassFromErr) mempty

--- a/inferno-core/src/Inferno/Infer/Exhaustiveness.hs
+++ b/inferno-core/src/Inferno/Infer/Exhaustiveness.hs
@@ -38,7 +38,7 @@ instance Eq Con where
   CEmpty == CEmpty = True
   (CTuple i) == (CTuple j) = i == j
   (CEnum e _) == (CEnum f _) = e == f
-  (CInf a) == (CInf b) = (show a) == (show b)
+  (CInf a) == (CInf b) = show a == show b
   _ == _ = False
 
 -- we don't really care about the ord instance here
@@ -208,10 +208,10 @@ exhaustive sigs pm = i sigs pm 1
                 Nothing -> go rest
                 Just pat ->
                   Just $
-                    [C ck $ take (cSize ck) pat] ++ drop (cSize ck) pat
+                    C ck (take (cSize ck) pat) : drop (cSize ck) pat
 
 checkUsefullness :: Map VCObjectHash (Set (VCObjectHash, Text)) -> PMatrix -> [(Int, Int)]
-checkUsefullness enum_sigs p = go 0 [] p
+checkUsefullness enum_sigs = go 0 []
   where
     go _ _ [] = []
     go n preceding (p_i : rest) =
@@ -262,7 +262,7 @@ mkEnumArrayPat = EnumArrayPat . length
 instance Pretty EnumArrayPat where
   pretty (EnumArrayPat n) =
     -- Since SourcePos is ignored when pretty printing, we use an undefined SourcePos
-    pretty $ PArray undefined (replicate n $ (PVar (initialPos "") Nothing, Nothing)) undefined
+    pretty $ PArray undefined (replicate n (PVar (initialPos "") Nothing, Nothing)) undefined
 
 instance Enum EnumArrayPat where
   toEnum = EnumArrayPat

--- a/inferno-core/src/Inferno/Instances/Arbitrary.hs
+++ b/inferno-core/src/Inferno/Instances/Arbitrary.hs
@@ -616,7 +616,7 @@ instance Arbitrary Type.TCScheme where
       arbitraryImplType =
         ImplType <$> arbitraryImpls <*> arbitrary
       arbitraryImpls =
-        Map.fromList <$> listOf ((,) <$> (ExtIdent . Right <$> arbitraryName) <*> arbitrary)
+        Map.fromList <$> listOf (((,) . ExtIdent . Right <$> arbitraryName) <*> arbitrary)
 
 deriving instance ToADTArbitrary Type.Namespace
 

--- a/inferno-core/src/Inferno/Instances/Arbitrary.hs
+++ b/inferno-core/src/Inferno/Instances/Arbitrary.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE GADTs #-}
@@ -124,19 +123,18 @@ instance Arbitrary BaseType where
       (TEnum <$> arbitraryTypeName <*> (Set.fromList <$> suchThat (listOf (Ident <$> arbitraryName)) (not . null)))
         -- NOTE: we don't generate custom types because these need to be known when constructing the parser
         -- : (TCustom . Text.unpack <$> arbitraryName)
-        : ( map
-              pure
-              [ TInt,
-                TDouble,
-                TWord16,
-                TWord32,
-                TWord64,
-                TText,
-                TTime,
-                TTimeDiff,
-                TResolution
-              ]
-          )
+        : map
+          pure
+          [ TInt,
+            TDouble,
+            TWord16,
+            TWord32,
+            TWord64,
+            TText,
+            TTime,
+            TTimeDiff,
+            TResolution
+          ]
 
 deriving instance ToADTArbitrary RestOfRecord
 
@@ -153,8 +151,8 @@ instance Arbitrary InfernoType where
 
       arbitraryArr =
         TArr
-          <$> (scale (`div` 3) arbitraryType)
-          <*> (scale (`div` 3) arbitraryType)
+          <$> scale (`div` 3) arbitraryType
+          <*> scale (`div` 3) arbitraryType
 
       arbitraryTTuple = do
         let arbitrarySmaller = scale (`div` 3) arbitraryType
@@ -165,15 +163,14 @@ instance Arbitrary InfernoType where
 
       arbitraryBase = TBase <$> arbitrary
 
-      arbitraryRecord = do
-        TRecord <$> scale (`div` 3) arbitrary <*> arbitrary
+      arbitraryRecord = TRecord <$> scale (`div` 3) arbitrary <*> arbitrary
 
       arbitraryRest = do
         -- NOTE: we omit TRep because it is an internal type that the parser does not support
         constr <- elements [TArray, TSeries, TOptional]
         constr <$> scale (`div` 3) arbitraryType
 
-      arbitraryType = do
+      arbitraryType =
         getSize >>= \case
           0 ->
             oneof [arbitraryVar, arbitraryBase]
@@ -191,19 +188,19 @@ instance Arbitrary InfernoType where
 arbitraryName :: Gen Text.Text
 arbitraryName =
   ( (\a as -> Text.pack $ a : as)
-      <$> (elements ['a' .. 'z'])
-      <*> (listOf $ elements $ ['0' .. '9'] ++ ['a' .. 'z'] ++ ['_'])
+      <$> elements ['a' .. 'z']
+      <*> listOf (elements $ ['0' .. '9'] ++ ['a' .. 'z'] ++ ['_'])
   )
-    `suchThat` (\i -> not $ i `elem` rws)
+    `suchThat` (`notElem` rws)
 
 -- | An arbitrary valid type variable name
 arbitraryTypeName :: Gen Text.Text
 arbitraryTypeName =
   ( (\a as -> Text.pack $ a : as)
-      <$> (elements ['a' .. 'z'])
-      <*> (listOf $ elements $ ['0' .. '9'] ++ ['a' .. 'z'])
+      <$> elements ['a' .. 'z']
+      <*> listOf (elements $ ['0' .. '9'] ++ ['a' .. 'z'])
   )
-    `suchThat` (not . (flip elem rws))
+    `suchThat` (not . (`elem` rws))
 
 deriving instance ToADTArbitrary Ident
 
@@ -222,7 +219,7 @@ deriving instance ToADTArbitrary ExtIdent
 instance Arbitrary ExtIdent where
   shrink = shrinkNothing
   arbitrary =
-    ExtIdent <$> oneof [Left <$> (arbitrary `suchThat` ((<) 0)), Right <$> arbitraryName]
+    ExtIdent <$> oneof [Left <$> (arbitrary `suchThat` (0 <)), Right <$> arbitraryName]
 
 deriving instance ToADTArbitrary ImplExpl
 
@@ -242,11 +239,11 @@ instance Arbitrary pos => Arbitrary (Comment pos) where
     oneof
       [ LineComment
           <$> arbitrary
-          <*> (Text.pack . getPrintableString <$> arbitrary) `suchThat` (Text.all $ \c -> c /= '\n' && c /= '\r')
+          <*> (Text.pack . getPrintableString <$> arbitrary) `suchThat` Text.all (\c -> c /= '\n' && c /= '\r')
           <*> arbitrary,
         BlockComment
           <$> arbitrary
-          <*> (Text.pack . getPrintableString <$> arbitrary) `suchThat` (Text.all $ \c -> c /= '*') -- prevent having a '*/'
+          <*> (Text.pack . getPrintableString <$> arbitrary) `suchThat` Text.all (/= '*') -- prevent having a '*/'
           <*> arbitrary
       ]
 
@@ -257,7 +254,7 @@ instance Arbitrary Lit where
     oneof
       [ LInt <$> arbitrary,
         LDouble <$> arbitrary,
-        (LText . Text.pack . getPrintableString) <$> arbitrary,
+        LText . Text.pack . getPrintableString <$> arbitrary,
         LHex <$> arbitrary
       ]
 
@@ -288,8 +285,8 @@ instance Arbitrary a => Arbitrary (SomeIStr a) where
   shrink (SomeIStr ISEmpty) = []
   shrink (SomeIStr (ISStr s xs)) =
     -- shrink to subterms
-    [SomeIStr xs]
-      ++
+    SomeIStr xs
+      :
       -- recursively shrink subterms
       [ case xs' of
           SomeIStr (ISStr _ _) -> xs'
@@ -331,7 +328,7 @@ instance (Arbitrary hash, Arbitrary pos) => Arbitrary (Expr hash pos) where
   arbitrary = sized arbitrarySized
     where
       -- Don't generate implicit variables, because parser does not support them
-      arbitraryExtIdent = ExtIdent <$> Right <$> arbitraryName
+      arbitraryExtIdent = ExtIdent . Right <$> arbitraryName
       arbitraryImplExpl = oneof [Impl <$> arbitraryExtIdent, Expl <$> arbitraryExtIdent]
       arbitraryVar :: (Arbitrary hash, Arbitrary pos) => Gen (Expr hash pos)
       arbitraryVar =
@@ -342,15 +339,15 @@ instance (Arbitrary hash, Arbitrary pos) => Arbitrary (Expr hash pos) where
               <*> arbitrary
               <*> pure LocalScope
               <*> ( Ident
-                      <$> ( oneof
-                              $ concatMap
-                                ( \case
-                                    (InfixOp _, _, op) -> [pure op]
-                                    _ -> []
-                                )
-                              $ concat
-                              $ IntMap.elems baseOpsTable
-                          )
+                      <$> oneof
+                        ( concatMap
+                            ( \case
+                                (InfixOp _, _, op) -> [pure op]
+                                _ -> []
+                            )
+                            $ concat
+                            $ IntMap.elems baseOpsTable
+                        )
                   )
           ]
       arbitraryEnum :: (Arbitrary hash, Arbitrary pos) => Gen (Expr hash pos)
@@ -360,19 +357,19 @@ instance (Arbitrary hash, Arbitrary pos) => Arbitrary (Expr hash pos) where
 
       arbitraryApp n =
         App
-          <$> (arbitrarySized $ n `div` 3)
-          <*> (arbitrarySized $ n `div` 3)
+          <$> arbitrarySized (n `div` 3)
+          <*> arbitrarySized (n `div` 3)
 
       arbitraryLam n =
         Lam
           <$> arbitrary
           <*> arbitraryLamVars
           <*> arbitrary
-          <*> (arbitrarySized $ n `div` 3)
+          <*> arbitrarySized (n `div` 3)
         where
           -- Don't generate implicit vars. Sorry, there must be a nicer way to do this
           arbitraryLamVars :: Arbitrary pos => Gen (NonEmpty (pos, Maybe ExtIdent))
-          arbitraryLamVars = arbitrary `suchThat` (all isSomeRight . snd . NonEmpty.unzip)
+          arbitraryLamVars = arbitrary `suchThat` all (isSomeRight . snd)
           isSomeRight (Just (ExtIdent (Right _))) = True
           isSomeRight _ = False
 
@@ -382,9 +379,9 @@ instance (Arbitrary hash, Arbitrary pos) => Arbitrary (Expr hash pos) where
           <*> arbitrary
           <*> arbitraryImplExpl
           <*> arbitrary
-          <*> (arbitrarySized $ n `div` 3)
+          <*> arbitrarySized (n `div` 3)
           <*> arbitrary
-          <*> (arbitrarySized $ n `div` 3)
+          <*> arbitrarySized (n `div` 3)
 
       arbitraryLetAnnot n =
         LetAnnot
@@ -394,9 +391,9 @@ instance (Arbitrary hash, Arbitrary pos) => Arbitrary (Expr hash pos) where
           <*> arbitrary
           <*> resize (n `div` 3) arbitrary
           <*> arbitrary
-          <*> (arbitrarySized $ n `div` 3)
+          <*> arbitrarySized (n `div` 3)
           <*> arbitrary
-          <*> (arbitrarySized $ n `div` 3)
+          <*> arbitrarySized (n `div` 3)
 
       arbitraryIString n =
         InterpolatedString
@@ -411,8 +408,8 @@ instance (Arbitrary hash, Arbitrary pos) => Arbitrary (Expr hash pos) where
             0 -> pure ISEmpty
             m ->
               oneof
-                [ ISExpr <$> ((,,) <$> arbitrary <*> (arbitrarySized $ n `div` 3) <*> arbitrary) <*> goT (m - 1),
-                  ISExpr <$> ((,,) <$> arbitrary <*> (arbitrarySized $ n `div` 3) <*> arbitrary) <*> goF (m - 1)
+                [ ISExpr <$> ((,,) <$> arbitrary <*> arbitrarySized (n `div` 3) <*> arbitrary) <*> goT (m - 1),
+                  ISExpr <$> ((,,) <$> arbitrary <*> arbitrarySized (n `div` 3) <*> arbitrary) <*> goF (m - 1)
                 ]
 
           goF :: (Arbitrary hash, Arbitrary pos) => Int -> Gen (IStr 'False (pos, Expr hash pos, pos))
@@ -433,55 +430,55 @@ instance (Arbitrary hash, Arbitrary pos) => Arbitrary (Expr hash pos) where
       arbitraryIf n =
         If
           <$> arbitrary
-          <*> (arbitrarySized $ n `div` 3)
+          <*> arbitrarySized (n `div` 3)
           <*> arbitrary
-          <*> (arbitrarySized $ n `div` 3)
+          <*> arbitrarySized (n `div` 3)
           <*> arbitrary
-          <*> (arbitrarySized $ n `div` 3)
+          <*> arbitrarySized (n `div` 3)
 
       arbitraryAssert n =
         Assert
           <$> arbitrary
-          <*> (arbitrarySized $ n `div` 3)
+          <*> arbitrarySized (n `div` 3)
           <*> arbitrary
-          <*> (arbitrarySized $ n `div` 3)
+          <*> arbitrarySized (n `div` 3)
 
       arbitraryOp n =
         (\(prec, fix, op) e1 e2 p h -> Op e1 p h (prec, fix) LocalScope (Ident op) e2)
-          <$> ( oneof
-                  $ map pure
-                  $ concatMap
-                    ( \(prec, xs) ->
-                        concatMap
-                          ( \case
-                              (InfixOp fix, _, op) -> [(prec, fix, op)]
-                              _ -> []
-                          )
-                          xs
-                    )
-                  $ IntMap.toList baseOpsTable
-              )
-          <*> (arbitrarySized $ n `div` 3)
-          <*> (arbitrarySized $ n `div` 3)
+          <$> oneof
+            ( map pure
+                $ concatMap
+                  ( \(prec, xs) ->
+                      concatMap
+                        ( \case
+                            (InfixOp fix, _, op) -> [(prec, fix, op)]
+                            _ -> []
+                        )
+                        xs
+                  )
+                $ IntMap.toList baseOpsTable
+            )
+          <*> arbitrarySized (n `div` 3)
+          <*> arbitrarySized (n `div` 3)
           <*> arbitrary
           <*> arbitrary
 
       arbitraryPreOp n =
         (\(prec, op) e p h -> PreOp p h prec LocalScope (Ident op) e)
-          <$> ( oneof
-                  $ map pure
-                  $ concatMap
-                    ( \(prec, xs) ->
-                        concatMap
-                          ( \case
-                              (PrefixOp, _, op) -> [(prec, op)]
-                              _ -> []
-                          )
-                          xs
-                    )
-                  $ IntMap.toList baseOpsTable
-              )
-          <*> (arbitrarySized $ n `div` 3)
+          <$> oneof
+            ( map pure
+                $ concatMap
+                  ( \(prec, xs) ->
+                      concatMap
+                        ( \case
+                            (PrefixOp, _, op) -> [(prec, op)]
+                            _ -> []
+                        )
+                        xs
+                  )
+                $ IntMap.toList baseOpsTable
+            )
+          <*> arbitrarySized (n `div` 3)
           <*> arbitrary
           <*> arbitrary
 
@@ -489,7 +486,7 @@ instance (Arbitrary hash, Arbitrary pos) => Arbitrary (Expr hash pos) where
       arbitraryCase 0 = undefined
       arbitraryCase n =
         (\e cs p1 p2 p3 -> Case p1 e p2 (NonEmpty.fromList cs) p3)
-          <$> (arbitrarySized $ n `div` 3)
+          <$> arbitrarySized (n `div` 3)
           <*> ( do
                   k <- choose (1, n)
                   sequence
@@ -513,14 +510,14 @@ instance (Arbitrary hash, Arbitrary pos) => Arbitrary (Expr hash pos) where
       arbitraryArrayComp n =
         ArrayComp
           <$> arbitrary
-          <*> (arbitrarySized $ n `div` 3)
+          <*> arbitrarySized (n `div` 3)
           <*> arbitrary
           <*> ( NonEmpty.fromList
                   <$> do
                     k <- choose (1, n)
                     sequence [(,,,,) <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrarySized (n `div` (3 * k)) <*> pure Nothing | _ <- [1 .. k]]
               )
-          <*> oneof [(\p e -> Just (p, e)) <$> arbitrary <*> (arbitrarySized $ n `div` 3), pure Nothing]
+          <*> oneof [curry Just <$> arbitrary <*> arbitrarySized (n `div` 3), pure Nothing]
           <*> arbitrary
 
       arbitraryRecord n = do
@@ -619,7 +616,7 @@ instance Arbitrary Type.TCScheme where
       arbitraryImplType =
         ImplType <$> arbitraryImpls <*> arbitrary
       arbitraryImpls =
-        Map.fromList <$> listOf ((,) <$> (ExtIdent <$> Right <$> arbitraryName) <*> arbitrary)
+        Map.fromList <$> listOf ((,) <$> (ExtIdent . Right <$> arbitraryName) <*> arbitrary)
 
 deriving instance ToADTArbitrary Type.Namespace
 

--- a/inferno-core/src/Inferno/Module/Builtin.hs
+++ b/inferno-core/src/Inferno/Module/Builtin.hs
@@ -53,7 +53,7 @@ builtinModule =
         [ ( enumBoolHash,
             TypeMetadata
               { identExpr = Var () () LocalScope (Expl $ ExtIdent $ Right "_"),
-                ty = ForallTC [] Set.empty $ ImplType Map.empty $ typeBool,
+                ty = ForallTC [] Set.empty $ ImplType Map.empty typeBool,
                 docs = Just "Boolean type"
               }
           ),
@@ -84,12 +84,12 @@ builtinModule =
 emptyTy, oneTy, boolTy :: TCScheme
 emptyTy = ForallTC [TV 0] Set.empty $ ImplType Map.empty $ TOptional (TVar $ TV 0)
 oneTy = ForallTC [TV 0] Set.empty $ ImplType Map.empty $ TVar (TV 0) .-> TOptional (TVar $ TV 0)
-boolTy = ForallTC [] Set.empty $ ImplType Map.empty $ typeBool
+boolTy = ForallTC [] Set.empty $ ImplType Map.empty typeBool
 
 emptyHash, oneHash, enumBoolHash :: VCObjectHash
 emptyHash = builtinFunHash "empty" emptyTy
 oneHash = builtinFunHash "one" oneTy
-enumBoolHash = vcHash $ BuiltinEnumHash $ boolTy
+enumBoolHash = vcHash $ BuiltinEnumHash boolTy
 
 builtinFunHash :: Text -> TCScheme -> VCObjectHash
 builtinFunHash n ty = vcHash $ BuiltinFunHash (Var () () LocalScope $ Expl $ ExtIdent $ Right n, ty)

--- a/inferno-core/src/Inferno/Module/Cast.hs
+++ b/inferno-core/src/Inferno/Module/Cast.hs
@@ -1,6 +1,4 @@
-
 {-# LANGUAGE ScopedTypeVariables #-}
-
 
 -- TODO export only needed?
 -- module Inferno.Module.Cast (FromValue, ToValue) where

--- a/inferno-core/src/Inferno/Module/Cast.hs
+++ b/inferno-core/src/Inferno/Module/Cast.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE ExplicitForAll #-}
+
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
+
 
 -- TODO export only needed?
 -- module Inferno.Module.Cast (FromValue, ToValue) where
@@ -41,7 +41,7 @@ class ToValue c m a where
 
 -- | Class of types that can be converted from script values, allowing IO in the process.
 class FromValue c m a where
-  fromValue :: MonadThrow m => (Value c m) -> m a
+  fromValue :: MonadThrow m => Value c m -> m a
 
 -- | Haskell types that can be casted to mask script types.
 class Kind0 a where
@@ -54,9 +54,9 @@ couldNotCast v =
   throwM $
     CastError $
       "Could not cast value "
-        <> (unpack $ renderPretty v)
+        <> unpack (renderPretty v)
         <> " to "
-        <> (show $ typeRep (Proxy :: Proxy a))
+        <> show (typeRep (Proxy :: Proxy a))
 
 instance ToValue c m (Value c m) where
   toValue = id
@@ -82,7 +82,7 @@ instance Pretty c => FromValue c m Bool where
         if ident == "true"
           then pure True
           else pure False
-      else couldNotCast $ (VEnum hash ident :: Value c m)
+      else couldNotCast (VEnum hash ident :: Value c m)
   fromValue v = couldNotCast v
 
 instance ToValue c m Double where
@@ -163,37 +163,37 @@ instance Kind0 Bool where
   toType _ = TBase $ TEnum "bool" $ Set.fromList ["true", "false"]
 
 instance Kind0 Float where
-  toType _ = TBase $ TDouble
+  toType _ = TBase TDouble
 
 instance Kind0 Double where
-  toType _ = TBase $ TDouble
+  toType _ = TBase TDouble
 
 instance Kind0 Int where
-  toType _ = TBase $ TInt
+  toType _ = TBase TInt
 
 instance Kind0 Int64 where
-  toType _ = TBase $ TInt
+  toType _ = TBase TInt
 
 instance Kind0 Integer where
-  toType _ = TBase $ TInt
+  toType _ = TBase TInt
 
 instance Kind0 Word16 where
-  toType _ = TBase $ TWord16
+  toType _ = TBase TWord16
 
 instance Kind0 Word32 where
-  toType _ = TBase $ TWord32
+  toType _ = TBase TWord32
 
 instance Kind0 Word64 where
-  toType _ = TBase $ TWord64
+  toType _ = TBase TWord64
 
 instance Kind0 () where
   toType _ = TTuple TNil
 
 instance Kind0 CTime where
-  toType _ = TBase $ TTime
+  toType _ = TBase TTime
 
 instance Kind0 Text where
-  toType _ = TBase $ TText
+  toType _ = TBase TText
 
 instance (Kind0 a, Kind0 b) => Kind0 (a -> b) where
   toType _ = TArr (toType (Proxy :: Proxy a)) (toType (Proxy :: Proxy b))

--- a/inferno-core/src/Inferno/Parse.hs
+++ b/inferno-core/src/Inferno/Parse.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE ApplicativeDo #-}
 {-# LANGUAGE ExplicitForAll #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
 module Inferno.Parse
@@ -28,10 +27,11 @@ import Control.Monad.Combinators.Expr
   )
 import Control.Monad.Reader (ReaderT (..), ask, withReaderT)
 import Control.Monad.Writer (WriterT (..), tell)
-import Data.Bifunctor (bimap)
+import Data.Bifunctor (Bifunctor (first))
 import Data.Char (isAlphaNum, isSpace)
 import Data.Data (Data)
 import Data.Either (partitionEithers)
+import Data.Functor (($>))
 import qualified Data.IntMap as IntMap
 import qualified Data.List as List
 import Data.List.NonEmpty (NonEmpty)
@@ -189,7 +189,7 @@ variable = do
   where
     p = pack <$> (((:) <$> letterChar <*> hidden (many alphaNumCharOrSeparator)) <?> "a variable")
     check oT x =
-      if x `elem` rws ++ (map (\(_, _, i) -> i) $ concat oT)
+      if x `elem` rws ++ map (\(_, _, i) -> i) (concat oT)
         then fail $ "Keyword " <> show x <> " cannot be a variable/function name"
         else return x
 
@@ -197,14 +197,14 @@ mIdent :: Parser (SourcePos, Maybe Ident)
 mIdent = lexeme $ do
   startPos <- getSourcePos
   (startPos,) . Just . Ident <$> variable
-    <|> (char '_' *> takeWhileP Nothing isAlphaNumOrSeparator *> pure (startPos, Nothing))
+    <|> (char '_' *> takeWhileP Nothing isAlphaNumOrSeparator $> (startPos, Nothing))
     <?> "a wildcard parameter '_'"
 
 mExtIdent :: Parser (SourcePos, Maybe ExtIdent)
 mExtIdent = lexeme $ do
   startPos <- getSourcePos
   (startPos,) . Just . ExtIdent . Right <$> variable
-    <|> (char '_' *> takeWhileP Nothing isAlphaNumOrSeparator *> pure (startPos, Nothing))
+    <|> (char '_' *> takeWhileP Nothing isAlphaNumOrSeparator $> (startPos, Nothing))
     <?> "a wildcard parameter '_'"
 
 implicitVariable :: Parser Text
@@ -218,11 +218,11 @@ enumConstructor =
 
 -- | 'signedInteger' parses an integer with an optional sign (with no space)
 signedInteger :: Num a => Parser a
-signedInteger = Lexer.signed (takeWhileP Nothing isHSpace *> pure ()) Lexer.decimal
+signedInteger = Lexer.signed (takeWhileP Nothing isHSpace $> ()) Lexer.decimal
 
 -- | 'signedInteger' parses a float/double with an optional sign (with no space)
 signedFloat :: Parser Double
-signedFloat = Lexer.signed (takeWhileP Nothing isHSpace *> pure ()) Lexer.float
+signedFloat = Lexer.signed (takeWhileP Nothing isHSpace $> ()) Lexer.float
 
 enumE :: (SourcePos -> () -> Scoped ModuleName -> Ident -> f) -> Parser f
 enumE f = do
@@ -261,12 +261,12 @@ signedDoubleE f = label "a number\nfor example: 42, 3.1415, (-6)" $ do
 noneE :: (SourcePos -> a) -> Parser a
 noneE e = label "an optional\nfor example: Some x, None" $ do
   startPos <- getSourcePos
-  lexeme $ (const $ e startPos) <$> (hidden $ string "None")
+  lexeme (e startPos <$ hidden (string "None"))
 
 someE :: (SourcePos -> t -> a) -> Parser t -> Parser a
 someE f p = label "an optional\nfor example: Some x, None" $ do
   startPos <- getSourcePos
-  lexeme $ (hidden $ string "Some")
+  lexeme (hidden $ string "Some")
   f startPos <$> p
 
 stringE :: (SourcePos -> Lit -> f SourcePos) -> Parser (f SourcePos)
@@ -281,27 +281,26 @@ interpolatedStringE = label "an interpolated string\nfor example: `hello ${1 + 2
   lexeme $ do
     startPos@(SourcePos _ _ col) <- getSourcePos
     es <- mkInterpolatedString <$> (char '`' *> go)
-    endPos <- getSourcePos
-    return $ InterpolatedString startPos (fromEitherList $ fixSpacing (unPos col) es) endPos
+    InterpolatedString startPos (fromEitherList $ fixSpacing (unPos col) es) <$> getSourcePos
   where
     go =
-      ([] <$ char '`')
-        <|> try (((:) . Left . singleton) <$> (hidden $ char '\\' *> char '\\') <*> go)
-        <|> try (((:) . Left . singleton) <$> (hidden $ char '\\' *> char '`') <*> go)
-        <|> try (((:) . Left . singleton) <$> (hidden $ char '\\' *> char '$') <*> go)
-        <|> ( ((:) . Right)
-                <$> ( hidden $ do
-                        startPos <- getSourcePos
-                        e <- char '$' *> char '{' *> sc *> expr <* char '}'
-                        endPos <- getSourcePos
-                        pure $ (startPos, e, endPos)
-                    )
-                <*> go
+      [] <$ char '`'
+        <|> try ((:) . Left . singleton <$> hidden (char '\\' *> char '\\') <*> go)
+        <|> try ((:) . Left . singleton <$> hidden (char '\\' *> char '`') <*> go)
+        <|> try ((:) . Left . singleton <$> hidden (char '\\' *> char '$') <*> go)
+        <|> (:) . Right
+          <$> hidden
+            ( do
+                startPos <- getSourcePos
+                e <- char '$' *> char '{' *> sc *> expr <* char '}'
+                endPos <- getSourcePos
+                pure (startPos, e, endPos)
             )
-        <|> (((:) . Left . singleton) <$> Lexer.charLiteral <*> go)
+          <*> go
+        <|> (:) . Left . singleton <$> Lexer.charLiteral <*> go
 
     fixSpacing newlineSpaceLength =
-      map (bimap (Text.replace (pack $ '\n' : List.replicate (newlineSpaceLength - 1) ' ') "\n") id)
+      map (first (Text.replace (pack $ '\n' : List.replicate (newlineSpaceLength - 1) ' ') "\n"))
 arrayComprE = label "array builder\nfor example: [n * 2 + 1 | n <- range 0 10, if n % 2 == 0]" $
   lexeme $ do
     startPos <- getSourcePos
@@ -331,7 +330,7 @@ arrayComprE = label "array builder\nfor example: [n * 2 + 1 | n <- range 0 10, i
             (xs, mcond) <- try rhsE <|> (\c -> ([], Just c)) <$> condE
             pure ((startPos, var, arrPos, e, Just pos) : xs, mcond)
         )
-        <|> ((\(startPos, var, arrPos, e) -> ([(startPos, var, arrPos, e, Nothing)], Nothing)) <$> selectE)
+        <|> (\(startPos, var, arrPos, e) -> ([(startPos, var, arrPos, e, Nothing)], Nothing)) <$> selectE
 
     condE :: Parser (SourcePos, Expr () SourcePos)
     condE = do
@@ -406,8 +405,7 @@ funE = label "a function\nfor example: fun x y -> x + y" $ do
   args <- some mExtIdent
   arrPos <- getSourcePos
   symbol "->" <?> "'->'"
-  body <- expr
-  return $ Lam startPos (NEList.fromList args) arrPos body
+  Lam startPos (NEList.fromList args) arrPos <$> expr
 
 renameModE :: Parser (Expr () SourcePos)
 renameModE = label "a 'let module' expression\nfor example: let module A = Base in A.#true" $
@@ -415,10 +413,10 @@ renameModE = label "a 'let module' expression\nfor example: let module A = Base 
     hidden $ rword "let"
     hidden $ rword "module"
     newNmPos <- getSourcePos
-    newNm <- lexeme $ (ModuleName <$> variable <?> "module name")
+    newNm <- lexeme (ModuleName <$> variable <?> "module name")
     symbol "=" <?> "'='"
     oldNmPos <- getSourcePos
-    oldNm <- lexeme $ (ModuleName <$> variable <?> "name of an existing module")
+    oldNm <- lexeme (ModuleName <$> variable <?> "name of an existing module")
     inPos <- getSourcePos
     (opsTable, modOpsTables, customTypes) <- ask
     case Map.lookup oldNm modOpsTables of
@@ -479,21 +477,21 @@ openModArgs modNm = do
         Nothing -> customFailure $ ModuleNotFound modNm
     go =
       try
-        ((:) <$> ((,) <$> parseImport <*> lexeme ((Just <$> getSourcePos) <* symbol ",")) <*> go)
-        <|> ((\i -> [(i, Nothing)]) <$> parseImport)
+        ((:) <$> ((,) <$> parseImport <*> lexeme (Just <$> getSourcePos <* symbol ",")) <*> go)
+        <|> (\i -> [(i, Nothing)]) <$> parseImport
 
     parseImport =
       try (IOpVar <$> getSourcePos <*> lexeme (char '(' *> (Ident <$> takeWhile1P Nothing isAlphaNum) <* char ')'))
         <|> try (IEnum <$> lexeme (getSourcePos <* string "enum") <*> getSourcePos <*> lexeme (Ident <$> variable))
-        <|> (IVar <$> getSourcePos <*> lexeme (Ident <$> variable))
+        <|> IVar <$> getSourcePos <*> lexeme (Ident <$> variable)
 
 openModE :: Parser (Expr () SourcePos)
 openModE = label "an 'open' module expression\nfor example: open A in ..." $
   do
     hidden $ rword "open"
     nmPos <- getSourcePos
-    nm <- lexeme $ (ModuleName <$> variable <?> "module name")
-    (uncurry3 (OpenModule nmPos () nm) <$> (try (openModArgs nm) <|> ((\inPos e -> ([], inPos, e)) <$> getSourcePos <*> openAll nm)))
+    nm <- lexeme (ModuleName <$> variable <?> "module name")
+    uncurry3 (OpenModule nmPos () nm) <$> (try (openModArgs nm) <|> (\inPos e -> ([], inPos, e)) <$> getSourcePos <*> openAll nm)
   where
     openAll modNm = do
       (opsTable, modOpsTables, customTypes) <- ask
@@ -509,7 +507,7 @@ letE = label ("a 'let' expression" ++ example "x") $
     startPos <- getSourcePos
     hidden $ rword "let"
     varPos <- getSourcePos
-    x <- lexeme $ (((Expl . ExtIdent . Right <$> variable) <|> (Impl . ExtIdent . Right <$> implicitVariable)) <?> "a variable")
+    x <- lexeme ((Expl . ExtIdent . Right <$> variable <|> Impl . ExtIdent . Right <$> implicitVariable) <?> "a variable")
     let xStr = unpack $ renderPretty x
     tPos <- getSourcePos
     maybeTy <-
@@ -530,14 +528,14 @@ letE = label ("a 'let' expression" ++ example "x") $
 
 pat :: Parser (Pat () SourcePos)
 pat =
-  (uncurry3 PArray <$> array pat)
+  uncurry3 PArray <$> array pat
     <|> try (uncurry3 PTuple <$> tuple pat)
     <|> parens pat
     <|> try (hexadecimal PLit)
     <|> try (signedDoubleE PLit)
     <|> signedIntE PLit
     <|> enumE PEnum
-    <|> (uncurry PVar <$> mIdent)
+    <|> uncurry PVar <$> mIdent
     <|> noneE PEmpty
     <|> someE POne pat
     <|> stringE PLit
@@ -594,7 +592,7 @@ tuple p = label "a tuple\nfor example: (2, #true, 4.4)" $
   lexeme $ do
     startPos <- getSourcePos
     symbol "("
-    r <- tListFromList <$> tupleArgs p <|> ((takeWhileP Nothing isHSpace) *> pure TNil)
+    r <- tListFromList <$> tupleArgs p <|> takeWhileP Nothing isHSpace $> TNil
     endPos <- getSourcePos
     char ')'
     return (startPos, r, endPos)
@@ -612,7 +610,7 @@ ifE :: Parser (Expr () SourcePos)
 ifE = do
   ifPos <- getSourcePos
   hidden $ rword "if"
-  cond <- (hidden $ expr) <?> "_a conditional expression\nfor example: x > 2"
+  cond <- hidden expr <?> "_a conditional expression\nfor example: x > 2"
   thenPos <- getSourcePos
   tr <- (rword "then" *> expr) <?> "_the 'then' branch\nfor example: if x > 2 then 1 else 0"
   elsePos <- getSourcePos
@@ -622,7 +620,7 @@ ifE = do
 -- | Parses an op in prefix syntax WITHOUT opening paren @(@ but with closing paren @)@
 -- E.g. @+)@
 prefixOpsWithoutModule :: SourcePos -> Parser (Expr () SourcePos)
-prefixOpsWithoutModule startPos = do
+prefixOpsWithoutModule startPos =
   hidden (ask >>= choiceOf (prefixOp startPos) . opsInLocalScope)
   where
     opsInLocalScope (ops, _, _) = [s | (_, modNm, s) <- concat ops, modNm == LocalScope]
@@ -633,7 +631,7 @@ prefixOpsWithoutModule startPos = do
 
 -- | Parses a op in prefix syntax of the form @Mod.(+)@
 prefixOpsWithModule :: SourcePos -> Parser (Expr () SourcePos)
-prefixOpsWithModule startPos = do
+prefixOpsWithModule startPos =
   hidden (ask >>= tryMany prefixOp . opsNotInLocal)
   where
     opsNotInLocal (ops, _, _) = [(modNm, s) | (_, modNm, s) <- concat ops, modNm /= LocalScope]
@@ -720,7 +718,7 @@ term =
     <|> try implVarE
     <|> stringE Lit
     <|> interpolatedStringE
-    <|> (try (uncurry3 Array <$> array expr))
+    <|> try (uncurry3 Array <$> array expr)
     <|> try (uncurry3 Record <$> record expr)
     <|> arrayComprE
 
@@ -750,19 +748,19 @@ mkOperators opsTable =
     mkOperatorP prec (InfixOp NoFix) ns o =
       InfixN $
         infixLabel $
-          (\pos e1 e2 -> Op e1 pos () (prec, NoFix) ns (Ident o) e2) <$> (lexeme $ getSourcePos <* string (opString ns o))
+          (\pos e1 e2 -> Op e1 pos () (prec, NoFix) ns (Ident o) e2) <$> lexeme (getSourcePos <* string (opString ns o))
     mkOperatorP prec (InfixOp LeftFix) ns o =
       InfixL $
         infixLabel $
-          (\pos e1 e2 -> Op e1 pos () (prec, LeftFix) ns (Ident o) e2) <$> (lexeme $ getSourcePos <* string (opString ns o))
+          (\pos e1 e2 -> Op e1 pos () (prec, LeftFix) ns (Ident o) e2) <$> lexeme (getSourcePos <* string (opString ns o))
     mkOperatorP prec (InfixOp RightFix) ns o =
       InfixR $
         infixLabel $
-          (\pos e1 e2 -> Op e1 pos () (prec, RightFix) ns (Ident o) e2) <$> (lexeme $ getSourcePos <* string (opString ns o))
+          (\pos e1 e2 -> Op e1 pos () (prec, RightFix) ns (Ident o) e2) <$> lexeme (getSourcePos <* string (opString ns o))
     mkOperatorP prec PrefixOp ns o =
       Prefix $
         prefixLabel $
-          (\pos e -> PreOp pos () prec ns (Ident o) e) <$> (lexeme $ getSourcePos <* string (opString ns o))
+          (\pos e -> PreOp pos () prec ns (Ident o) e) <$> lexeme (getSourcePos <* string (opString ns o))
 
 parseExpr ::
   OpsTable ->
@@ -797,20 +795,20 @@ baseType :: TyParser InfernoType
 baseType = do
   (_, _, _, customTypes) <- ask
   TBase
-    <$> ( (symbol "int" *> pure TInt)
-            <|> (symbol "double" *> pure TDouble)
-            <|> (symbol "word16" *> pure TWord16)
-            <|> (symbol "word32" *> pure TWord32)
-            <|> (symbol "word64" *> pure TWord64)
-            <|> (symbol "text" *> pure TText)
-            <|> try (symbol "timeDiff" *> pure TTimeDiff)
-            <|> (symbol "time" *> pure TTime)
-            <|> (symbol "resolution" *> pure TResolution)
-            <|> choice (map (\t -> symbol (pack t) *> pure (TCustom t)) customTypes)
+    <$> ( symbol "int" $> TInt
+            <|> symbol "double" $> TDouble
+            <|> symbol "word16" $> TWord16
+            <|> symbol "word32" $> TWord32
+            <|> symbol "word64" $> TWord64
+            <|> symbol "text" $> TText
+            <|> try (symbol "timeDiff" $> TTimeDiff)
+            <|> symbol "time" $> TTime
+            <|> symbol "resolution" $> TResolution
+            <|> choice (map (\t -> symbol (pack t) $> TCustom t) customTypes)
         )
 
 type_variable_raw :: TyParser Text
-type_variable_raw = (char '\'' *> takeWhile1P Nothing isAlphaNum)
+type_variable_raw = char '\'' *> takeWhile1P Nothing isAlphaNum
 
 type_variable :: TyParser Int
 type_variable = do
@@ -875,7 +873,7 @@ typeParserBase =
     enumList =
       try
         ((:) <$> enumConstructor <* symbol "," <*> enumList)
-        <|> ((: []) <$> enumConstructor)
+        <|> (: []) <$> enumConstructor
 
 typeParser :: TyParser InfernoType
 typeParser =
@@ -923,25 +921,25 @@ tyContext = lexeme $ do
   _ <- symbol "{"
   res <- listParser tyContextSingle
   _ <- symbol "}"
-  _ <- (symbol "=>" <|> symbol "⇒")
+  _ <- symbol "=>" <|> symbol "⇒"
   return res
 
 typeClass :: TyParser TypeClass
-typeClass = TypeClass <$> (lexeme typeIdent <* symbol "on") <*> (many typeParser)
+typeClass = TypeClass <$> (lexeme typeIdent <* symbol "on") <*> many typeParser
 
 tyContextSingle :: TyParser (Either TypeClass (Text, InfernoType))
-tyContextSingle = (Left <$> (symbol "requires" *> typeClass)) <|> (Right <$> ((,) <$> (symbol "implicit" *> lexeme (withReaderT (\(_, ops, m, customTypes) -> (ops, m, customTypes)) variable)) <*> (symbol ":" *> typeParser)))
+tyContextSingle = Left <$> (symbol "requires" *> typeClass) <|> Right <$> ((,) <$> (symbol "implicit" *> lexeme (withReaderT (\(_, ops, m, customTypes) -> (ops, m, customTypes)) variable)) <*> (symbol ":" *> typeParser))
 
 schemeParser :: TyParser TCScheme
 schemeParser = do
-  vars <- try (rword "forall" *> (many $ lexeme $ type_variable_raw) <* rword ".") <|> pure mempty
+  vars <- try (rword "forall" *> many (lexeme type_variable_raw) <* rword ".") <|> pure mempty
   withReaderT (\(_, ops, m, ts) -> (Map.fromList $ zip vars [0 ..], ops, m, ts)) $
     constructScheme <$> (try tyContext <|> pure []) <*> typeParser
   where
     constructScheme :: [Either TypeClass (Text, InfernoType)] -> InfernoType -> TCScheme
     constructScheme cs t =
       let (tcs, impls) = partitionEithers cs
-       in closeOver (Set.fromList tcs) $ ImplType (Map.fromList $ map (bimap (ExtIdent . Right) id) impls) t
+       in closeOver (Set.fromList tcs) $ ImplType (Map.fromList $ map (first (ExtIdent . Right)) impls) t
 
 doc :: Parser Text
 doc = do
@@ -984,24 +982,24 @@ sigVariable =
             $ concat
             $ IntMap.elems opsTable
      in lexeme $
-          (tryMany (\op -> char '(' *> (SigOpVar <$> string op) <* char ')') opList)
-            <|> (tryMany (\op -> (SigVar <$> string op)) preOpList)
-            <|> (SigVar <$> variable)
+          tryMany (\op -> char '(' *> (SigOpVar <$> string op) <* char ')') opList
+            <|> tryMany (fmap SigVar . string) preOpList
+            <|> SigVar <$> variable
 
 data QQDefinition = QQRawDef String | QQToValueDef String | InlineDef (Expr () SourcePos) deriving (Data)
 
 exprOrBuiltin :: Parser QQDefinition
 exprOrBuiltin =
-  try ((QQToValueDef . unpack) <$> lexeme (string "###" *> withReaderT (const (mempty, mempty, [])) variable <* string "###"))
-    <|> try ((QQRawDef . unpack) <$> lexeme (string "###!" *> withReaderT (const (mempty, mempty, [])) variable <* string "###"))
-    <|> (InlineDef <$> expr)
+  try (QQToValueDef . unpack <$> lexeme (string "###" *> withReaderT (const (mempty, mempty, [])) variable <* string "###"))
+    <|> try (QQRawDef . unpack <$> lexeme (string "###!" *> withReaderT (const (mempty, mempty, [])) variable <* string "###"))
+    <|> InlineDef <$> expr
 
 sigParser :: Parser (TopLevelDefn (Maybe TCScheme, QQDefinition))
 sigParser =
-  ( try (Signature <$> (try (Just <$> doc) <|> pure Nothing) <*> sigVariable <*> ((,) <$> (try (Just <$> (symbol ":" *> (withReaderT (\(ops, m, customTypes) -> (mempty, ops, m, customTypes)) schemeParser))) <|> pure Nothing) <*> (symbol ":=" *> exprOrBuiltin)))
+  ( try (Signature <$> (try (Just <$> doc) <|> pure Nothing) <*> sigVariable <*> ((,) <$> (try (Just <$> (symbol ":" *> withReaderT (\(ops, m, customTypes) -> (mempty, ops, m, customTypes)) schemeParser)) <|> pure Nothing) <*> (symbol ":=" *> exprOrBuiltin)))
       <|> try (EnumDef <$> (Just <$> doc) <*> (symbol "enum" *> lexeme variable <* symbol ":=") <*> enumConstructors)
-      <|> (EnumDef Nothing <$> (symbol "enum" *> lexeme variable <* symbol ":=") <*> enumConstructors)
-      <|> TypeClassInstance <$> (symbol "define" *> (withReaderT (\(ops, m, customTypes) -> (mempty, ops, m, customTypes)) typeClass))
+      <|> EnumDef Nothing <$> (symbol "enum" *> lexeme variable <* symbol ":=") <*> enumConstructors
+      <|> TypeClassInstance <$> (symbol "define" *> withReaderT (\(ops, m, customTypes) -> (mempty, ops, m, customTypes)) typeClass)
       <|> Export <$> (symbol "export" *> (ModuleName <$> lexeme variable))
   )
     <* symbol ";"
@@ -1009,10 +1007,10 @@ sigParser =
 fixityP :: Parser Fixity
 fixityP =
   lexeme $
-    try (rword "infixr" *> pure (InfixOp RightFix))
-      <|> try (rword "infixl" *> pure (InfixOp LeftFix))
-      <|> try (rword "infix" *> pure (InfixOp NoFix))
-      <|> try (rword "prefix" *> pure PrefixOp)
+    try (rword "infixr" $> InfixOp RightFix)
+      <|> try (rword "infixl" $> InfixOp LeftFix)
+      <|> try (rword "infix" $> InfixOp NoFix)
+      <|> try (rword "prefix" $> PrefixOp)
 
 type OpsTable = IntMap.IntMap [(Fixity, Scoped ModuleName, Text)]
 
@@ -1022,7 +1020,7 @@ fixityLvl = try (lexeme Lexer.decimal >>= check)
     check x =
       if x >= 0 && x < 20
         then return x
-        else fail $ "Fixity level annotation must be between 0 and 19 (inclusive)"
+        else fail "Fixity level annotation must be between 0 and 19 (inclusive)"
 
 sigsParser :: Parser (OpsTable, [TopLevelDefn (Maybe TCScheme, QQDefinition)])
 sigsParser =

--- a/inferno-core/src/Inferno/Parse.hs
+++ b/inferno-core/src/Inferno/Parse.hs
@@ -997,7 +997,7 @@ exprOrBuiltin =
 sigParser :: Parser (TopLevelDefn (Maybe TCScheme, QQDefinition))
 sigParser =
   ( try (Signature <$> (try (Just <$> doc) <|> pure Nothing) <*> sigVariable <*> ((,) <$> (try (Just <$> (symbol ":" *> withReaderT (\(ops, m, customTypes) -> (mempty, ops, m, customTypes)) schemeParser)) <|> pure Nothing) <*> (symbol ":=" *> exprOrBuiltin)))
-      <|> try (EnumDef <$> (Just <$> doc) <*> (symbol "enum" *> lexeme variable <* symbol ":=") <*> enumConstructors)
+      <|> try ((EnumDef . Just <$> doc) <*> (symbol "enum" *> lexeme variable <* symbol ":=") <*> enumConstructors)
       <|> EnumDef Nothing <$> (symbol "enum" *> lexeme variable <* symbol ":=") <*> enumConstructors
       <|> TypeClassInstance <$> (symbol "define" *> withReaderT (\(ops, m, customTypes) -> (mempty, ops, m, customTypes)) typeClass)
       <|> Export <$> (symbol "export" *> (ModuleName <$> lexeme variable))

--- a/inferno-core/src/Inferno/Parse/Commented.hs
+++ b/inferno-core/src/Inferno/Parse/Commented.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveFoldable #-}
-{-# LANGUAGE DeriveTraversable #-}
-{-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 
 module Inferno.Parse.Commented where
@@ -72,7 +66,7 @@ insertCommentIntoPat comment e =
       x : xs -> x : insertTuple xs
 
 insertCommentIntoExpr :: Comment SourcePos -> Expr hash SourcePos -> Expr hash SourcePos
-insertCommentIntoExpr comment expr = go' expr
+insertCommentIntoExpr comment = go'
   where
     (startC, endC) = blockPosition comment
     commentIsWithin s e = s <= startC && endC <= e
@@ -203,7 +197,7 @@ insertCommentIntoExpr comment expr = go' expr
                               then ArrayComp p1 (go' e1) posOfBar args mcond p2
                               else
                                 let (args', mcond') = arrayCompGo' mcond $ toList args
-                                 in ArrayComp p1 e1 posOfBar (fromList $ args') mcond' p2
+                                 in ArrayComp p1 e1 posOfBar (fromList args') mcond' p2
                           CommentAfter e1 c -> CommentAfter (go' e1) c
                           CommentBelow e1 c -> CommentBelow (go' e1) c
                           Bracketed p1 e1 p2 -> Bracketed p1 (go' e1) p2

--- a/inferno-core/src/Inferno/Utils/QQ/Common.hs
+++ b/inferno-core/src/Inferno/Utils/QQ/Common.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TemplateHaskellQuotes #-}
 
 module Inferno.Utils.QQ.Common where
 
@@ -18,7 +18,7 @@ location' :: Q SourcePos
 location' = aux <$> location
   where
     aux :: Loc -> SourcePos
-    aux loc = let (l, c) = (loc_start loc) in SourcePos (loc_filename loc) (mkPos l) (mkPos c)
+    aux loc = let (l, c) = loc_start loc in SourcePos (loc_filename loc) (mkPos l) (mkPos c)
 
 -- fix for https://stackoverflow.com/questions/38143464/cant-find-inerface-file-declaration-for-variable
 liftText :: Text -> Q Exp
@@ -27,8 +27,8 @@ liftText txt = AppE (VarE 'Text.pack) <$> lift (Text.unpack txt)
 mkParseErrorStr :: ShowErrorComponent e => (ParseError Text e, SourcePos) -> String
 mkParseErrorStr (err, SourcePos {..}) =
   "Error at line "
-    <> (show $ unPos sourceLine)
+    <> show (unPos sourceLine)
     <> " column "
-    <> (show $ unPos sourceColumn)
+    <> show (unPos sourceColumn)
     <> "\n        "
-    <> (Text.unpack $ Text.replace "\n" "\n        " $ Text.pack $ prettyError err)
+    <> Text.unpack (Text.replace "\n" "\n        " $ Text.pack $ prettyError err)

--- a/inferno-core/test/Infer/Spec.hs
+++ b/inferno-core/test/Infer/Spec.hs
@@ -41,15 +41,15 @@ inferTests = describe "infer" $
 
     let tv i = TVar (TV {unTV = i})
     let makeTCs name params = TypeClass {className = name, params = params}
-    let addTC ts = makeTCs "addition" ts
-    let mulTC ts = makeTCs "multiplication" ts
-    let negTC ts = makeTCs "negate" ts
-    let numTC ts = makeTCs "numeric" ts
-    let ordTC ts = makeTCs "order" ts
-    let repTC ts = makeTCs "rep" ts
+    let addTC = makeTCs "addition"
+    let mulTC = makeTCs "multiplication"
+    let negTC = makeTCs "negate"
+    let numTC = makeTCs "numeric"
+    let ordTC = makeTCs "order"
+    let repTC = makeTCs "rep"
     let makeType numTypeVars typeClassList t = ForallTC (map (\i -> TV {unTV = i}) [0 .. numTypeVars]) (Set.fromList typeClassList) (ImplType mempty t)
 
-    inferno <- runIO $ (mkInferno Prelude.builtinModules [] :: IO (Interpreter IO ()))
+    inferno <- runIO (mkInferno Prelude.builtinModules [] :: IO (Interpreter IO ()))
     let shouldInferTypeFor str t =
           it ("should infer type of \"" <> unpack str <> "\"") $
             case parseAndInfer inferno str of
@@ -62,7 +62,7 @@ inferTests = describe "infer" $
               Left (ParseError err) -> expectationFailure $ prettyError $ fst $ NEList.head err
               Left (PinError _err) -> pure ()
               Left (InferenceError _err) -> pure ()
-              Right _ -> expectationFailure $ "Should fail to infer a type"
+              Right _ -> expectationFailure "Should fail to infer a type"
 
     shouldInferTypeFor "3" $
       makeType 0 [numTC [tv 0], repTC [tv 0]] (TVar $ TV {unTV = 0})
@@ -340,13 +340,13 @@ inferTests = describe "infer" $
     shouldBeExhaustive patts =
       it ("patterns\n      " <> printPatts patts <> "\n    should be exhaustive") $
         case exhaustive enum_sigs $ map (: []) patts of
-          Just _ps -> expectationFailure $ "These patterns should be exhaustive"
+          Just _ps -> expectationFailure "These patterns should be exhaustive"
           Nothing -> pure ()
     shouldBeInexhaustive patts =
       it ("patterns\n      " <> printPatts patts <> "\n    should be inexhaustive") $
         case exhaustive enum_sigs $ map (: []) patts of
           Just _ps -> pure ()
-          Nothing -> expectationFailure $ "These patterns should be inexhaustive"
+          Nothing -> expectationFailure "These patterns should be inexhaustive"
     shouldBeUseful patts =
       it ("patterns\n      " <> printPatts patts <> "\n    should be useful") $
         checkUsefullness enum_sigs (map (: []) patts) `shouldBe` []

--- a/inferno-core/test/Parse/Spec.hs
+++ b/inferno-core/test/Parse/Spec.hs
@@ -1,11 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Parse.Spec where
 
+import Control.Monad (void)
+import Data.Bifunctor (second)
 import Data.Functor.Foldable (ana, project)
 import qualified Data.List.NonEmpty as NonEmpty
 import Data.Text (Text, pack, unpack)
@@ -53,7 +54,7 @@ normalizeExpr = ana $ \case
   PreOp pos hsh prec LocalScope (Ident "-") e -> case normalizeExpr e of
     Lit l' (LInt x) -> project $ Lit l' $ LInt $ -x
     Lit l' (LDouble x) -> project $ Lit l' $ LDouble $ -x
-    PreOp _ _ _ LocalScope (Ident "-") e' -> project $ e'
+    PreOp _ _ _ LocalScope (Ident "-") e' -> project e'
     e' -> project $ PreOp pos hsh prec LocalScope (Ident "-") e'
   Tuple p1 xs p2 -> project $ Tuple p1 (fmap (\(e, _) -> (normalizeExpr e, Nothing)) xs) p2
   Record p1 xs p2 -> project $ Record p1 (fmap (\(f, e, _) -> (f, normalizeExpr e, Nothing)) xs) p2
@@ -67,7 +68,7 @@ normalizeExpr = ana $ \case
         (normalizeExpr e_body)
         p2
         (fmap (\(p4, x, p5, e, _) -> (p4, x, p5, normalizeExpr e, Nothing)) args)
-        (fmap (\(p4, e) -> (p4, normalizeExpr e)) e_cond)
+        (fmap (second normalizeExpr) e_cond)
         p3
   Bracketed _ e _ -> project $ normalizeExpr e
   Op e1 p1 h (_, fix) modNm i e2 -> project $ Op (normalizeExpr e1) p1 h (0, fix) modNm i (normalizeExpr e2)
@@ -88,18 +89,18 @@ parsingTests = describe "pretty printing/parsing" $ do
           Left err ->
             property False
               <?> ( "Pretty: \n"
-                      <> (renderPretty x)
+                      <> renderPretty x
                       <> "\nParse error:\n"
-                      <> (pack $ prettyError $ fst $ NonEmpty.head err)
+                      <> pack (prettyError $ fst $ NonEmpty.head err)
                   )
           Right (res, _comments) ->
-            (normalizeExpr (removeComments x) === normalizeExpr (fmap (const ()) res))
+            (normalizeExpr (removeComments x) === normalizeExpr (void res))
               <?> ( "Pretty: \n"
-                      <> (renderPretty x)
+                      <> renderPretty x
                       <> "\nParsed: \n"
-                      <> (toStrict $ pShow res)
+                      <> toStrict (pShow res)
                       <> "\nParsed pretty: \n"
-                      <> (renderPretty res)
+                      <> renderPretty res
                   )
 
   describe "parsing literals" $ do
@@ -119,7 +120,7 @@ parsingTests = describe "pretty printing/parsing" $ do
     shouldFailFor "\"0X\nFF\""
 
   describe "parsing interpolated strings" $ do
-    shouldSucceedFor "``" $ InterpolatedString () (SomeIStr $ ISEmpty) ()
+    shouldSucceedFor "``" $ InterpolatedString () (SomeIStr ISEmpty) ()
     shouldSucceedFor "`hello\nworld`" $ InterpolatedString () (SomeIStr (ISStr "hello\nworld" ISEmpty)) ()
     shouldSucceedFor "`${1}`" $ InterpolatedString () (SomeIStr (ISExpr ((), Lit () (LInt 1), ()) ISEmpty)) ()
     shouldSucceedFor "`hello\nworld${1}`" $ InterpolatedString () (SomeIStr (ISStr "hello\nworld" (ISExpr ((), Lit () (LInt 1), ()) ISEmpty))) ()
@@ -171,7 +172,7 @@ parsingTests = describe "pretty printing/parsing" $ do
   describe "parsing records" $ do
     let r = Record () [(Ident "name", Lit () (LText "Zaphod"), Just ()), (Ident "age", Lit () (LInt 391), Nothing)] ()
     shouldSucceedFor "{}" $ Record () [] ()
-    shouldSucceedFor "{name = \"Zaphod\"; age = 391}" $ r
+    shouldSucceedFor "{name = \"Zaphod\"; age = 391}" r
     -- Records are parsed as Var, converted to RecordField later in pinExpr:
     let varRecordAccess = Var () () (Scope (ModuleName "r")) (Expl (ExtIdent (Right "age")))
     shouldSucceedFor "let r = {name = \"Zaphod\"; age = 391} in r.age" $
@@ -267,10 +268,10 @@ parsingTests = describe "pretty printing/parsing" $ do
     shouldSucceedFor str ast =
       it ("should succeed for \"" <> unpack str <> "\"") $
         case parseExpr (baseOpsTable prelude) (builtinModulesOpsTable prelude) [] str of
-          Left err -> expectationFailure $ "Failed with: " <> (prettyError $ fst $ NonEmpty.head err)
-          Right (res, _) -> fmap (const ()) res `shouldBe` ast
+          Left err -> expectationFailure $ "Failed with: " <> prettyError (fst $ NonEmpty.head err)
+          Right (res, _) -> void res `shouldBe` ast
     shouldFailFor str =
       it ("should fail for \"" <> unpack str <> "\"") $
         case parseExpr (baseOpsTable prelude) (builtinModulesOpsTable prelude) [] str of
           Left _err -> pure ()
-          Right _res -> expectationFailure $ "This should not parse"
+          Right _res -> expectationFailure "This should not parse"

--- a/inferno-lsp/CHANGELOG.md
+++ b/inferno-lsp/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Revision History for inferno-lsp
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.2.4.0 -- 2024-03-18
+* HLint everything
+
 ## 0.2.3.0 -- 2024-03-12
 * Update inferno-types and inferno-core version; fix `parseAndInferTypeReps`
 

--- a/inferno-lsp/inferno-lsp.cabal
+++ b/inferno-lsp/inferno-lsp.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                inferno-lsp
-version:             0.2.3.0
+version:             0.2.4.0
 synopsis:            LSP for Inferno
 description:         A language server protocol implementation for the Inferno language
 category:            IDE,DSL,Scripting

--- a/inferno-lsp/src/Inferno/LSP/ParseInfer.hs
+++ b/inferno-lsp/src/Inferno/LSP/ParseInfer.hs
@@ -5,7 +5,7 @@
 
 module Inferno.LSP.ParseInfer where
 
-import Control.Monad (forM_)
+import Control.Monad (forM_, void)
 import Control.Monad.IO.Class (MonadIO (..))
 import Data.Either (isLeft)
 import Data.List (find, findIndices, foldl', nub, sort)
@@ -135,7 +135,7 @@ inferErrorDiagnostic = \case
         (unPos $ sourceLine e)
         (unPos $ sourceColumn e)
         $ renderDoc
-        $ "Could not unify" <+> pretty tv <+> "~" <+> (pretty $ closeOverType t)
+        $ "Could not unify" <+> pretty tv <+> "~" <+> pretty (closeOverType t)
     ]
   UnboundExtIdent modNm v (s, e) ->
     [ errorDiagnosticInfer
@@ -223,9 +223,9 @@ inferErrorDiagnostic = \case
         $ renderDoc
         $ vsep
           [ "The implicit variable '" <> case ident of { Left i -> "var$" <> pretty i; Right i -> pretty i } <> "' has multiple types:",
-            indent 2 (pretty $ closeOverType $ t1),
+            indent 2 (pretty $ closeOverType t1),
             "and",
-            indent 2 (pretty $ closeOverType $ t2)
+            indent 2 (pretty $ closeOverType t2)
           ]
     ]
   VarMultipleOccurrence (Ident x) (s2, e2) (s1, e1) ->
@@ -241,13 +241,13 @@ inferErrorDiagnostic = \case
             (unPos $ sourceColumn s1)
             (unPos $ sourceLine e1)
             (unPos $ sourceColumn e1)
-            $ message,
+            message,
           errorDiagnosticInfer
             (unPos $ sourceLine s2)
             (unPos $ sourceColumn s2)
             (unPos $ sourceLine e2)
             (unPos $ sourceColumn e2)
-            $ message
+            message
         ]
   IfConditionMustBeBool _ t (s, e) ->
     [ errorDiagnosticInfer
@@ -287,13 +287,13 @@ inferErrorDiagnostic = \case
             (unPos $ sourceColumn s1)
             (unPos $ sourceLine e1)
             (unPos $ sourceColumn e1)
-            $ message,
+            message,
           errorDiagnosticInfer
             (unPos $ sourceLine s2)
             (unPos $ sourceColumn s2)
             (unPos $ sourceLine e2)
             (unPos $ sourceColumn e2)
-            $ message
+            message
         ]
   CaseBranchesMustBeEqType _ t1 t2 (s1, e1) (s2, e2) ->
     let message =
@@ -309,13 +309,13 @@ inferErrorDiagnostic = \case
             (unPos $ sourceColumn s1)
             (unPos $ sourceLine e1)
             (unPos $ sourceColumn e1)
-            $ message,
+            message,
           errorDiagnosticInfer
             (unPos $ sourceLine s2)
             (unPos $ sourceColumn s2)
             (unPos $ sourceLine e2)
             (unPos $ sourceColumn e2)
-            $ message
+            message
         ]
   PatternUnificationFail tPat tE p (s, e) ->
     [ errorDiagnosticInfer
@@ -346,13 +346,13 @@ inferErrorDiagnostic = \case
             (unPos $ sourceColumn s1)
             (unPos $ sourceLine e1)
             (unPos $ sourceColumn e1)
-            $ message,
+            message,
           errorDiagnosticInfer
             (unPos $ sourceLine s2)
             (unPos $ sourceColumn s2)
             (unPos $ sourceLine e2)
             (unPos $ sourceColumn e2)
-            $ message
+            message
         ]
   NonExhaustivePatternMatch pat (s, e) ->
     [ errorDiagnosticInfer
@@ -364,7 +364,7 @@ inferErrorDiagnostic = \case
         $ vsep
           [ "The patterns in this case expression are non-exhaustive.",
             "For example, the following pattern is missing:",
-            indent 2 (pretty $ pat)
+            indent 2 (pretty pat)
           ]
     ]
   UselessPattern (Just pat) (s, e) ->
@@ -376,7 +376,7 @@ inferErrorDiagnostic = \case
         $ renderDoc
         $ vsep
           [ "This case is unreachable, since it is subsumed by the previous pattern",
-            indent 2 (pretty $ pat)
+            indent 2 (pretty pat)
           ]
     ]
   UselessPattern Nothing (s, e) ->
@@ -385,8 +385,7 @@ inferErrorDiagnostic = \case
         (unPos $ sourceColumn s)
         (unPos $ sourceLine e)
         (unPos $ sourceColumn e)
-        $ renderDoc
-        $ "This case is unreachable, since it is subsumed by the previous patterns"
+        $ renderDoc "This case is unreachable, since it is subsumed by the previous patterns"
     ]
   -- TypeClassUnificationError t1 t2 tcs (s, e) ->
   --   [ errorDiagnosticInfer
@@ -480,7 +479,7 @@ inferErrorDiagnostic = \case
             "you are trying to import from",
             indent 2 (pretty m),
             "already exists in local scope and would be overshadowed. Consider using:",
-            indent 2 $ (pretty m) <> "." <> (pretty i)
+            indent 2 $ pretty m <> "." <> pretty i
           ]
     ]
   CouldNotFindTypeclassWitness tyCls (s, e) ->
@@ -507,16 +506,13 @@ parseAndInferDiagnostics ::
 parseAndInferDiagnostics Interpreter {parseAndInfer, typeClasses} idents txt validateInput = do
   let input = case idents of
         [] -> "\n" <> txt
-        ids -> "fun " <> (Text.intercalate " " $ map (maybe "_" (\(Ident i) -> i)) ids) <> " -> \n" <> txt
+        ids -> "fun " <> Text.intercalate " " (map (maybe "_" (\(Ident i) -> i)) ids) <> " -> \n" <> txt
   -- AppConfig _ _ tracer <- ask
   -- let trace = const $ pure () --traceWith tracer
   case parseAndInfer input of
-    Left (ParseError err) -> do
-      return $ Left $ fmap parseErrorDiagnostic $ NEList.toList err
-    Left (PinError err) -> do
-      return $ Left $ concatMap inferErrorDiagnostic $ Set.toList $ Set.fromList err
-    Left (InferenceError err) -> do
-      return $ Left $ concatMap inferErrorDiagnostic $ Set.toList $ Set.fromList err
+    Left (ParseError err) -> return $ Left (parseErrorDiagnostic <$> NEList.toList err)
+    Left (PinError err) -> return $ Left $ concatMap inferErrorDiagnostic $ Set.toList $ Set.fromList err
+    Left (InferenceError err) -> return $ Left $ concatMap inferErrorDiagnostic $ Set.toList $ Set.fromList err
     Right (pinnedAST', tcSch@(ForallTC _ currentClasses (ImplType _ typSig)), tyMap, comments) -> do
       let signature = collectArrs typSig
       -- Validate input types
@@ -529,12 +525,12 @@ parseAndInferDiagnostics Interpreter {parseAndInfer, typeClasses} idents txt val
             Left errors -> return $ Left errors
             Right () -> do
               -- Insert comments into Lam body
-              let final = putBackLams lams $ fmap (const ()) $ insertCommentsIntoExpr comments lamBody
+              let final = putBackLams lams (void (insertCommentsIntoExpr comments lamBody))
               return $
                 Right
                   ( final,
                     tcSch,
-                    Map.foldrWithKey (\k v xs -> (mkHover typeClasses currentClasses k v) : xs) mempty tyMap
+                    Map.foldrWithKey (\k v xs -> mkHover typeClasses currentClasses k v : xs) mempty tyMap
                   )
   where
     -- Extract and replace outermost Lams so that comments can be inserted into script body.
@@ -542,11 +538,11 @@ parseAndInferDiagnostics Interpreter {parseAndInfer, typeClasses} idents txt val
     extractLams lams = \case
       Lam _ xs _ e -> extractLams (fmap snd xs : lams) e
       e -> (lams, e)
-    putBackLams = flip $ foldl' (\e xs -> Lam () (fmap (\x -> ((), x)) xs) () e)
+    putBackLams = flip $ foldl' (\e xs -> Lam () (fmap ((),) xs) () e)
 
     checkScriptIsNotAFunction signature parameters =
       -- A function with N parameters should have a signature a_1 -> a_2 -> ... -> a_{N+1}
-      if length signature > (length parameters + 1)
+      if length signature > length parameters + 1
         then Left [errorDiagnosticInfer 0 0 0 2 $ renderDoc $ vsep ["This script evaluates to a function. Did you mean to add input parameters instead?"]]
         else Right ()
 
@@ -570,7 +566,7 @@ parseAndInferDiagnostics Interpreter {parseAndInfer, typeClasses} idents txt val
 parseAndInferPretty :: forall c. (Pretty c, Eq c) => ModuleMap IO c -> Text -> IO ()
 parseAndInferPretty prelude txt = do
   interpreter@(Interpreter {typeClasses}) <- mkInferno prelude []
-  (parseAndInferDiagnostics @IO @c interpreter) [] txt (const $ Right ()) >>= \case
+  parseAndInferDiagnostics @IO @c interpreter [] txt (const $ Right ()) >>= \case
     Left err -> print err
     Right (expr, typ, _hovers) -> do
       putStrLn $ Text.unpack $ "internal: " <> renderPretty expr
@@ -579,16 +575,16 @@ parseAndInferPretty prelude txt = do
 
       putStrLn $ Text.unpack $ "\ntype: " <> renderPretty typ
 
-      putStrLn $ "\ntype (pretty)" <> (Text.unpack $ renderDoc $ mkPrettyTy typeClasses mempty typ)
+      putStrLn $ "\ntype (pretty)" <> Text.unpack (renderDoc $ mkPrettyTy typeClasses mempty typ)
 
 parseAndInferTypeReps :: forall c. (Pretty c, Eq c) => ModuleMap IO c -> Text -> [Text] -> Text -> IO ()
 parseAndInferTypeReps prelude expr inTys outTy = do
   interpreter@(Interpreter {typeClasses}) <- mkInferno prelude []
-  (parseAndInferDiagnostics @IO @c interpreter) [] expr (const $ Right ()) >>= \case
+  parseAndInferDiagnostics @IO @c interpreter [] expr (const $ Right ()) >>= \case
     Left err -> print err
     Right (_expr, typ, _hovers) -> do
       putStrLn $ Text.unpack $ "\ntype: " <> renderPretty typ
-      putStrLn $ "\ntype (pretty)" <> (Text.unpack $ renderDoc $ mkPrettyTy typeClasses mempty typ)
+      putStrLn $ "\ntype (pretty)" <> Text.unpack (renderDoc $ mkPrettyTy typeClasses mempty typ)
 
       case traverse parseType inTys of
         Left errs -> print errs
@@ -607,15 +603,15 @@ parseAndInferPossibleTypes :: forall c. (Pretty c, Eq c) => ModuleMap IO c -> Te
 parseAndInferPossibleTypes prelude expr args inTys outTy = do
   let argIdents = map (Just . Ident) args
   interpreter@(Interpreter {typeClasses}) <- mkInferno prelude []
-  (parseAndInferDiagnostics @IO @c interpreter) argIdents expr (const $ Right ()) >>= \case
+  parseAndInferDiagnostics @IO @c interpreter argIdents expr (const $ Right ()) >>= \case
     Left err -> print err
     Right (_expr, typ, _hovers) -> do
       putStrLn $ Text.unpack $ "\ntype: " <> renderPretty typ
-      putStrLn $ "\ntype (pretty)" <> (Text.unpack $ renderDoc $ mkPrettyTy typeClasses mempty typ)
+      putStrLn $ "\ntype (pretty)" <> Text.unpack (renderDoc $ mkPrettyTy typeClasses mempty typ)
 
       case traverse (maybe (pure Nothing) ((Just <$>) . parseType)) inTys of
         Left errs -> print errs
-        Right inTysParsed -> case (maybe (pure Nothing) ((Just <$>) . parseType)) outTy of
+        Right inTysParsed -> case maybe (pure Nothing) ((Just <$>) . parseType) outTy of
           Left errTy -> print errTy
           Right outTyParsed ->
             case inferPossibleTypes typeClasses typ inTysParsed outTyParsed of
@@ -631,13 +627,13 @@ parseAndInferPossibleTypes prelude expr args inTys outTy = do
 mkHover :: Set.Set TypeClass -> Set.Set TypeClass -> (SourcePos, SourcePos) -> TypeMetadata TCScheme -> (Range, MarkupContent)
 mkHover allClasses currentClasses (s, e) meta@TypeMetadata {identExpr = expr, ty = tcSchTy} =
   let prettyTy = mkPrettyTy allClasses currentClasses tcSchTy
-   in ( mkRange ((fromIntegral $ unPos $ sourceLine s) - 2) ((fromIntegral $ unPos $ sourceColumn s) - 1) ((fromIntegral $ unPos $ sourceLine e) - 2) ((fromIntegral $ unPos $ sourceColumn e) - 1),
+   in ( mkRange (fromIntegral (unPos $ sourceLine s) - 2) (fromIntegral (unPos $ sourceColumn s) - 1) (fromIntegral (unPos $ sourceLine e) - 2) (fromIntegral (unPos $ sourceColumn e) - 1),
         MarkupContent MkMarkdown $
           "**Type**\n"
             <> "~~~inferno\n"
-            <> (renderDoc $ pretty expr <+> align prettyTy)
+            <> renderDoc (pretty expr <+> align prettyTy)
             <> "\n~~~"
-            <> (maybe "" ("\n" <>) (getTypeMetadataText meta))
+            <> maybe "" ("\n" <>) (getTypeMetadataText meta)
       )
 
 mkPrettyTy :: forall ann. Set.Set TypeClass -> Set.Set TypeClass -> TCScheme -> Doc ann
@@ -656,8 +652,8 @@ mkPrettyTy allClasses currentClasses (ForallTC _tvs cls typ) =
             let prettyList = map pretty $ nub $ sort $ map (flip apply $ filterOutImplicitTypeReps typ) subs
                 prettyListMax10 = take 10 prettyList
              in if length prettyListMax10 == length prettyList
-                  then (sep $ unionTySig prettyList)
-                  else (sep $ unionTySig $ prettyList <> ["..."])
+                  then sep $ unionTySig prettyList
+                  else sep $ unionTySig $ prettyList <> ["..."]
   where
     unionTySig [] = []
     unionTySig (t : ts) = (":" <+> t) : go ts
@@ -680,7 +676,7 @@ getTypeMetadataText TypeMetadata {docs = tcsDocs, ty = ForallTC _ _ (ImplType _ 
             <> hardline
             <> "enum"
             <+> pretty nm
-            <+> align (sep $ "=" : (punctuate' "|" $ map (("#" <>) . pretty . unIdent) $ Set.toList cs))
+            <+> align (sep $ "=" : punctuate' "|" (map (("#" <>) . pretty . unIdent) $ Set.toList cs))
               <> hardline
               <> "~~~"
       _ -> Just $ pretty (fromMaybe "" tcsDocs)

--- a/inferno-ml/CHANGELOG.md
+++ b/inferno-ml/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Revision History for inferno-ml
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.3.3.0 -- 2024-03-18
+* HLint everything
+
 ## 0.3.0.0 -- 2024-02-26
 * Breaking change: add `VExtended` constructor to `MlValue`
 * Add `toType` primitive

--- a/inferno-ml/inferno-ml.cabal
+++ b/inferno-ml/inferno-ml.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                inferno-ml
-version:             0.3.0.0
+version:             0.3.1.0
 synopsis:            Machine Learning primitives for Inferno
 description:         Machine Learning primitives for Inferno
 homepage:            https://github.com/plow-technologies/inferno.git#readme

--- a/inferno-ml/src/Inferno/ML/Module/Prelude.hs
+++ b/inferno-ml/src/Inferno/ML/Module/Prelude.hs
@@ -111,19 +111,19 @@ asArray4Fun :: Tensor -> [[[[Double]]]]
 asArray4Fun t = asValue $ toType TD.Double t
 
 argmaxFun :: Int -> Bool -> Tensor -> Tensor
-argmaxFun i keepDim t = argmax (Dim i) (if keepDim then KeepDim else RemoveDim) t
+argmaxFun i keepDim = argmax (Dim i) (if keepDim then KeepDim else RemoveDim)
 
 softmaxFun :: Int -> Tensor -> Tensor
-softmaxFun i t = softmax (Dim i) t
+softmaxFun i = softmax (Dim i)
 
 stackFun :: Int -> [Tensor] -> Tensor
-stackFun i t = Torch.stack (Dim i) t
+stackFun i = Torch.stack (Dim i)
 
 tanHTFun :: Tensor -> Tensor
 tanHTFun = Torch.Functional.tanh
 
 powTFun :: Int -> Tensor -> Tensor
-powTFun i t = pow i t
+powTFun = pow
 
 loadModelFun :: Text -> ScriptModule
 loadModelFun f = unsafePerformIO $ TS.loadScript TS.WithoutRequiredGrad $ unpack f

--- a/inferno-ml/test/Spec.hs
+++ b/inferno-ml/test/Spec.hs
@@ -51,7 +51,7 @@ evalTests = describe "evaluate" $
     Interpreter {evalExpr, defaultEnv, parseAndInfer, parseAndInferTypeReps} <-
       runIO $ mkInferno @_ @(MlValue ()) mlPrelude customTypes
     let shouldEvaluateInEnvTo implEnv str (v :: Value (MlValue ()) IO) =
-          it ("\"" <> unpack str <> "\" should evaluate to " <> (unpack $ renderPretty v)) $ do
+          it ("\"" <> unpack str <> "\" should evaluate to " <> unpack (renderPretty v)) $ do
             case parseAndInferTypeReps str of
               Left err -> expectationFailure $ show err
               Right ast ->

--- a/inferno-types/CHANGELOG.md
+++ b/inferno-types/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Revision History for inferno-types
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.4.1.0 -- 2024-03-18
+* HLint everything
+
 ## 0.4.0.0 -- 2024-03-12
 * Add record types to InfernoType, Value, and Expr
 

--- a/inferno-types/inferno-types.cabal
+++ b/inferno-types/inferno-types.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                inferno-types
-version:             0.4.0.0
+version:             0.4.1.0
 synopsis:            Core types for Inferno
 description:         Core types for the Inferno language
 category:            DSL,Scripting

--- a/inferno-types/src/Inferno/Types/Type.hs
+++ b/inferno-types/src/Inferno/Types/Type.hs
@@ -1,7 +1,4 @@
-
-
 {-# LANGUAGE DerivingVia #-}
-
 
 module Inferno.Types.Type
   ( BaseType (..),

--- a/inferno-types/src/Inferno/Types/Type.hs
+++ b/inferno-types/src/Inferno/Types/Type.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DerivingStrategies #-}
+
+
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
 
 module Inferno.Types.Type
   ( BaseType (..),

--- a/inferno-types/src/Inferno/Types/Value.hs
+++ b/inferno-types/src/Inferno/Types/Value.hs
@@ -59,7 +59,7 @@ instance NFData custom => NFData (Value custom m) where
   rnf (VWord64 x) = x `seq` ()
   rnf (VEpochTime x) = x `seq` ()
   rnf (VText x) = rnf x
-  rnf (VEnum hash i) = rnf hash `seq` rnf i `seq` ()
+  rnf (VEnum hash i) = rnf hash `seq` rnf i
   rnf (VArray xs) = rnf xs
   rnf (VTuple xs) = rnf xs
   rnf (VRecord xs) = rnf xs
@@ -80,8 +80,8 @@ instance Eq c => Eq (Value c m) where
   (VEnum h1 e1) == (VEnum h2 e2) = h1 == h2 && e1 == e2
   (VOne v1) == (VOne v2) = v1 == v2
   VEmpty == VEmpty = True
-  (VArray a1) == (VArray a2) = length a1 == length a2 && (foldr ((&&) . (uncurry (==))) True $ zip a1 a2)
-  (VTuple a1) == (VTuple a2) = length a1 == length a2 && (foldr ((&&) . (uncurry (==))) True $ zip a1 a2)
+  (VArray a1) == (VArray a2) = length a1 == length a2 && foldr ((&&) . uncurry (==)) True (zip a1 a2)
+  (VTuple a1) == (VTuple a2) = length a1 == length a2 && foldr ((&&) . uncurry (==)) True (zip a1 a2)
   (VRecord fs1) == (VRecord fs2) =
     Map.size fs1 == Map.size fs2 && Map.toAscList fs1 == Map.toAscList fs2
   (VTypeRep t1) == (VTypeRep t2) = t1 == t2
@@ -92,9 +92,9 @@ instance Pretty c => Pretty (Value c m) where
   pretty = \case
     VInt n -> pretty n
     VDouble n -> pretty n
-    VWord16 w -> "0x" <> (pretty $ showHex w "")
-    VWord32 w -> "0x" <> (pretty $ showHex w "")
-    VWord64 w -> "0x" <> (pretty $ showHex w "")
+    VWord16 w -> "0x" <> pretty (showHex w "")
+    VWord32 w -> "0x" <> pretty (showHex w "")
+    VWord64 w -> "0x" <> pretty (showHex w "")
     VText t -> pretty $ Text.pack $ show t
     VEnum _ (Ident s) -> "#" <> pretty s
     VArray vs -> encloseSep lbracket rbracket comma $ map pretty vs

--- a/inferno-types/src/Inferno/Types/VersionControl.hs
+++ b/inferno-types/src/Inferno/Types/VersionControl.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE DeriveAnyClass #-}
-
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}

--- a/inferno-types/src/Inferno/Utils/Prettyprinter.hs
+++ b/inferno-types/src/Inferno/Utils/Prettyprinter.hs
@@ -19,4 +19,4 @@ renderPretty :: Pretty a => a -> Text.Text
 renderPretty = renderDoc . pretty
 
 showPretty :: MonadIO m => Pretty a => a -> m ()
-showPretty = liftIO . Text.putStrLn . (renderPretty)
+showPretty = liftIO . Text.putStrLn . renderPretty

--- a/inferno-types/src/Inferno/Utils/Prettyprinter.hs
+++ b/inferno-types/src/Inferno/Utils/Prettyprinter.hs
@@ -19,4 +19,4 @@ renderPretty :: Pretty a => a -> Text.Text
 renderPretty = renderDoc . pretty
 
 showPretty :: MonadIO m => Pretty a => a -> m ()
-showPretty = liftIO . Text.putStrLn . renderPretty
+showPretty = liftIO . Text.putStrLn . (renderPretty)

--- a/inferno-vc/CHANGELOG.md
+++ b/inferno-vc/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Revision History for inferno-vc
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.3.6.0 -- 2024-03-18
+* HLint everything
+
 ## 0.3.5.0 -- 2024-03-12
 * Update inferno-types version
 

--- a/inferno-vc/inferno-vc.cabal
+++ b/inferno-vc/inferno-vc.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                inferno-vc
-version:             0.3.5.0
+version:             0.3.6.0
 synopsis:            Version control server for Inferno
 description:         A version control server for Inferno scripts
 category:            DSL,Scripting

--- a/inferno-vc/src/Inferno/VersionControl/Server/UnzipRequest.hs
+++ b/inferno-vc/src/Inferno/VersionControl/Server/UnzipRequest.hs
@@ -19,6 +19,6 @@ ungzipRequest app req = app req'
     req'
       | Just "gzip" <- lookup "Content-encoding" (requestHeaders req) = go req
       | otherwise = req
-    go r = r {requestBody = decompressNonEmpty <$> (strictRequestBody r)}
+    go r = r {requestBody = decompressNonEmpty <$> strictRequestBody r}
     decompressNonEmpty "" = "" -- Necessary 'cause the IO gets pulled until requestBody gives ""
     decompressNonEmpty x = BL.toStrict . decompress $ x

--- a/inferno-vc/src/Inferno/VersionControl/Types.hs
+++ b/inferno-vc/src/Inferno/VersionControl/Types.hs
@@ -1,12 +1,7 @@
-{-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TypeOperators #-}
 
 module Inferno.VersionControl.Types
   ( VCObjectHash (..),
@@ -27,7 +22,7 @@ where
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Map (Map)
 import qualified Data.Map as Map
-import Data.Maybe (catMaybes)
+import Data.Maybe (mapMaybe)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text)
@@ -35,7 +30,7 @@ import Foreign.C.Types (CTime)
 import GHC.Generics (Generic)
 import Inferno.Types.Module (Module (..))
 import Inferno.Types.Syntax (Dependencies (..), Expr (..), Ident (..))
-import Inferno.Types.Type (Namespace, TCScheme (..)) -- TypeMetadata(..),
+import Inferno.Types.Type (Namespace, TCScheme (..))
 import Inferno.Types.VersionControl (Pinned (..), VCHashUpdate (..), VCObjectHash (..), pinnedUnderVCToMaybe, vcHash, vcObjectHashToByteString)
 
 data VCObject
@@ -55,8 +50,8 @@ showVCObjectType = \case
 instance Dependencies VCObject VCObjectHash where
   getDependencies = \case
     VCModule Module {moduleObjects = os} -> Set.fromList $ Map.elems os
-    VCFunction expr _ -> Set.fromList $ catMaybes $ map pinnedUnderVCToMaybe $ Set.toList $ getDependencies expr
-    VCTestFunction expr -> Set.fromList $ catMaybes $ map pinnedUnderVCToMaybe $ Set.toList $ getDependencies expr
+    VCFunction expr _ -> Set.fromList $ mapMaybe pinnedUnderVCToMaybe (Set.toList $ getDependencies expr)
+    VCTestFunction expr -> Set.fromList $ mapMaybe pinnedUnderVCToMaybe (Set.toList $ getDependencies expr)
     VCEnum _ _ -> mempty
 
 data VCObjectVisibility = VCObjectPublic | VCObjectPrivate deriving (Show, Eq, Generic, ToJSON, FromJSON, VCHashUpdate)


### PR DESCRIPTION
Spring cleaning: thought I'd get rid of all the blue squiggles while there weren't many open PRs. :)

I ran:
```bash
cabal install apply-refact hlint
for f in `git ls-files | grep -e '.*\.hs'`; do echo linting $f; hlint --refactor --refactor-options="-i" $f; done
```
And manually checked that nothing semantically changed.

~Also trying out a GitHub action that should generate lint suggestions in the PRs.~
I thought the action would add PR suggestions in the web interface which could be applied with one click, but it didn't do that, and going through the CI logs feels a bit painful. This other action might do that, but it needs some security/token set up so I'll save it for another time:
https://github.com/haskell-actions/hlint-scan

For now, it just adds a hint to the PR diff view:
![image](https://github.com/plow-technologies/inferno/assets/10712637/525849ee-555d-455d-8c50-899040b29df8)
