### PR TITLE
[inferno-ml] Add arbitrary instances

### DIFF
--- a/inferno-ml-server-types/CHANGELOG.md
+++ b/inferno-ml-server-types/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Revision History for inferno-ml-server-types
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.9.0
+* Add `Arbitrary`/`ToADTArbitrary` instances for most types
+* Simplify `ModelMetadata`
+
 ## 0.8.0
 * Store model IDs in script metadata mapped to model name 
 * Remove model IDs from `InferenceParam`

--- a/inferno-ml-server-types/inferno-ml-server-types.cabal
+++ b/inferno-ml-server-types/inferno-ml-server-types.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          inferno-ml-server-types
-version:       0.8.0
+version:       0.9.0
 synopsis:      Types for Inferno ML server
 description:   Types for Inferno ML server
 homepage:      https://github.com/plow-technologies/inferno.git#readme

--- a/inferno-ml-server-types/inferno-ml-server-types.cabal
+++ b/inferno-ml-server-types/inferno-ml-server-types.cabal
@@ -66,7 +66,5 @@ library
     , text
     , time
     , unix
-    , uri-bytestring
-    , uri-bytestring-aeson
     , uuid
     , vector

--- a/inferno-ml-server-types/inferno-ml-server-types.cabal
+++ b/inferno-ml-server-types/inferno-ml-server-types.cabal
@@ -56,6 +56,9 @@ library
     , iproute
     , microlens-platform
     , postgresql-simple
+    , QuickCheck
+    , quickcheck-arbitrary-adt
+    , quickcheck-instances
     , scientific
     , servant-client
     , servant-conduit

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
@@ -457,10 +457,7 @@ instance
   where
   parseJSON = withObject "ModelVersion" $ \o ->
     ModelVersion
-      -- Note that for a model serialized as JSON, the `id` must be present
-      -- (this assumes that a model version serialized as JSON always refers
-      -- to one that exists in the DB already)
-      <$> fmap Just (o .: "id")
+      <$> o .:? "id"
       <*> o .: "model"
       <*> o .: "card"
       <*> fmap (Oid . fromIntegral @Word64) (o .: "contents")

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
@@ -499,11 +499,9 @@ instance FromJSON ModelDescription where
 
 -- | Metadata for the model, inspired by Hugging Face model card format
 data ModelMetadata = ModelMetadata
-  { languages :: Vector ISO63912,
-    tags :: Vector Text,
+  { categories :: Vector Int,
     datasets :: Vector Text,
     metrics :: Vector Text,
-    license :: Maybe Text,
     baseModel :: Maybe Text,
     thumbnail :: Maybe (Text, URIRef Absolute)
   }
@@ -515,11 +513,9 @@ instance NFData ModelMetadata where
 instance FromJSON ModelMetadata where
   parseJSON = withObject "ModelMetadata" $ \o ->
     ModelMetadata
-      <$> o .:? "languages" .!= mempty
-      <*> o .:? "tags" .!= mempty
+      <$> o .:? "categories" .!= mempty
       <*> o .:? "datasets" .!= mempty
       <*> o .:? "metrics" .!= mempty
-      <*> o .:? "license"
       <*> o .:? "base_model"
       <*> (thumbnailP =<< o .:? "thumbnail")
     where

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
@@ -9,7 +9,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators #-}
-{-# OPTIONS_GHC -Wno-orphans #-}
 {-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
 
 module Inferno.ML.Server.Types where

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
@@ -112,8 +112,6 @@ import Test.QuickCheck.Instances.Time ()
 import Test.QuickCheck.Instances.UUID ()
 import Test.QuickCheck.Instances.Vector ()
 import Text.Read (readMaybe)
-import URI.ByteString (Absolute, URIRef)
-import URI.ByteString.Aeson ()
 import Web.HttpApiData
   ( FromHttpApiData (parseUrlPiece),
     ToHttpApiData (toUrlPiece),
@@ -557,8 +555,7 @@ data ModelMetadata = ModelMetadata
   { categories :: Vector Int,
     datasets :: Vector Text,
     metrics :: Vector Text,
-    baseModel :: Maybe Text,
-    thumbnail :: Maybe (Text, URIRef Absolute)
+    baseModel :: Maybe Text
   }
   deriving stock (Show, Eq, Generic)
 
@@ -569,9 +566,6 @@ instance Arbitrary ModelMetadata where
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
-      -- For the sake of simplicity, just set this field
-      -- unconditionally to `Nothing` for now
-      <*> pure Nothing
 
 instance ToADTArbitrary ModelMetadata where
   toADTArbitrarySingleton _ =
@@ -593,12 +587,6 @@ instance FromJSON ModelMetadata where
       <*> o .:? "datasets" .!= mempty
       <*> o .:? "metrics" .!= mempty
       <*> o .:? "base_model"
-      <*> (thumbnailP =<< o .:? "thumbnail")
-    where
-      thumbnailP :: Maybe Object -> Parser (Maybe (Text, URIRef Absolute))
-      thumbnailP = \case
-        Nothing -> pure Nothing
-        Just o -> fmap Just $ (,) <$> o .: "description" <*> o .: "url"
 
 instance ToJSON ModelMetadata where
   toJSON =


### PR DESCRIPTION
Adds `Arbitrary` and `ToADTArbitrary` instances for most types in `inferno-ml-server-types`

Also simplifies `ModelMetadata` 