### PR TITLE
[inferno-ml] Map model idents to IDs in script metadata

### DIFF
--- a/docs/dev.md
+++ b/docs/dev.md
@@ -64,10 +64,10 @@ Tensor Int64 [2,10] [[ 1,  1,  1,  1,  1,  1,  1,  1,  1,  1],
 
 # Importing a TorchScript model into Inferno
 
-In an Inferno script, you can load the model using the `ML.loadScript` function. For instance,
+In an Inferno script, you can load the model using the `ML.unsafeLoadScript` function. For instance,
 
 ```
-let model = ML.loadScript "path/to/model/<model_name>.ts.pt" in ...
+let model = ML.unsafeLoadScript "path/to/model/<model_name>.ts.pt" in ...
 ```
 
 You can pass arguments of type `array of tensor` to the model by passing them to `ML.forward` along with your model.

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -64,10 +64,10 @@ Tensor Int64 [2,10] [[ 1,  1,  1,  1,  1,  1,  1,  1,  1,  1],
 
 # Importing a TorchScript model into Inferno
 
-In an Inferno script, you can load the model using the `ML.loadModel` function. For instance,
+In an Inferno script, you can load the model using the `ML.loadScript` function. For instance,
 
 ```
-let model = ML.loadModel "path/to/model/<model_name>.ts.pt" in ...
+let model = ML.loadScript "path/to/model/<model_name>.ts.pt" in ...
 ```
 
 You can pass arguments of type `array of tensor` to the model by passing them to `ML.forward` along with your model.

--- a/inferno-ml-server-types/CHANGELOG.md
+++ b/inferno-ml-server-types/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Revision History for inferno-ml-server-types
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.8.0
+* Store model IDs in script metadata mapped to model name 
+* Remove model IDs from `InferenceParam`
+
 ## 0.7.0
 * Change representation of `BridgeInfo`
 * Add more instances for various types

--- a/inferno-ml-server-types/inferno-ml-server-types.cabal
+++ b/inferno-ml-server-types/inferno-ml-server-types.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          inferno-ml-server-types
-version:       0.7.0
+version:       0.8.0
 synopsis:      Types for Inferno ML server
 description:   Types for Inferno ML server
 homepage:      https://github.com/plow-technologies/inferno.git#readme

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
@@ -694,7 +694,13 @@ instance
 -- linked to it indirectly via its script. This is provided for convenience
 data InferenceParamWithModels uid gid p s = InferenceParamWithModels
   { param :: InferenceParam uid gid p s,
-    models :: Vector (Id (ModelVersion uid gid Oid))
+    models ::
+      Map
+        Ident
+        ( Id (ModelVersion uid gid Oid),
+          -- Name of parent model
+          Text
+        )
   }
   deriving stock (Show, Eq, Generic)
 

--- a/inferno-ml-server/CHANGELOG.md
+++ b/inferno-ml-server/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Revision History for `inferno-ml-server`
 
+## 2023.7.2
+* Use new `loadModel` primitive and pass model names to script evaluator
+
 ## 2023.6.19
 * Save `BridgeInfo` to DB
 

--- a/inferno-ml-server/exe/ParseAndSave.hs
+++ b/inferno-ml-server/exe/ParseAndSave.hs
@@ -18,6 +18,7 @@ import Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as Char8
 import qualified Data.ByteString.Lazy.Char8 as Lazy.Char8
 import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text.IO as Text.IO
 import Data.Time.Clock.POSIX (getPOSIXTime)
@@ -153,7 +154,14 @@ saveScriptAndParam x now inputs conn = insertScript *> insertParam
     vcmeta = VCMeta now smd gid "mnist" "A script" Init VCObjectPublic vcfunc
 
     smd :: ScriptMetadata
-    smd = ScriptMetadata uid mempty mempty mempty
+    smd = ScriptMetadata uid [inferenceScript] mempty
+      where
+        inferenceScript :: ScriptType
+        inferenceScript =
+          MLInferenceScript
+            . InferenceOptions
+            . Map.singleton "mnist"
+            $ Id 1
 
     uid :: EntityId UId
     uid = entityIdFromInteger 0

--- a/inferno-ml-server/exe/ParseAndSave.hs
+++ b/inferno-ml-server/exe/ParseAndSave.hs
@@ -101,8 +101,8 @@ saveScriptAndParam x now inputs conn = insertScript *> insertParam
               VALUES (?, ?)
               RETURNING id
             )
-            INSERT INTO mselection (script, model)
-              SELECT id, 1::integer
+            INSERT INTO mselection (script, model, ident)
+              SELECT id, 1::integer, 'mnist'
             FROM ins
           |]
 

--- a/inferno-ml-server/exe/ParseAndSave.hs
+++ b/inferno-ml-server/exe/ParseAndSave.hs
@@ -101,7 +101,7 @@ saveScriptAndParam x now inputs conn = insertScript *> insertParam
               VALUES (?, ?)
               RETURNING id
             )
-            INSERT INTO smodels (script, model)
+            INSERT INTO mselection (script, model)
               SELECT id, 1::integer
             FROM ins
           |]

