### PR TITLE
[inferno-ml-server-types] Split `Model` and `ModelVersion`

### DIFF
--- a/inferno-ml-server-types/CHANGELOG.md
+++ b/inferno-ml-server-types/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Revision History for inferno-ml-server-types
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.1.0
+* Split `Model` and `ModelVersion`
+
 ## 0.0.1
 * Initial pre-release

--- a/inferno-ml-server-types/inferno-ml-server-types.cabal
+++ b/inferno-ml-server-types/inferno-ml-server-types.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          inferno-ml-server-types
-version:       0.0.1
+version:       0.1.0
 synopsis:      Types for Inferno ML server
 description:   Types for Inferno ML server
 homepage:      https://github.com/plow-technologies/inferno.git#readme

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
@@ -350,9 +350,9 @@ instance
   toRow mv =
     [ toField Default,
       mv ^. the @"model" & toField,
-      mv ^. the @"version" & toField,
+      mv ^. the @"card" & Aeson & toField,
       mv ^. the @"contents" & toField,
-      mv ^. the @"card" & Aeson & toField
+      mv ^. the @"version" & toField
     ]
 
 {- ORMOLU_DISABLE -}

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
@@ -89,7 +89,10 @@ import System.Posix (EpochTime)
 import Text.Read (readMaybe)
 import URI.ByteString (Absolute, URIRef)
 import URI.ByteString.Aeson ()
-import Web.HttpApiData (FromHttpApiData (parseUrlPiece), ToHttpApiData (toUrlPiece))
+import Web.HttpApiData
+  ( FromHttpApiData (parseUrlPiece),
+    ToHttpApiData (toUrlPiece),
+  )
 
 -- API type for `inferno-ml-server`
 type InfernoMlServerAPI uid gid p s =
@@ -364,8 +367,8 @@ instance
   parseJSON = withObject "ModelVersion" $ \o ->
     ModelVersion
       -- Note that for a model serialized as JSON, the `id` must be present
-      -- (this assumes that a model serialized as JSON always refers to one
-      -- that exists in the DB already)
+      -- (this assumes that a model version serialized as JSON always refers
+      -- to one that exists in the DB already)
       <$> fmap Just (o .: "id")
       <*> o .: "model"
       <*> o .: "version"

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
@@ -369,9 +369,9 @@ instance
       -- to one that exists in the DB already)
       <$> fmap Just (o .: "id")
       <*> o .: "model"
-      <*> o .: "version"
-      <*> fmap (Oid . fromIntegral @Word64) (o .: "contents")
       <*> o .: "card"
+      <*> fmap (Oid . fromIntegral @Word64) (o .: "contents")
+      <*> o .: "version"
 {- ORMOLU_ENABLE -}
 
 instance

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
@@ -275,10 +275,8 @@ instance
   where
   parseJSON = withObject "Model" $ \o ->
     Model
-      -- Note that for a model serialized as JSON, the `id` must be present
-      -- (this assumes that a serialized model always refers to one that exists
-      -- in the DB already)
-      <$> fmap Just (o .: "id")
+      -- If a new model is being created, its ID will not be present
+      <$> o .:? "id"
       <*> (ensureNotNull =<< o .: "name")
       <*> o .: "permissions"
       <*> o .:? "user"

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
@@ -231,8 +231,7 @@ instance NFData (Model uid gid) where
   rnf = rwhnf
 
 instance
-  ( Typeable uid,
-    Typeable gid,
+  ( Typeable gid,
     FromField uid,
     FromField gid,
     FromJSONKey gid,
@@ -249,9 +248,7 @@ instance
       <*> field
 
 instance
-  ( Typeable uid,
-    Typeable gid,
-    ToField uid,
+  ( ToField uid,
     ToField gid,
     ToJSONKey gid
   ) =>
@@ -268,7 +265,6 @@ instance
 {- ORMOLU_DISABLE -}
 instance
   ( FromJSON uid,
-    FromJSON gid,
     FromJSONKey gid,
     Ord gid
   ) =>
@@ -293,7 +289,6 @@ instance
 
 instance
   ( ToJSON uid,
-    ToJSON gid,
     ToJSONKey gid
   ) =>
   ToJSON (Model uid gid)
@@ -328,9 +323,7 @@ data ModelVersion uid gid c = ModelVersion
   deriving anyclass (NFData)
 
 instance
-  ( Typeable uid,
-    Typeable gid,
-    FromField uid,
+  ( FromField uid,
     FromField gid
   ) =>
   FromRow (ModelVersion uid gid Oid)
@@ -347,11 +340,8 @@ instance
       <*> field
 
 instance
-  ( Typeable uid,
-    Typeable gid,
-    ToField uid,
-    ToField gid,
-    ToJSONKey gid
+  ( ToField uid,
+    ToField gid
   ) =>
   ToRow (ModelVersion uid gid Oid)
   where
@@ -367,9 +357,7 @@ instance
 {- ORMOLU_DISABLE -}
 instance
   ( FromJSON uid,
-    FromJSON gid,
-    FromJSONKey gid,
-    Ord gid
+    FromJSON gid
   ) =>
   FromJSON (ModelVersion uid gid Oid)
   where
@@ -387,8 +375,7 @@ instance
 
 instance
   ( ToJSON uid,
-    ToJSON gid,
-    ToJSONKey gid
+    ToJSON gid
   ) =>
   ToJSON (ModelVersion uid gid Oid)
   where


### PR DESCRIPTION
Splits the `Model` type into two parts:
- `Model`, which now just contains metadata that should not change between versions (`name`, `user`, `permissions`)
- `ModelVersion`, which contains other version-specific metadata as well as the actual model contents

Splitting the type like this helps prevent certain undesirable scenarios. For example, all model versions previously had their own `permissions`. This meant that it would be possible for a user to have access to (or even own) one version of a model, but not others. That's not what we want. 

Also, previously the different versions of a model were only linked together by their `name` field. This wasn't really structured into the database in any way. Now it is possible to get all versions of a model directly by a foreign key lookup.

I've integrated these changes on branches for the other Inferno ML projects but this will need to be merged first.

The DB tables now look like this: 

```plantuml
,------------------------.
| Model                  |
|------------------------|
| id : serial            |
| --                     |
| * name : text          |
| * permissions : jsonb  |
| user : User (id)       |
|                        |
`------------------------'
          \|/
           o
           |           
           |           
           _
           -
,------------------------. 
| ModelVersion           | 
|------------------------| 
| id : serial            | 
| --                     | 
| * model : Model (id)   | 
| * card : jsonb         | 
| * contents : oid       | 
| * version : text       | 
|                        |
`------------------------' 

```