### PR TITLE
[inferno-ml] Add `resolution` to inference params

### DIFF
--- a/inferno-ml-server-types/CHANGELOG.md
+++ b/inferno-ml-server-types/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Revision History for inferno-ml-server-types
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.5.0
+* Add `resolution` to `InferenceParam`
+
 ## 0.4.0
 * Change representation of script inputs/outputs
 

--- a/inferno-ml-server-types/inferno-ml-server-types.cabal
+++ b/inferno-ml-server-types/inferno-ml-server-types.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          inferno-ml-server-types
-version:       0.4.0
+version:       0.5.0
 synopsis:      Types for Inferno ML server
 description:   Types for Inferno ML server
 homepage:      https://github.com/plow-technologies/inferno.git#readme

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Client.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Client.hs
@@ -27,7 +27,9 @@ inferenceC ::
   -- | SQL identifier of the inference parameter to be run
   Id (InferenceParam uid gid p s) ->
   -- | Optional resolution for scripts that use e.g. @valueAt@; defaults to
-  -- 128 if not specified
+  -- the param\'s stored resolution if not provided. This lets users override
+  -- the resolution on an ad-hoc basis without needing to alter the stored
+  -- values for the parameter
   Maybe Int64 ->
   -- | Job identifer. This is used to save execution statistics for each
   -- inference evaluation

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
@@ -28,7 +28,7 @@ import Data.Data (Typeable)
 import Data.Generics.Product (HasType (typed), the)
 import Data.Generics.Wrapped (wrappedTo)
 import qualified Data.IP
-import Data.Int (Int32, Int64)
+import Data.Int (Int64)
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NonEmpty
 import Data.Map.Strict (Map)
@@ -639,7 +639,7 @@ instance
       <*> fmap wrappedTo (field @VCObjectHashRow)
       <*> field
       <*> fmap getAeson field
-      <*> fmap fromIntegral (field @Int32)
+      <*> fmap fromIntegral (field @Int64)
       <*> field
       <*> field
 

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
@@ -28,7 +28,7 @@ import Data.Data (Typeable)
 import Data.Generics.Product (HasType (typed), the)
 import Data.Generics.Wrapped (wrappedTo)
 import qualified Data.IP
-import Data.Int (Int64, Int32)
+import Data.Int (Int32, Int64)
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NonEmpty
 import Data.Map.Strict (Map)

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
@@ -28,7 +28,7 @@ import Data.Data (Typeable)
 import Data.Generics.Product (HasType (typed), the)
 import Data.Generics.Wrapped (wrappedTo)
 import qualified Data.IP
-import Data.Int (Int64)
+import Data.Int (Int64, Int32)
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NonEmpty
 import Data.Map.Strict (Map)
@@ -614,6 +614,8 @@ data InferenceParam uid gid p s = InferenceParam
     -- Inferno identifiers are always pointing to the correct input\/output;
     -- otherwise we would need to rely on the order of the original identifiers
     inputs :: Map Ident (SingleOrMany p, ScriptInputType),
+    -- | Resolution, passed to bridge routes
+    resolution :: Word64,
     -- | The time that this parameter was \"deleted\", if any. For active
     -- parameters, this will be @Nothing@
     terminated :: Maybe UTCTime,
@@ -637,6 +639,7 @@ instance
       <*> fmap wrappedTo (field @VCObjectHashRow)
       <*> field
       <*> fmap getAeson field
+      <*> fmap fromIntegral (field @Int32)
       <*> field
       <*> field
 
@@ -652,6 +655,7 @@ instance
       ip ^. the @"script" & VCObjectHashRow & toField,
       ip ^. the @"model" & toField,
       ip ^. the @"inputs" & Aeson & toField,
+      ip ^. the @"resolution" & Aeson & toField,
       toField Default,
       ip ^. the @"user" & toField
     ]

--- a/inferno-ml-server/CHANGELOG.md
+++ b/inferno-ml-server/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2023.6.1
+* Add `resolution` to `InferenceParam`
+
 ## 2023.5.29
 * Change representation of script inputs/outputs
 

--- a/inferno-ml-server/exe/ParseAndSave.hs
+++ b/inferno-ml-server/exe/ParseAndSave.hs
@@ -103,11 +103,12 @@ saveScriptAndParam x now inputs conn = insertScript *> insertParam
           -- tests, so we can just hard-code the ID here
           (Id 1)
           inputs
+          128
           Nothing
         $ entityIdFromInteger 0
       where
         q :: Query
-        q = [sql| INSERT INTO params VALUES (?, ?, ?, ?, ?, ?) |]
+        q = [sql| INSERT INTO params VALUES (?, ?, ?, ?, ?, ?, ?) |]
 
     vcfunc :: VCObject
     vcfunc = uncurry VCFunction x

--- a/inferno-ml-server/inferno-ml-server.cabal
+++ b/inferno-ml-server/inferno-ml-server.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               inferno-ml-server
-version:            2023.5.29
+version:            2023.6.1
 synopsis:           Server for Inferno ML
 description:        Server for Inferno ML
 homepage:           https://github.com/plow-technologies/inferno.git#readme

--- a/inferno-ml-server/src/Inferno/ML/Server/Module/Bridge.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Module/Bridge.hs
@@ -11,7 +11,7 @@ import Inferno.ML.Server.Types
 import Inferno.Module.Cast (ToValue (toValue))
 import Inferno.Types.Value
   ( ImplicitCast (ImplicitCast),
-    Value (..),
+    Value (VDouble, VTuple, VOne),
     liftImplEnvM,
   )
 import System.Posix.Types (EpochTime)

--- a/inferno-ml-server/src/Inferno/ML/Server/Module/Bridge.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Module/Bridge.hs
@@ -11,7 +11,7 @@ import Inferno.ML.Server.Types
 import Inferno.Module.Cast (ToValue (toValue))
 import Inferno.Types.Value
   ( ImplicitCast (ImplicitCast),
-    Value (VDouble, VTuple, VOne),
+    Value (VDouble, VOne, VTuple),
     liftImplEnvM,
   )
 import System.Posix.Types (EpochTime)

--- a/inferno-ml-server/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Types.hs
@@ -374,11 +374,12 @@ pattern InferenceParam ::
   VCObjectHash ->
   Id ModelVersion ->
   Map Ident (SingleOrMany PID, ScriptInputType) ->
+  Word64 ->
   Maybe UTCTime ->
   EntityId UId ->
   InferenceParam
-pattern InferenceParam iid s m ios mt uid =
-  Types.InferenceParam iid s m ios mt uid
+pattern InferenceParam iid s m ios res mt uid =
+  Types.InferenceParam iid s m ios res mt uid
 
 pattern VCMeta ::
   CTime ->

--- a/nix/inferno-ml/migrations/v1-create-tables.sql
+++ b/nix/inferno-ml/migrations/v1-create-tables.sql
@@ -71,6 +71,8 @@ create table if not exists params
     -- corresponding Haskell type contains `(p, ScriptInputType)`, with
     -- the second element determining readability and writability
   , inputs jsonb not null
+    -- Resolution passed to script evaluator
+  , resolution integer not null
     -- See note above
   , terminated timestamptz
   , "user" integer references users (id)


### PR DESCRIPTION
Adds a `resolution` field to the inference param type. The script evaluator will use this resolution as part of the implicit env, unless the optional `res` query param is set via the `/inference` route. Originally I was going to drop that query param, but then I thought it would be useful to allow overriding `?resolution` without needing to edit the param or the script