--- a/inferno-ml-server/exe/ParseAndSave.hs
+++ b/inferno-ml-server/exe/ParseAndSave.hs
@@ -21,6 +21,7 @@ import Data.Map.Strict (Map)
 import Data.Text (Text)
 import qualified Data.Text.IO as Text.IO
 import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.Vector as Vector
 import Database.PostgreSQL.Simple
   ( Connection,
     Only (fromOnly),
@@ -150,10 +151,13 @@ saveScriptAndParam x now inputs conn = insertScript *> insertParam
     hash = vcHash vcfunc
 
     vcmeta :: VCMeta VCObject
-    vcmeta = VCMeta now smd gid "mnist" "A script" Init VCObjectPublic vcfunc
+    vcmeta = VCMeta now mlmd gid "mnist" "A script" Init VCObjectPublic vcfunc
+      where
+        mlmd :: MlMetadata
+        mlmd = MlMetadata smd . Vector.singleton $ Id 1
 
-    smd :: ScriptMetadata
-    smd = ScriptMetadata uid mempty mempty
+        smd :: ScriptMetadata
+        smd = ScriptMetadata uid mempty mempty
 
     uid :: EntityId UId
     uid = entityIdFromInteger 0

--- a/inferno-ml-server/exe/ParseAndSave.hs
+++ b/inferno-ml-server/exe/ParseAndSave.hs
@@ -101,7 +101,7 @@ saveScriptAndParam x now inputs conn = insertScript *> insertParam
               VALUES (?, ?)
               RETURNING id
             )
-            INSERT INTO mselection (script, model, ident)
+            INSERT INTO mselections (script, model, ident)
               SELECT id, 1::integer, 'mnist'
             FROM ins
           |]

--- a/inferno-ml-server/exe/ParseAndSave.hs
+++ b/inferno-ml-server/exe/ParseAndSave.hs
@@ -21,7 +21,6 @@ import Data.Map.Strict (Map)
 import Data.Text (Text)
 import qualified Data.Text.IO as Text.IO
 import Data.Time.Clock.POSIX (getPOSIXTime)
