### PR TITLE
[inferno-ml] Move `BridgeInfo` to DB, add more instances

### DIFF
--- a/inferno-ml-server-types/CHANGELOG.md
+++ b/inferno-ml-server-types/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Revision History for inferno-ml-server-types
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.7.0
+* Change representation of `BridgeInfo`
+* Add more instances for various types
+
 ## 0.6.0
 * Support linking multiple models to inference parameters
 

--- a/inferno-ml-server-types/inferno-ml-server-types.cabal
+++ b/inferno-ml-server-types/inferno-ml-server-types.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          inferno-ml-server-types
-version:       0.6.0
+version:       0.7.0
 synopsis:      Types for Inferno ML server
 description:   Types for Inferno ML server
 homepage:      https://github.com/plow-technologies/inferno.git#readme

--- a/inferno-ml-server-types/inferno-ml-server-types.cabal
+++ b/inferno-ml-server-types/inferno-ml-server-types.cabal
@@ -48,6 +48,7 @@ library
     , deepseq
     , extra
     , generic-lens
+    , hashable
     , http-api-data
     , inferno-core
     , inferno-types

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Client.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Client.hs
@@ -6,7 +6,6 @@ module Inferno.ML.Server.Client
   ( statusC,
     inferenceC,
     cancelC,
-    registerBridgeC,
     checkBridgeC,
   )
 where
@@ -44,16 +43,12 @@ inferenceC ::
 -- | Cancel the existing inference job, if it exists
 cancelC :: ClientM ()
 
--- | Register the information required to communicate with the bridge server
-registerBridgeC :: BridgeInfo -> ClientM ()
-
 -- | Check if any bridge information has been previously registered with this
 -- server instance
 checkBridgeC :: ClientM (Maybe BridgeInfo)
 statusC
   :<|> inferenceC
   :<|> cancelC
-  :<|> registerBridgeC
   :<|> checkBridgeC =
     client api
 

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Client.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Client.hs
@@ -6,7 +6,6 @@ module Inferno.ML.Server.Client
   ( statusC,
     inferenceC,
     cancelC,
-    checkBridgeC,
   )
 where
 
@@ -42,15 +41,8 @@ inferenceC ::
 
 -- | Cancel the existing inference job, if it exists
 cancelC :: ClientM ()
-
--- | Check if any bridge information has been previously registered with this
--- server instance
-checkBridgeC :: ClientM (Maybe BridgeInfo)
-statusC
-  :<|> inferenceC
-  :<|> cancelC
-  :<|> checkBridgeC =
-    client api
+statusC :<|> inferenceC :<|> cancelC =
+  client api
 
 api :: Proxy (InfernoMlServerAPI uid gid p s t)
 api = Proxy

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
@@ -77,11 +77,9 @@ import Servant
     Get,
     JSON,
     NewlineFraming,
-    Post,
     Put,
     QueryParam,
     QueryParam',
-    ReqBody,
     Required,
     StreamPost,
     (:<|>),
@@ -113,9 +111,6 @@ type InfernoMlServerAPI uid gid p s t =
       :> QueryParam' '[Required] "uuid" UUID
       :> StreamPost NewlineFraming JSON (WriteStream IO)
     :<|> "inference" :> "cancel" :> Put '[JSON] ()
-    -- Register the bridge. This is an `inferno-ml-server` endpoint, not a
-    -- bridge endpoint
-    :<|> "bridge" :> ReqBody '[JSON] BridgeInfo :> Post '[JSON] ()
     -- Check for bridge registration
     :<|> "bridge" :> Get '[JSON] (Maybe BridgeInfo)
 

--- a/inferno-ml-server/CHANGELOG.md
+++ b/inferno-ml-server/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Revision History for `inferno-ml-server`
 
+## 2023.6.19
+* Save `BridgeInfo` to DB
+
 ## 2023.6.5
 * Support linking multiple models to inference parameters
 

--- a/inferno-ml-server/inferno-ml-server.cabal
+++ b/inferno-ml-server/inferno-ml-server.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               inferno-ml-server
-version:            2023.6.5
+version:            2023.6.19
 synopsis:           Server for Inferno ML
 description:        Server for Inferno ML
 homepage:           https://github.com/plow-technologies/inferno.git#readme

--- a/inferno-ml-server/inferno-ml-server.cabal
+++ b/inferno-ml-server/inferno-ml-server.cabal
@@ -177,6 +177,7 @@ executable parse-and-save
     , inferno-ml-server
     , inferno-types
     , inferno-vc
+    , microlens-platform
     , postgresql-simple
     , text
     , time

--- a/inferno-ml-server/src/Inferno/ML/Server/Log.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Log.hs
@@ -40,13 +40,6 @@ traceRemote = \case
         [ "Copying model to cache:",
           tshow m
         ]
-    RegisteringBridge bi ->
-      Text.unwords
-        [ "Registering orchestrator bridge with IP address",
-          bi ^. #host & tshow,
-          "and port",
-          bi ^. #port & tshow
-        ]
     OtherInfo t -> t
   WarnTrace w -> warn $ case w of
     CancelingInference i ->

--- a/inferno-ml-server/src/Inferno/ML/Server/Log.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Log.hs
@@ -9,7 +9,6 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import GHC.Generics (Generic)
 import Inferno.ML.Server.Types
