### PR TITLE
[inferno-ml] Link multiple models to params

### DIFF
--- a/inferno-ml-server-types/CHANGELOG.md
+++ b/inferno-ml-server-types/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Revision History for inferno-ml-server-types
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.6.0
+* Support linking multiple models to inference parameters
+
 ## 0.5.0
 * Add `resolution` to `InferenceParam`
 

--- a/inferno-ml-server-types/inferno-ml-server-types.cabal
+++ b/inferno-ml-server-types/inferno-ml-server-types.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          inferno-ml-server-types
-version:       0.5.0
+version:       0.6.0
 synopsis:      Types for Inferno ML server
 description:   Types for Inferno ML server
 homepage:      https://github.com/plow-technologies/inferno.git#readme

--- a/inferno-ml-server/CHANGELOG.md
+++ b/inferno-ml-server/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Revision History for `inferno-ml-server`
+
+## 2023.6.5
+* Support linking multiple models to inference parameters
+
 ## 2023.6.1
 * Add `resolution` to `InferenceParam`
 

--- a/inferno-ml-server/exe/ParseAndSave.hs
+++ b/inferno-ml-server/exe/ParseAndSave.hs
@@ -21,6 +21,7 @@ import Data.Map.Strict (Map)
 import Data.Text (Text)
 import qualified Data.Text.IO as Text.IO
 import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as Vector
 import Database.PostgreSQL.Simple
   ( Connection,
     Query,
@@ -101,7 +102,7 @@ saveScriptAndParam x now inputs conn = insertScript *> insertParam
           hash
           -- Bit of a hack. We only have one model version in the
           -- tests, so we can just hard-code the ID here
-          (Id 1)
+          (Vector.singleton (Id 1))
           inputs
           128
           Nothing

--- a/inferno-ml-server/inferno-ml-server.cabal
+++ b/inferno-ml-server/inferno-ml-server.cabal
@@ -116,6 +116,7 @@ executable tests
     , mtl
     , text
     , unliftio
+    , vector
 
 executable test-client
   import:         common

--- a/inferno-ml-server/inferno-ml-server.cabal
+++ b/inferno-ml-server/inferno-ml-server.cabal
@@ -114,6 +114,7 @@ executable tests
     , inferno-ml-server
     , microlens-platform
     , mtl
+    , plow-log
     , text
     , unliftio
     , vector

--- a/inferno-ml-server/inferno-ml-server.cabal
+++ b/inferno-ml-server/inferno-ml-server.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               inferno-ml-server
-version:            2023.6.1
+version:            2023.6.5
 synopsis:           Server for Inferno ML
 description:        Server for Inferno ML
 homepage:           https://github.com/plow-technologies/inferno.git#readme

--- a/inferno-ml-server/src/Inferno/ML/Server.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server.hs
@@ -159,6 +159,4 @@ server =
         =<< view #job
       where
         logAndCancel :: (Id InferenceParam, Async (Maybe (WriteStream IO))) -> RemoteM ()
-        logAndCancel (i, j) =
-          (logTrace . WarnTrace . CancelingInference) i
-            *> cancel j
+        logAndCancel (i, j) = logWarn (CancelingInference i) *> cancel j

--- a/inferno-ml-server/src/Inferno/ML/Server.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server.hs
@@ -81,7 +81,7 @@ main = runServer =<< mkOptions
 
 runInEnv :: Config -> (Env -> IO ()) -> IO ()
 runInEnv cfg f = withRemoteTracer $ \tracer -> do
-  traceWith tracer StartingServer
+  traceWith tracer $ InfoTrace StartingServer
   withConnect (view #store cfg) $ \conn ->
     f
       =<< Env cfg conn tracer
@@ -159,4 +159,6 @@ server =
         =<< view #job
       where
         logAndCancel :: (Id InferenceParam, Async (Maybe (WriteStream IO))) -> RemoteM ()
-        logAndCancel (i, j) = logTrace (CancelingInference i) *> cancel j
+        logAndCancel (i, j) =
+          (logTrace . WarnTrace . CancelingInference) i
+            *> cancel j

--- a/inferno-ml-server/src/Inferno/ML/Server/Bridge.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Bridge.hs
@@ -36,7 +36,7 @@ import UnliftIO.IORef (atomicWriteIORef, readIORef)
 -- data from\/to the data source)
 registerBridgeInfo :: BridgeInfo -> RemoteM ()
 registerBridgeInfo bi = do
-  logTrace $ RegisteringBridge bi
+  logTrace . InfoTrace $ RegisteringBridge bi
   liftIO $ encodeFile bridgeCache bi
   (`atomicWriteIORef` Just bi) =<< view (#bridge . #info)
   interpreter <- mkInferno @_ @BridgeMlValue (mkBridgePrelude funs) customTypes

--- a/inferno-ml-server/src/Inferno/ML/Server/Bridge.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Bridge.hs
@@ -36,7 +36,7 @@ import UnliftIO.IORef (atomicWriteIORef, readIORef)
 -- data from\/to the data source)
 registerBridgeInfo :: BridgeInfo -> RemoteM ()
 registerBridgeInfo bi = do
-  logTrace . InfoTrace $ RegisteringBridge bi
+  logInfo $ RegisteringBridge bi
   liftIO $ encodeFile bridgeCache bi
   (`atomicWriteIORef` Just bi) =<< view (#bridge . #info)
   interpreter <- mkInferno @_ @BridgeMlValue (mkBridgePrelude funs) customTypes

--- a/inferno-ml-server/src/Inferno/ML/Server/Inference.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Inference.hs
@@ -7,7 +7,7 @@
 
 module Inferno.ML.Server.Inference
   ( runInferenceParam,
-    getAndCacheModel,
+    getAndCacheModels,
     linkVersionedModel,
   )
 where
@@ -15,12 +15,12 @@ where
 import Conduit (ConduitT, awaitForever, mapC, yieldMany, (.|))
 import Control.Monad (void, when, (<=<))
 import Control.Monad.Catch (throwM)
-import Control.Monad.Extra (loopM, unlessM, whenM)
+import Control.Monad.Extra (loopM, unlessM, whenJust, whenM)
 import Control.Monad.IO.Class (MonadIO (liftIO))
 import Control.Monad.ListM (sortByM)
 import Data.Bifoldable (bitraverse_)
 import Data.Conduit.List (chunksOf, sourceList)
-import Data.Foldable (foldl')
+import Data.Foldable (foldl', traverse_)
 import Data.Generics.Wrapped (wrappedTo)
 import Data.Int (Int64)
 import Data.Map (Map)
@@ -30,6 +30,7 @@ import Data.Time (UTCTime, getCurrentTime)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import Data.Traversable (for)
 import Data.UUID (UUID)
+import Data.Vector (Vector)
 import Data.Word (Word64)
 import Database.PostgreSQL.Simple
   ( Only (Only),
@@ -140,7 +141,8 @@ runInferenceParam ipid mres uuid =
           -- e.g. `loadModel "~/inferno/.cache/..."`)
           withCurrentDirectory (view #path cache) $ do
             logTrace $ EvaluatingScript ipid
-            linkVersionedModel =<< getAndCacheModel cache (view #model param)
+            traverse_ linkVersionedModel
+              =<< getAndCacheModels cache (view #models param)
             runEval interpreter param t obj
           where
             runEval ::
@@ -361,29 +363,20 @@ getParameter iid =
         LIMIT 1
       |]
 
--- | First retrieves the specified model version from the database, then fetches
--- the associated parent model. The contents of the model version are retrieved
--- (the Postgres large object), then copied to the model cache if it has not
--- yet been cached. Older previously saved model versions(s) are evicted if the
--- cache 'maxSize' is exceeded by adding the model version contents
---
--- NOTE: This action assumes that the current working directory is the model
--- cache! It can be run using e.g. 'withCurrentDirectory'
-getAndCacheModel :: ModelCache -> Id ModelVersion -> RemoteM FilePath
-getAndCacheModel cache mid = do
-  -- Both the individual version is required (in order to fetch the contents)
-  -- as well as the parent model row (for the model name)
-  mversion <- getModelVersion mid
-  model <- getModel $ view #model mversion
-  copyAndCache model mversion
+-- | For all of the model version IDs declared in the param, fetch the model
+-- version and the parent model, and then cache them
+getAndCacheModels ::
+  ModelCache -> Vector (Id ModelVersion) -> RemoteM (Vector FilePath)
+getAndCacheModels cache =
+  traverse (uncurry copyAndCache) <=< getModelsAndVersions
   where
     copyAndCache :: Model -> ModelVersion -> RemoteM FilePath
     copyAndCache model mversion =
       versioned <$ do
         unlessM (doesPathExist versioned) $ do
-          logTrace $ CopyingModel mid
+          mversion ^. #id & (`whenJust` logTrace . CopyingModel)
           bitraverse_ checkCacheSize (writeBinaryFileDurableAtomic versioned)
-            =<< getModelSizeAndContents (view #contents mversion)
+            =<< getModelVersionSizeAndContents (view #contents mversion)
       where
         -- Cache the model with its specific version, i.e.
         -- `<name>.ts.pt.<version>`, which will later be

--- a/inferno-ml-server/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Types.hs
@@ -12,6 +12,7 @@
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE NoFieldSelectors #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
+{-# LANGUAGE TypeOperators #-}
 
 module Inferno.ML.Server.Types
   ( module Inferno.ML.Server.Types,
@@ -55,6 +56,7 @@ import Database.PostgreSQL.Simple
   ( ConnectInfo (ConnectInfo),
     Connection,
     ResultError (ConversionFailed, UnexpectedNull),
+    (:.) ((:.)),
   )
 import Database.PostgreSQL.Simple.FromField
   ( FromField (fromField),
@@ -97,6 +99,7 @@ import UnliftIO (Async)
 import UnliftIO.IORef (IORef)
 import UnliftIO.MVar (MVar)
 import Web.HttpApiData (FromHttpApiData, ToHttpApiData)
+import Data.Vector (Vector)
 
 type RemoteM = ReaderT Env IO
 
@@ -372,14 +375,14 @@ pattern InferenceScript h o = Types.InferenceScript h o
 pattern InferenceParam ::
   Maybe (Id InferenceParam) ->
   VCObjectHash ->
-  Id ModelVersion ->
+  Vector (Id ModelVersion) ->
   Map Ident (SingleOrMany PID, ScriptInputType) ->
   Word64 ->
   Maybe UTCTime ->
   EntityId UId ->
   InferenceParam
-pattern InferenceParam iid s m ios res mt uid =
-  Types.InferenceParam iid s m ios res mt uid
+pattern InferenceParam iid s ms ios res mt uid =
+  Types.InferenceParam iid s ms ios res mt uid
 
 pattern VCMeta ::
   CTime ->
@@ -418,3 +421,6 @@ instance ToField VCObjectHash where
 deriving newtype instance ToHttpApiData EpochTime
 
 deriving newtype instance FromHttpApiData EpochTime
+
+joinToTuple :: (a :. b) -> (a, b)
+joinToTuple (a :. b) = (a, b)

--- a/inferno-ml-server/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Types.hs
@@ -372,6 +372,15 @@ logTrace t =
     shouldLog :: RemoteM Bool
     shouldLog = (traceLevel t >=) <$> view (#config . #logLevel)
 
+logInfo :: TraceInfo -> RemoteM ()
+logInfo = logTrace . InfoTrace
+
+logWarn :: TraceWarn -> RemoteM ()
+logWarn = logTrace . WarnTrace
+
+logError :: RemoteError -> RemoteM ()
+logError = logTrace . ErrorTrace
+
 -- FLAP!
 infixl 4 ??
 

--- a/inferno-ml-server/test/Main.hs
+++ b/inferno-ml-server/test/Main.hs
@@ -26,6 +26,7 @@ import Inferno.ML.Server.Inference.Model
   )
 import Inferno.ML.Server.Types hiding (models)
 import Lens.Micro.Platform
+import Plow.Logging.Message (LogLevel (LevelWarn))
 import Test.Hspec (Spec)
 import qualified Test.Hspec as Hspec
 import UnliftIO (throwString)
@@ -43,7 +44,8 @@ main =
   getArgs >>= \case
     cfg : args ->
       (`runInEnv` runTests args)
-        =<< either throwString pure
+        -- Silence logs
+        =<< either throwString (pure . set #logLevel LevelWarn)
         =<< eitherDecodeFileStrict @Config cfg
     _ -> throwString "Missing path to configuration file"
   where

--- a/inferno-ml-server/test/Main.hs
+++ b/inferno-ml-server/test/Main.hs
@@ -1,6 +1,8 @@
 -- These test items do not run a full `inferno-ml-server` instance and only
 -- check that a limited subset of server operations work as intended (e.g. model
--- fetching and caching). For full server tests, see `tests/server.nix`
+-- fetching and caching). For full server tests, see `tests/server.nix`.
+-- Note that the `mnist` model and its first version must be saved to the DB
+-- before running this test
 
 module Main (main) where
 
@@ -9,19 +11,20 @@ import Control.Monad.Reader (runReaderT)
 import Data.Aeson (eitherDecodeFileStrict)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as ByteString
-import Data.Foldable (traverse_)
+import Data.Foldable (toList, traverse_)
+import Data.Vector (Vector)
+import qualified Data.Vector as Vector
 import Data.Word (Word8)
 import Inferno.ML.Server (runInEnv)
 import Inferno.ML.Server.Inference
-  ( getAndCacheModel,
+  ( getAndCacheModels,
     linkVersionedModel,
   )
 import Inferno.ML.Server.Inference.Model
-  ( getModel,
-    getModelSizeAndContents,
-    getModelVersion,
+  ( getModelVersionSizeAndContents,
+    getModelsAndVersions,
   )
-import Inferno.ML.Server.Types
+import Inferno.ML.Server.Types hiding (models)
 import Lens.Micro.Platform
 import Test.Hspec (Spec)
 import qualified Test.Hspec as Hspec
@@ -56,7 +59,7 @@ mkCacheSpec env = Hspec.before_ clearCache . Hspec.describe "Model cache" $ do
     dir <- env ^. #config . #cache . #path & listDirectory
     dir `Hspec.shouldMatchList` ["mnist.v1", "mnist.ts.pt"]
     contents <- ByteString.readFile "mnist.ts.pt"
-    ByteString.length contents `Hspec.shouldBe` mnistSize
+    ByteString.length contents `Hspec.shouldBe` mnistV1Size
     getZipMagic contents `Hspec.shouldBe` zipMagic
 
   Hspec.it "doesn't re-cache" . cdCache $ do
@@ -67,8 +70,8 @@ mkCacheSpec env = Hspec.before_ clearCache . Hspec.describe "Model cache" $ do
     cacheModel :: IO ()
     cacheModel =
       void . flip runReaderT env $
-        linkVersionedModel
-          =<< (`getAndCacheModel` mnistV1)
+        traverse_ linkVersionedModel
+          =<< (`getAndCacheModels` models)
           =<< view (#config . #cache)
 
     clearCache :: IO ()
@@ -84,38 +87,39 @@ mkCacheSpec env = Hspec.before_ clearCache . Hspec.describe "Model cache" $ do
 mkDbSpec :: Env -> Spec
 mkDbSpec env = Hspec.describe "Database" $ do
   Hspec.it "gets a model" $ do
-    (model, mversion) <-
-      flip runReaderT env $
-        (,)
-          <$> getModel mnist
-          <*> getModelVersion mnistV1
-    view #name model `Hspec.shouldBe` "mnist"
-    view (#version . to showVersion) mversion `Hspec.shouldBe` "v1"
-    view #user model `Hspec.shouldBe` Nothing
+    runReaderT (getModelsAndVersions models) env >>= \case
+      v
+        | Just (model, mversion) <- v ^? _head -> do
+            view #name model `Hspec.shouldBe` "mnist"
+            view (#version . to showVersion) mversion `Hspec.shouldBe` "v1"
+            view #user model `Hspec.shouldBe` Nothing
+        | otherwise -> Hspec.expectationFailure "No models were retrieved"
 
   Hspec.it "gets model size and contents" $ do
-    (size, contents) <-
-      flip runReaderT env $
-        getModelSizeAndContents . view #contents
-          =<< getModelVersion mnistV1
-    -- This size is computed using PG functions
-    size `Hspec.shouldBe` fromIntegral mnistSize
-    -- This is the magic number for a ZIP
-    getZipMagic contents `Hspec.shouldBe` zipMagic
-    -- The size from PG and the size of the bytestring should be the same
-    ByteString.length contents `Hspec.shouldBe` fromIntegral size
+    getWithContents env >>= \case
+      (size, contents) -> do
+        -- This size is computed using PG functions
+        size `Hspec.shouldBe` fromIntegral mnistV1Size
+        -- This is the magic number for a ZIP
+        getZipMagic contents `Hspec.shouldBe` zipMagic
+        -- The size from PG and the size of the bytestring should be
+        -- the same
+        ByteString.length contents `Hspec.shouldBe` fromIntegral size
 
--- This should be the first and only model saved to the store for the test,
--- otherwise the ID will be wrong
-mnist :: Id Model
-mnist = Id 1
+getWithContents :: Env -> IO (Integer, ByteString)
+getWithContents env = flip runReaderT env $ do
+  (getModelsAndVersions models >>=) . (. fmap snd . toList) $ \case
+    [] -> throwString "No model was retrieved"
+    v : _ -> getModelVersionSizeAndContents $ view #contents v
 
--- Same as above
 mnistV1 :: Id ModelVersion
 mnistV1 = Id 1
 
-mnistSize :: Int
-mnistSize = 4808991
+models :: Vector (Id ModelVersion)
+models = Vector.singleton mnistV1
+
+mnistV1Size :: Int
+mnistV1Size = 4808991
 
 -- Magic header for a zip file (the underlying format of a `.ts.pt`)
 zipMagic :: [Word8]

--- a/nix/inferno-ml/migrations/v1-create-tables.sql
+++ b/nix/inferno-ml/migrations/v1-create-tables.sql
@@ -96,6 +96,10 @@ create table if not exists evalinfo
   , cpu bigint not null
   );
 
+-- Because the `params` table references an array of model versions, and
+-- because Postgres does not natively support arrays of foreign keys, this
+-- trigger function checks that each array item in the `models` column is
+-- a valid `mversions` primary key
 create or replace function verifymvs()
 returns trigger as $$
 declare

--- a/nix/inferno-ml/migrations/v1-create-tables.sql
+++ b/nix/inferno-ml/migrations/v1-create-tables.sql
@@ -103,7 +103,7 @@ declare
 begin
   foreach mv in array new.models loop
     if not exists(select 1 from mversions where id = mv) then
-      raise exception 'Model version ID % is not a valid primary key', mv;
+      raise exception 'ID % is not a valid model version primary key', mv;
     end if;
   end loop;
   return new;


### PR DESCRIPTION
Adds the ability to link multiple `ModelVersion` IDs to inference params and updates `inferno-ml-server` script evaluator to copy all models linked to a given param

Also adds configurable log level for `inferno-ml-server`