-import qualified Data.Vector as Vector
 import Database.PostgreSQL.Simple
   ( Connection,
     Only (fromOnly),
@@ -151,13 +150,10 @@ saveScriptAndParam x now inputs conn = insertScript *> insertParam
     hash = vcHash vcfunc
 
     vcmeta :: VCMeta VCObject
-    vcmeta = VCMeta now mlmd gid "mnist" "A script" Init VCObjectPublic vcfunc
-      where
-        mlmd :: MlMetadata
-        mlmd = MlMetadata smd . Vector.singleton $ Id 1
+    vcmeta = VCMeta now smd gid "mnist" "A script" Init VCObjectPublic vcfunc
 
-        smd :: ScriptMetadata
-        smd = ScriptMetadata uid mempty mempty
+    smd :: ScriptMetadata
+    smd = ScriptMetadata uid mempty mempty
 
     uid :: EntityId UId
     uid = entityIdFromInteger 0

--- a/inferno-ml-server/exe/ParseAndSave.hs
+++ b/inferno-ml-server/exe/ParseAndSave.hs
@@ -153,7 +153,7 @@ saveScriptAndParam x now inputs conn = insertScript *> insertParam
     vcmeta = VCMeta now smd gid "mnist" "A script" Init VCObjectPublic vcfunc
 
     smd :: ScriptMetadata
-    smd = ScriptMetadata uid mempty mempty
+    smd = ScriptMetadata uid mempty mempty mempty
 
     uid :: EntityId UId
     uid = entityIdFromInteger 0

--- a/inferno-ml-server/inferno-ml-server.cabal
+++ b/inferno-ml-server/inferno-ml-server.cabal
@@ -109,9 +109,11 @@ executable tests
     , aeson
     , base
     , bytestring
+    , containers
     , generic-lens
     , hspec
     , inferno-ml-server
+    , inferno-types
     , microlens-platform
     , mtl
     , plow-log

--- a/inferno-ml-server/src/Inferno/ML/Server/Inference.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Inference.hs
@@ -145,7 +145,7 @@ runInferenceParam ipid mres uuid =
       -- Change working directories to the model cache so that Hasktorch
       -- can find the models using relative paths (otherwise the AST would
       -- need to be updated to use an absolute path to a versioned model,
-      -- e.g. `loadScript "~/inferno/.cache/..."`)
+      -- e.g. `loadModel "~/inferno/.cache/..."`)
       withCurrentDirectory (view #path cache) $ do
         logInfo $ EvaluatingScript ipid
         traverse_ linkVersionedModel

--- a/inferno-ml-server/src/Inferno/ML/Server/Inference.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Inference.hs
@@ -367,6 +367,11 @@ linkVersionedModel withVersion = do
 
 getParameterWithModels :: Id InferenceParam -> RemoteM InferenceParamWithModels
 getParameterWithModels iid =
+  -- NOTE: `fromOnly` is required on the second tuple element; this means
+  -- that the query returns `InferenceParam :. Only (Vector (Id ModelVersion))`,
+  -- i.e. the entire array of model version IDs is parsed at once. Otherwise,
+  -- the row parser will try to parse each model version ID individually, which
+  -- will fail
   fmap (uncurry InferenceParamWithModels . fmap fromOnly . joinToTuple)
     . firstOrThrow (NoSuchParameter (wrappedTo iid))
     =<< queryStore q (Only iid)

--- a/inferno-ml-server/src/Inferno/ML/Server/Inference.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Inference.hs
@@ -449,9 +449,13 @@ getParameterWithModels iid =
     -- where the second element of each tuple value is the name of the parent
     -- model
     --
+    -- `jsonb_object_agg` is used in order to convert the row of results
+    -- into a single JSONB object
+    --
     -- Note that `jsonb_build_array` is used with the model version ID and
     -- parent model name to create a two-element array, because this is the
-    -- tuple encoding expected by Aeson
+    -- tuple encoding expected by Aeson, and the `FromJSON` instance is
+    -- reused in order to parse the `InferenceParamWithModels`
     q :: Query
     q =
       [sql|

--- a/inferno-ml-server/src/Inferno/ML/Server/Inference.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Inference.hs
@@ -140,7 +140,7 @@ runInferenceParam ipid mres uuid =
       -- Change working directories to the model cache so that Hasktorch
       -- can find the models using relative paths (otherwise the AST would
       -- need to be updated to use an absolute path to a versioned model,
-      -- e.g. `loadModel "~/inferno/.cache/..."`)
+      -- e.g. `loadScript "~/inferno/.cache/..."`)
       withCurrentDirectory (view #path cache) $ do
         logInfo $ EvaluatingScript ipid
         traverse_ linkVersionedModel

--- a/inferno-ml-server/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Types.hs
@@ -73,6 +73,17 @@ import Foreign.C (CTime (CTime))
 import GHC.Generics (Generic)
 import Inferno.Core (Interpreter)
 import Inferno.ML.Server.Module.Types as M
+import "inferno-ml-server-types" Inferno.ML.Server.Types as M hiding
+  ( BridgeInfo,
+    EvaluationInfo,
+    InferenceParam,
+    InferenceParamWithModels,
+    InferenceScript,
+    InfernoMlServerAPI,
+    Model,
+    ModelVersion,
+  )
+import qualified "inferno-ml-server-types" Inferno.ML.Server.Types as Types
 import Inferno.Types.Syntax (Ident)
 import Inferno.VersionControl.Types
   ( VCObject,
@@ -96,17 +107,6 @@ import UnliftIO (Async)
 import UnliftIO.IORef (IORef)
 import UnliftIO.MVar (MVar)
 import Web.HttpApiData (FromHttpApiData, ToHttpApiData)
-import "inferno-ml-server-types" Inferno.ML.Server.Types as M hiding
-  ( BridgeInfo,
-    EvaluationInfo,
-    InferenceParam,
-    InferenceParamWithModels,
-    InferenceScript,
-    InfernoMlServerAPI,
-    Model,
-    ModelVersion,
-  )
-import qualified "inferno-ml-server-types" Inferno.ML.Server.Types as Types
 
 type RemoteM = ReaderT Env IO
 

--- a/inferno-ml-server/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Types.hs
@@ -246,13 +246,6 @@ mkOptions = decodeFileThrow =<< p
             Options.long "config"
               <> Options.metavar "FILEPATH"
 
-data MlMetadata = MlMetadata
-  { metadata :: ScriptMetadata,
-    models :: Vector (Id ModelVersion)
-  }
-  deriving stock (Show, Eq, Generic)
-  deriving anyclass (FromJSON, ToJSON)
-
 -- | Metadata for Inferno scripts
 data ScriptMetadata = ScriptMetadata
   { author :: EntityId UId,
@@ -401,9 +394,9 @@ type Model = Types.Model (EntityId UId) (EntityId GId)
 
 type ModelVersion = Types.ModelVersion (EntityId UId) (EntityId GId) Oid
 
-type InferenceScript = Types.InferenceScript MlMetadata (EntityId GId)
+type InferenceScript = Types.InferenceScript ScriptMetadata (EntityId GId)
 
-type VCMeta a = Inferno.VersionControl.Types.VCMeta MlMetadata (EntityId GId) a
+type VCMeta a = Inferno.VersionControl.Types.VCMeta ScriptMetadata (EntityId GId) a
 
 pattern InferenceScript :: VCObjectHash -> VCMeta VCObject -> InferenceScript
 pattern InferenceScript h o = Types.InferenceScript h o
@@ -430,7 +423,7 @@ pattern BridgeInfo ipid h p = Types.BridgeInfo ipid h p
 
 pattern VCMeta ::
   CTime ->
-  MlMetadata ->
+  ScriptMetadata ->
   EntityId GId ->
   Text ->
   Text ->

--- a/inferno-ml-server/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Types.hs
@@ -132,7 +132,7 @@ data Env = Env
   deriving stock (Generic)
 
 -- | Config for caching ML models to be used with Inferno scripts. When a script
--- uses @ML.loadScript@, models will be copied from the DB and saved to the cache
+-- uses @ML.loadModel@, models will be copied from the DB and saved to the cache
 -- directory. Once the 'maxSize' has been exceeded, least-recently-used cached
 -- models will be removed
 data ModelCache = ModelCache

--- a/inferno-ml-server/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Types.hs
@@ -246,6 +246,13 @@ mkOptions = decodeFileThrow =<< p
             Options.long "config"
               <> Options.metavar "FILEPATH"
 
+data MlMetadata = MlMetadata
+  { metadata :: ScriptMetadata,
+    models :: Vector (Id ModelVersion)
+  }
+  deriving stock (Show, Eq, Generic)
+  deriving anyclass (FromJSON, ToJSON)
+
 -- | Metadata for Inferno scripts
 data ScriptMetadata = ScriptMetadata
   { author :: EntityId UId,
@@ -394,9 +401,9 @@ type Model = Types.Model (EntityId UId) (EntityId GId)
 
 type ModelVersion = Types.ModelVersion (EntityId UId) (EntityId GId) Oid
 
-type InferenceScript = Types.InferenceScript ScriptMetadata (EntityId GId)
+type InferenceScript = Types.InferenceScript MlMetadata (EntityId GId)
 
-type VCMeta a = Inferno.VersionControl.Types.VCMeta ScriptMetadata (EntityId GId) a
+type VCMeta a = Inferno.VersionControl.Types.VCMeta MlMetadata (EntityId GId) a
 
 pattern InferenceScript :: VCObjectHash -> VCMeta VCObject -> InferenceScript
 pattern InferenceScript h o = Types.InferenceScript h o
@@ -423,7 +430,7 @@ pattern BridgeInfo ipid h p = Types.BridgeInfo ipid h p
 
 pattern VCMeta ::
   CTime ->
-  ScriptMetadata ->
+  MlMetadata ->
   EntityId GId ->
   Text ->
   Text ->

--- a/inferno-ml-server/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Types.hs
@@ -74,16 +74,6 @@ import Foreign.C (CTime (CTime))
 import GHC.Generics (Generic)
 import Inferno.Core (Interpreter)
 import Inferno.ML.Server.Module.Types as M
-import "inferno-ml-server-types" Inferno.ML.Server.Types as M hiding
-  ( BridgeInfo,
-    EvaluationInfo,
-    InferenceParam,
-    InferenceScript,
-    InfernoMlServerAPI,
-    Model,
-    ModelVersion,
-  )
-import qualified "inferno-ml-server-types" Inferno.ML.Server.Types as Types
 import Inferno.Types.Syntax (Ident)
 import Inferno.VersionControl.Types
   ( VCObject,
@@ -107,6 +97,17 @@ import UnliftIO (Async)
 import UnliftIO.IORef (IORef)
 import UnliftIO.MVar (MVar)
 import Web.HttpApiData (FromHttpApiData, ToHttpApiData)
+import "inferno-ml-server-types" Inferno.ML.Server.Types as M hiding
+  ( BridgeInfo,
+    EvaluationInfo,
+    InferenceParam,
+    InferenceParamWithModels,
+    InferenceScript,
+    InfernoMlServerAPI,
+    Model,
+    ModelVersion,
+  )
+import qualified "inferno-ml-server-types" Inferno.ML.Server.Types as Types
 
 type RemoteM = ReaderT Env IO
 
@@ -381,6 +382,9 @@ f ?? x = ($ x) <$> f
 type InferenceParam =
   Types.InferenceParam (EntityId UId) (EntityId GId) PID VCObjectHash
 
+type InferenceParamWithModels =
+  Types.InferenceParamWithModels (EntityId UId) (EntityId GId) PID VCObjectHash
+
 type BridgeInfo =
   Types.BridgeInfo (EntityId UId) (EntityId GId) PID VCObjectHash
 
@@ -400,14 +404,19 @@ pattern InferenceScript h o = Types.InferenceScript h o
 pattern InferenceParam ::
   Maybe (Id InferenceParam) ->
   VCObjectHash ->
-  Vector (Id ModelVersion) ->
   Map Ident (SingleOrMany PID, ScriptInputType) ->
   Word64 ->
   Maybe UTCTime ->
   EntityId UId ->
   InferenceParam
-pattern InferenceParam iid s ms ios res mt uid =
-  Types.InferenceParam iid s ms ios res mt uid
+pattern InferenceParam iid s ios res mt uid =
+  Types.InferenceParam iid s ios res mt uid
+
+pattern InferenceParamWithModels ::
+  InferenceParam ->
+  Vector (Id ModelVersion) ->
+  InferenceParamWithModels
+pattern InferenceParamWithModels ip mvs = Types.InferenceParamWithModels ip mvs
 
 pattern BridgeInfo :: Id InferenceParam -> IPv4 -> Word64 -> BridgeInfo
 pattern BridgeInfo ipid h p = Types.BridgeInfo ipid h p

--- a/inferno-ml-server/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Types.hs
@@ -53,7 +53,6 @@ import qualified Data.Text as Text
 import qualified Data.Text.Read as Text.Read
 import Data.Time (UTCTime)
 import Data.UUID (UUID)
-import Data.Vector (Vector)
 import Data.Word (Word64)
 import Data.Yaml (decodeFileThrow)
 import Database.PostgreSQL.Simple
@@ -251,7 +250,7 @@ data ScriptMetadata = ScriptMetadata
   { author :: EntityId UId,
     scriptTypes :: [Text],
     categoryIds :: [Int],
-    models :: Vector (Id ModelVersion)
+    models :: Map Ident (Id ModelVersion)
   }
   deriving stock (Show, Eq, Generic)
   deriving anyclass (ToJSON)
@@ -415,7 +414,7 @@ pattern InferenceParam iid s ios res mt uid =
 
 pattern InferenceParamWithModels ::
   InferenceParam ->
-  Vector (Id ModelVersion) ->
+  Map Ident (Id ModelVersion, Text) ->
   InferenceParamWithModels
 pattern InferenceParamWithModels ip mvs = Types.InferenceParamWithModels ip mvs
 

--- a/inferno-ml-server/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Types.hs
@@ -250,7 +250,8 @@ mkOptions = decodeFileThrow =<< p
 data ScriptMetadata = ScriptMetadata
   { author :: EntityId UId,
     scriptTypes :: [Text],
-    categoryIds :: [Int]
+    categoryIds :: [Int],
+    models :: Vector (Id ModelVersion)
   }
   deriving stock (Show, Eq, Generic)
   deriving anyclass (ToJSON)
@@ -264,7 +265,7 @@ instance FromJSON ScriptMetadata where
       ]
     where
       fromUid :: EntityId UId -> ScriptMetadata
-      fromUid uid = ScriptMetadata uid mempty mempty
+      fromUid uid = ScriptMetadata uid mempty mempty mempty
 
 data RemoteError
   = CacheSizeExceeded

--- a/inferno-ml-server/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Types.hs
@@ -133,7 +133,7 @@ data Env = Env
   deriving stock (Generic)
 
 -- | Config for caching ML models to be used with Inferno scripts. When a script
--- uses @ML.loadModel@, models will be copied from the DB and saved to the cache
+-- uses @ML.loadScript@, models will be copied from the DB and saved to the cache
 -- directory. Once the 'maxSize' has been exceeded, least-recently-used cached
 -- models will be removed
 data ModelCache = ModelCache

--- a/inferno-ml-server/test/Main.hs
+++ b/inferno-ml-server/test/Main.hs
@@ -12,6 +12,9 @@ import Data.Aeson (eitherDecodeFileStrict)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as ByteString
 import Data.Foldable (toList, traverse_)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Text (Text)
 import Data.Vector (Vector)
 import qualified Data.Vector as Vector
 import Data.Word (Word8)
@@ -31,6 +34,7 @@ import Inferno.ML.Server.Types
     ModelVersion,
     showVersion,
   )
+import Inferno.Types.Syntax (Ident)
 import Lens.Micro.Platform
 import Plow.Logging.Message (LogLevel (LevelWarn))
 import Test.Hspec (Spec)
@@ -79,7 +83,7 @@ mkCacheSpec env = Hspec.before_ clearCache . Hspec.describe "Model cache" $ do
     cacheModel =
       void . flip runReaderT env $
         traverse_ linkVersionedModel
-          =<< (`getAndCacheModels` models)
+          =<< (`getAndCacheModels` modelsWithIdents)
           =<< view (#config . #cache)
 
     clearCache :: IO ()
@@ -91,6 +95,9 @@ mkCacheSpec env = Hspec.before_ clearCache . Hspec.describe "Model cache" $ do
 
     cdCache :: IO a -> IO a
     cdCache = env ^. #config . #cache . #path & withCurrentDirectory
+
+modelsWithIdents :: Map Ident (Id ModelVersion, Text)
+modelsWithIdents = Map.singleton "dummy" (mnistV1, "mnist")
 
 mkDbSpec :: Env -> Spec
 mkDbSpec env = Hspec.describe "Database" $ do

--- a/inferno-ml-server/test/Main.hs
+++ b/inferno-ml-server/test/Main.hs
@@ -24,7 +24,13 @@ import Inferno.ML.Server.Inference.Model
   ( getModelVersionSizeAndContents,
     getModelsAndVersions,
   )
-import Inferno.ML.Server.Types hiding (models)
+import Inferno.ML.Server.Types
+  ( Config,
+    Env,
+    Id (Id),
+    ModelVersion,
+    showVersion,
+  )
 import Lens.Micro.Platform
 import Plow.Logging.Message (LogLevel (LevelWarn))
 import Test.Hspec (Spec)

--- a/inferno-ml/CHANGELOG.md
+++ b/inferno-ml/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Revision History for inferno-ml
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.4.0.0 -- 2024-07-02
+* Breaking change: old `loadModel` renamed to `unsafeLoadScript`
+* Breaking change: new `loadModel` primitive
+
 ## 0.3.3.0 -- 2024-03-18
 * HLint everything
 

--- a/inferno-ml/inferno-ml.cabal
+++ b/inferno-ml/inferno-ml.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                inferno-ml
-version:             0.3.1.0
+version:             0.4.0.0
 synopsis:            Machine Learning primitives for Inferno
 description:         Machine Learning primitives for Inferno
 homepage:            https://github.com/plow-technologies/inferno.git#readme

--- a/inferno-ml/inferno-ml.cabal
+++ b/inferno-ml/inferno-ml.cabal
@@ -34,6 +34,7 @@ library
     , template-haskell
     , text
     , prettyprinter
+    , filepath
   default-language: Haskell2010
   default-extensions:
       LambdaCase

--- a/inferno-ml/src/Inferno/ML/Module/Prelude.hs
+++ b/inferno-ml/src/Inferno/ML/Module/Prelude.hs
@@ -25,11 +25,11 @@ import qualified Inferno.Module.Prelude as Prelude
 import Inferno.Types.Syntax (Ident)
 import Inferno.Types.Value (Value (..))
 import Prettyprinter (Pretty)
+import System.FilePath ((<.>))
 import Torch
 import qualified Torch.DType as TD
 import Torch.Functional
 import qualified Torch.Script as TS
-import System.FilePath ((<.>))
 
 getDtype :: (MonadThrow m) => String -> Ident -> m DType
 getDtype funName = \case

--- a/inferno-ml/src/Inferno/ML/Module/Prelude.hs
+++ b/inferno-ml/src/Inferno/ML/Module/Prelude.hs
@@ -252,7 +252,7 @@ module ML
   @doc Load a named, serialized model;
   loadModel : modelName -> model := ###!loadModelFun###;
 
-  unsafeLoadScript : text -> model := ###loadScriptFun###;
+  unsafeLoadScript : text -> model := ###unsafeLoadScriptFun###;
 
   forward : model -> array of tensor -> array of tensor := ###forwardFun###;
 

--- a/inferno-ml/src/Inferno/ML/Module/Prelude.hs
+++ b/inferno-ml/src/Inferno/ML/Module/Prelude.hs
@@ -5,7 +5,13 @@
 
 module Inferno.ML.Module.Prelude (mlPrelude) where
 
-import Control.Monad.Catch (MonadCatch, MonadThrow (throwM))
+import Control.Monad.Catch
+  ( Exception (displayException),
+    MonadCatch,
+    MonadThrow (throwM),
+    SomeException,
+    try,
+  )
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Data.Functor ((<&>))
 import qualified Data.Map as Map
@@ -125,8 +131,19 @@ tanHTFun = Torch.Functional.tanh
 powTFun :: Int -> Tensor -> Tensor
 powTFun = pow
 
-loadModelFun :: Text -> ScriptModule
-loadModelFun f = unsafePerformIO $ TS.loadScript TS.WithoutRequiredGrad $ unpack f
+loadScriptFun :: Text -> ScriptModule
+loadScriptFun f = unsafePerformIO $ TS.loadScript TS.WithoutRequiredGrad $ unpack f
+
+loadModelFun ::
+  forall m x. (Pretty x, MonadIO m, MonadThrow m) => Value (MlValue x) m
+loadModelFun = VFun $ \case
+  VCustom (VModelName (ModelName mn)) ->
+    either (throwM . RuntimeError . displayException) (pure . VCustom . VModel)
+      =<< liftIO (try @_ @SomeException loadModel)
+    where
+      loadModel :: IO ScriptModule
+      loadModel = TS.loadScript TS.WithoutRequiredGrad mn
+  _ -> throwM $ RuntimeError "Expected a modelName"
 
 forwardFun :: ScriptModule -> [Tensor] -> [Tensor]
 forwardFun m ts =
@@ -231,7 +248,10 @@ module ML
   @doc Move a tensor to a different device, e.g. "cpu" or "cuda:0";
   toDevice : text -> tensor -> tensor := ###toDeviceFun###;
 
-  loadModel : text -> model := ###loadModelFun###;
+  @doc Load a named, serialized model;
+  loadModel : modelName -> model := ###!loadModelFun###;
+
+  loadScript : text -> model := ###loadScriptFun###;
 
   forward : model -> array of tensor -> array of tensor := ###forwardFun###;
 

--- a/inferno-ml/src/Inferno/ML/Module/Prelude.hs
+++ b/inferno-ml/src/Inferno/ML/Module/Prelude.hs
@@ -132,8 +132,8 @@ tanHTFun = Torch.Functional.tanh
 powTFun :: Int -> Tensor -> Tensor
 powTFun = pow
 
-loadScriptFun :: Text -> ScriptModule
-loadScriptFun f = unsafePerformIO $ TS.loadScript TS.WithoutRequiredGrad $ unpack f
+unsafeLoadScriptFun :: Text -> ScriptModule
+unsafeLoadScriptFun f = unsafePerformIO $ TS.loadScript TS.WithoutRequiredGrad $ unpack f
 
 loadModelFun ::
   forall m x. (Pretty x, MonadIO m, MonadThrow m) => Value (MlValue x) m
@@ -252,7 +252,7 @@ module ML
   @doc Load a named, serialized model;
   loadModel : modelName -> model := ###!loadModelFun###;
 
-  loadScript : text -> model := ###loadScriptFun###;
+  unsafeLoadScript : text -> model := ###loadScriptFun###;
 
   forward : model -> array of tensor -> array of tensor := ###forwardFun###;
 

--- a/inferno-ml/src/Inferno/ML/Module/Prelude.hs
+++ b/inferno-ml/src/Inferno/ML/Module/Prelude.hs
@@ -29,6 +29,7 @@ import Torch
 import qualified Torch.DType as TD
 import Torch.Functional
 import qualified Torch.Script as TS
+import System.FilePath ((<.>))
 
 getDtype :: (MonadThrow m) => String -> Ident -> m DType
 getDtype funName = \case
@@ -142,7 +143,7 @@ loadModelFun = VFun $ \case
       =<< liftIO (try @_ @SomeException loadModel)
     where
       loadModel :: IO ScriptModule
-      loadModel = TS.loadScript TS.WithoutRequiredGrad mn
+      loadModel = TS.loadScript TS.WithoutRequiredGrad $ mn <.> "ts.pt"
   _ -> throwM $ RuntimeError "Expected a modelName"
 
 forwardFun :: ScriptModule -> [Tensor] -> [Tensor]

--- a/inferno-ml/src/Inferno/ML/Types/Value.hs
+++ b/inferno-ml/src/Inferno/ML/Types/Value.hs
@@ -14,6 +14,7 @@ import Language.Haskell.TH.Quote (QuasiQuoter (..))
 import Prettyprinter (Pretty (pretty), align)
 import qualified Torch as T
 
+-- | The name of a serialized model, e.g. @model.ts.pt@
 newtype ModelName = ModelName FilePath
   deriving stock (Show, Generic)
   deriving newtype (Eq, Pretty)

--- a/inferno-ml/src/Inferno/ML/Types/Value.hs
+++ b/inferno-ml/src/Inferno/ML/Types/Value.hs
@@ -1,6 +1,11 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
 module Inferno.ML.Types.Value where
 
 import qualified Data.Text as Text
+import GHC.Generics (Generic)
 import Inferno.Module.Cast (FromValue (..), ToValue (..), couldNotCast)
 import Inferno.Types.Syntax (CustomType)
 import Inferno.Types.Value (Value (VCustom))
@@ -9,9 +14,14 @@ import Language.Haskell.TH.Quote (QuasiQuoter (..))
 import Prettyprinter (Pretty (pretty), align)
 import qualified Torch as T
 
+newtype ModelName = ModelName FilePath
+  deriving stock (Show, Generic)
+  deriving newtype (Eq, Pretty)
+
 data MlValue x
   = VTensor T.Tensor
   | VModel T.ScriptModule
+  | VModelName ModelName
   | VExtended x
 
 instance Eq x => Eq (MlValue x) where
@@ -23,6 +33,7 @@ instance Pretty x => Pretty (MlValue x) where
   pretty = \case
     VTensor t -> align (pretty $ Text.pack $ show t)
     VModel m -> align (pretty $ Text.pack $ show m)
+    VModelName x -> align $ pretty x
     VExtended x -> align $ pretty x
 
 instance ToValue (MlValue x) m T.Tensor where
@@ -39,8 +50,23 @@ instance Pretty x => FromValue (MlValue x) m T.ScriptModule where
   fromValue (VCustom (VModel t)) = pure t
   fromValue v = couldNotCast v
 
+instance ToValue (MlValue x) m ModelName where
+  toValue = VCustom . VModelName
+
+instance Pretty x => FromValue (MlValue x) m ModelName where
+  fromValue = \case
+    VCustom (VModelName t) -> pure t
+    v -> couldNotCast v
+
 customTypes :: [CustomType]
-customTypes = ["tensor", "model", "write"]
+customTypes =
+  [ "tensor",
+    -- NOTE It seems that `modelName` needs to come before `model`,
+    -- otherwise Inferno's parser fails??
+    "modelName",
+    "model",
+    "write"
+  ]
 
 mlQuoter :: QuasiQuoter
 mlQuoter = moduleQuoter customTypes

--- a/inferno-ml/test/downhole-autoencoder.inferno
+++ b/inferno-ml/test/downhole-autoencoder.inferno
@@ -51,7 +51,7 @@ let good_input = ML.asTensor2 ML.#float [
   1.3800e+02]]
 in
 let bad_input = ML.asTensor2 ML.#float [[if x == 1 then 1234 else 0 | x <- 1 .. 295]] in
-let model = ML.loadScript "downhole_autoencoder.ts.pt" in
+let model = ML.unsafeLoadScript "downhole_autoencoder.ts.pt" in
 let get_model_loss = fun input ->
   match ML.forward model [input] with {
     | [output] ->

--- a/inferno-ml/test/downhole-autoencoder.inferno
+++ b/inferno-ml/test/downhole-autoencoder.inferno
@@ -51,7 +51,7 @@ let good_input = ML.asTensor2 ML.#float [
   1.3800e+02]]
 in
 let bad_input = ML.asTensor2 ML.#float [[if x == 1 then 1234 else 0 | x <- 1 .. 295]] in
-let model = ML.loadModel "downhole_autoencoder.ts.pt" in
+let model = ML.loadScript "downhole_autoencoder.ts.pt" in
 let get_model_loss = fun input ->
   match ML.forward model [input] with {
     | [output] ->

--- a/inferno-ml/test/mnist.inferno
+++ b/inferno-ml/test/mnist.inferno
@@ -30,7 +30,7 @@ let input = ML.asTensor4 ML.#float [[[
   [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
   [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 ]]] in
-let model = ML.loadScript "mnist.ts.pt" in
+let model = ML.unsafeLoadScript "mnist.ts.pt" in
 let prediction =
   match ML.forward model [input] with {
     | [scores] -> ML.asDouble (ML.argmax 1 #false scores)

--- a/inferno-ml/test/mnist.inferno
+++ b/inferno-ml/test/mnist.inferno
@@ -30,7 +30,7 @@ let input = ML.asTensor4 ML.#float [[[
   [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
   [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 ]]] in
-let model = ML.loadModel "mnist.ts.pt" in
+let model = ML.loadScript "mnist.ts.pt" in
 let prediction =
   match ML.forward model [input] with {
     | [scores] -> ML.asDouble (ML.argmax 1 #false scores)

--- a/nix/inferno-ml/migrations/v1-create-tables.sql
+++ b/nix/inferno-ml/migrations/v1-create-tables.sql
@@ -67,6 +67,7 @@ create table if not exists scripts
 create table if not exists smodels
   ( script bytea not null references scripts (id)
   , model integer not null references mversions (id)
+  , unique (script, model)
   );
 
 create table if not exists params

--- a/nix/inferno-ml/migrations/v1-create-tables.sql
+++ b/nix/inferno-ml/migrations/v1-create-tables.sql
@@ -62,15 +62,17 @@ create table if not exists scripts
   , obj jsonb not null
   );
 
+-- Model versions linked to specific Inferno scripts (i.e. junction table
+-- between `scripts` and `mversions`)
+create table if not exists smodels
+  ( script bytea not null references scripts (id)
+  , model integer not null references mversions (id)
+  );
+
 create table if not exists params
   ( id serial primary key
     -- Script hash from `inferno-vc`
   , script bytea not null references scripts (id)
-    -- Array of model version IDs; unfortunately we lose referential
-    -- integrity because Postgres does not allow arrays of foreign keys.
-    -- However, we don't allow model version deletion anyway, which
-    -- mitigates this to some degree
-  , models integer[] not null
     -- Strictly speaking, this includes both inputs and outputs. The
     -- corresponding Haskell type contains `(p, ScriptInputType)`, with
     -- the second element determining readability and writability
@@ -104,33 +106,6 @@ create table if not exists bridges
   , ip inet not null
   , port integer check (port > 0)
   );
-
--- Because the `params` table references an array of model versions, and
--- because Postgres does not natively support arrays of foreign keys, this
--- trigger function checks that each array item in the `models` column is
--- a valid `mversions` primary key and that the model has not been terminated
-create or replace function verifymvs()
-returns trigger as $$
-declare
-  mv int;
-begin
-  foreach mv in array new.models loop
-    if
-      not exists
-        ( select 1 from mversions
-          where id = mv
-            and terminated is null
-        )
-    then
-      raise exception 'ID % is not a valid model version primary key', mv;
-    end if;
-  end loop;
-  return new;
-end;
-$$ language plpgsql;
-
-create trigger "verify-param-models" before insert or update on params
-  for each row execute function verifymvs();
 
 create trigger "manage-mversion-lo" before update or delete on mversions
   for each row execute function lo_manage(contents);

--- a/nix/inferno-ml/migrations/v1-create-tables.sql
+++ b/nix/inferno-ml/migrations/v1-create-tables.sql
@@ -67,7 +67,6 @@ create table if not exists scripts
 create table if not exists smodels
   ( script bytea not null references scripts (id)
   , model integer not null references mversions (id)
-  , unique (script, model)
   );
 
 create table if not exists params

--- a/nix/inferno-ml/migrations/v1-create-tables.sql
+++ b/nix/inferno-ml/migrations/v1-create-tables.sql
@@ -64,7 +64,7 @@ create table if not exists scripts
 
 -- Model versions linked to specific Inferno scripts (i.e. junction table
 -- between `scripts` and `mversions`)
-create table if not exists mselection
+create table if not exists mselections
   ( script bytea not null references scripts (id)
   , model integer not null references mversions (id)
     -- Inferno identifier linked to this specific model version

--- a/nix/inferno-ml/migrations/v1-create-tables.sql
+++ b/nix/inferno-ml/migrations/v1-create-tables.sql
@@ -64,9 +64,11 @@ create table if not exists scripts
 
 -- Model versions linked to specific Inferno scripts (i.e. junction table
 -- between `scripts` and `mversions`)
-create table if not exists smodels
+create table if not exists mselection
   ( script bytea not null references scripts (id)
   , model integer not null references mversions (id)
+    -- Inferno identifier linked to this specific model version
+  , ident text not null
   , unique (script, model)
   );
 

--- a/nix/inferno-ml/tests/scripts/contrived.inferno
+++ b/nix/inferno-ml/tests/scripts/contrived.inferno
@@ -1,4 +1,4 @@
-fun input0 ->
+fun input0 mnist ->
   let t = Time.toTime (Time.seconds 200) in
   let ?resolution = (toResolution 128) in
   let v = valueAt input0 t ? 0.0 in

--- a/nix/inferno-ml/tests/scripts/mnist.inferno
+++ b/nix/inferno-ml/tests/scripts/mnist.inferno
@@ -1,4 +1,4 @@
-fun input0 input1 ->
+fun input0 input1 mnist ->
   let input = ML.asTensor4 ML.#float [[[
     [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
     [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -30,7 +30,7 @@ fun input0 input1 ->
     [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
   ]]] in
   let t = Time.toTime (Time.seconds 100) in
-  let model = ML.loadScript "mnist.ts.pt" in
+  let model = ML.loadModel mnist in
   match ML.forward model [input] with {
     | [scores] ->
         let m = ML.toType ML.#double (ML.argmax 1 #false scores) in

--- a/nix/inferno-ml/tests/scripts/mnist.inferno
+++ b/nix/inferno-ml/tests/scripts/mnist.inferno
@@ -30,7 +30,7 @@ fun input0 input1 ->
     [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
   ]]] in
   let t = Time.toTime (Time.seconds 100) in
-  let model = ML.loadModel "mnist.ts.pt" in
+  let model = ML.loadScript "mnist.ts.pt" in
   match ML.forward model [input] with {
     | [scores] ->
         let m = ML.toType ML.#double (ML.argmax 1 #false scores) in

--- a/nix/inferno-ml/tests/scripts/ones.inferno
+++ b/nix/inferno-ml/tests/scripts/ones.inferno
@@ -1,4 +1,4 @@
-fun input0 ->
+fun input0 mnist ->
   let mkV = fun t -> valueAt input0 (Time.toTime (Time.seconds t)) ? 0.0 in
   let ts = [150, 250] in
   let vs = Array.map mkV ts in


### PR DESCRIPTION
Two large changes:

- The `ScriptMetadata` now contains the model IDs, which are mapped to their identifiers. The `InferenceParam` type no longer contains the models. Each entry in the map should correspond to a row in a junction table between models and scripts (note that this is done elsewhere) 

- The `ML.loadModel` primitive has been changed to take a `modelName` which are provided to the script evaluator. This is similar to how all of the bridge primitives work (i.e. only an identifier is provided directly by the user, which is resolved by the script evaluator). The old behavior is still available under `ML.unsafeLoadScript`, which just takes a filepath. The advantage of this is that `loadModel` can only be used with names known to be valid -- the correct filepath is derived for the user