-import Lens.Micro.Platform
 import Plow.Logging (IOTracer (IOTracer), withEitherTracer)
 import Plow.Logging.Async (withAsyncHandleTracer)
 import Plow.Logging.Message

--- a/inferno-ml-server/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Types.hs
@@ -409,6 +409,9 @@ pattern InferenceParam ::
 pattern InferenceParam iid s ms ios res mt uid =
   Types.InferenceParam iid s ms ios res mt uid
 
+pattern BridgeInfo :: Id InferenceParam -> IPv4 -> Word64 -> BridgeInfo
+pattern BridgeInfo ipid h p = Types.BridgeInfo ipid h p
+
 pattern VCMeta ::
   CTime ->
   ScriptMetadata ->

--- a/inferno-ml-server/src/Inferno/ML/Server/Utils.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Utils.hs
@@ -4,7 +4,6 @@ module Inferno.ML.Server.Utils
   ( throwInfernoError,
     firstOrThrow,
     queryStore,
-    bridgeCache,
     executeStore,
   )
 where
@@ -39,8 +38,3 @@ executeStore q x =
 
 firstOrThrow :: (MonadThrow m, Exception e) => e -> Vector a -> m a
 firstOrThrow e = maybe (throwM e) pure . (!? 0)
-
--- | Pathe to the cached bridge info; the server will save the info when the
--- bridge is registered
-bridgeCache :: FilePath
-bridgeCache = "/home/inferno/.cache/bridge/info.json"

--- a/inferno-ml-server/test/Client.hs
+++ b/inferno-ml-server/test/Client.hs
@@ -7,23 +7,20 @@
 module Client (main) where
 
 import Conduit
-import Control.Monad (unless, void)
+import Control.Monad (unless)
 import Data.Coerce (coerce)
 import Data.Int (Int64)
 import qualified Data.Map as Map
-import Inferno.ML.Server.Client (inferenceC, registerBridgeC)
+import Inferno.ML.Server.Client (inferenceC)
 import Inferno.ML.Server.Types
-  ( BridgeInfo (BridgeInfo),
-    IValue (IDouble),
+  ( IValue (IDouble),
     Id (Id),
     WriteStream,
-    toIPv4,
   )
 import Network.HTTP.Client (defaultManagerSettings, newManager)
 import Servant.Client.Streaming
   ( mkClientEnv,
     parseBaseUrl,
-    runClientM,
     withClientM,
   )
 import System.Exit (die)
@@ -44,12 +41,6 @@ main =
         mkClientEnv
           <$> newManager defaultManagerSettings
           <*> parseBaseUrl "http://localhost:8080"
-      -- Register the bridge to communicate with the dummy bridge server
-      void
-        . flip runClientM env
-        . registerBridgeC
-        . flip BridgeInfo 9999
-        $ toIPv4 (127, 0, 0, 1)
       withClientM (inferenceC ipid Nothing uuid) env . either throwIO $
         verifyWrites (coerce ipid)
     _ -> die "Usage: test-client <inference-parameter-id>"

--- a/nix/inferno-ml/migrations/v1-create-tables.sql
+++ b/nix/inferno-ml/migrations/v1-create-tables.sql
@@ -98,8 +98,8 @@ create table if not exists evalinfo
 
 -- Stores information required to call the data bridge
 create table if not exists bridges
-  ( id serial primary key
-  , param integer not null references params (id)
+  ( -- Same ID as the referenced param
+    id integer not null references params (id)
     -- Host of the bridge server
   , ip inet not null
   , port integer check (port > 0)

--- a/nix/inferno-ml/migrations/v1-create-tables.sql
+++ b/nix/inferno-ml/migrations/v1-create-tables.sql
@@ -96,6 +96,15 @@ create table if not exists evalinfo
   , cpu bigint not null
   );
 
+-- Stores information required to call the data bridge
+create table if not exists bridges
+  ( id serial primary key
+  , param integer not null references params (id)
+    -- Host of the bridge server
+  , ip inet not null
+  , port integer check (port > 0)
+  );
+
 -- Because the `params` table references an array of model versions, and
 -- because Postgres does not natively support arrays of foreign keys, this
 -- trigger function checks that each array item in the `models` column is

--- a/nix/inferno-ml/tests/server.nix
+++ b/nix/inferno-ml/tests/server.nix
@@ -110,16 +110,6 @@ pkgs.nixosTest {
       )
       (
         pkgs.writeShellApplication {
-          name = "register-bridge";
-          runtimeInputs = with pkgs; [ curl jo ];
-          text = ''
-            curl --fail -s -X POST -H 'Content-Type: application/json' \
-              localhost:8080/bridge -d "$(jo host=127.0.0.1 port=9999)"
-          '';
-        }
-      )
-      (
-        pkgs.writeShellApplication {
           name = "run-inference-client-test";
           runtimeInputs = with pkgs; [ inferno-ml-server.test-client ];
           text = ''
@@ -230,8 +220,6 @@ pkgs.nixosTest {
 
     node.systemctl("start inferno-ml-server.service", user="inferno")
     node.succeed('sudo -HE -u inferno run-db-test >&2')
-
-    node.succeed('register-bridge')
 
     # `tests/scripts/ones.inferno`
     runtest(1)


### PR DESCRIPTION
Various changes:
- Moves `BridgeInfo` to DB instead of having convoluted endpoint and local caching
- Updates script evaluator accordingly
- Adds some useful instances for different types (e.g. `InferenceParam`) so we don't need orphans elsewhere anymore