### PR TITLE
Make it build with mil 2.3

### DIFF
--- a/inferno-core/src/Inferno/Core.hs
+++ b/inferno-core/src/Inferno/Core.hs
@@ -6,7 +6,7 @@ module Inferno.Core where
 
 import Control.Monad (foldM)
 import Control.Monad.Catch (MonadCatch, MonadThrow)
-import Control.Monad.Except (MonadFix)
+import Control.Monad.Fix (MonadFix)
 import Data.Bifunctor (bimap, first)
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.Map as Map

--- a/inferno-core/src/Inferno/Eval.hs
+++ b/inferno-core/src/Inferno/Eval.hs
@@ -3,8 +3,8 @@
 
 module Inferno.Eval where
 
+import Control.Monad (forM)
 import Control.Monad.Catch (MonadCatch, MonadThrow (throwM), try)
-import Control.Monad.Except (forM)
 import Control.Monad.Reader (ask, local)
 import Data.Foldable (foldrM)
 import Data.Functor ((<&>))

--- a/inferno-core/src/Inferno/Infer.hs
+++ b/inferno-core/src/Inferno/Infer.hs
@@ -16,14 +16,16 @@ module Inferno.Infer
   )
 where
 
-import Control.Monad (when)
+import Control.Monad
+  ( foldM,
+    forM,
+    forM_,
+    when
+  )
 import Control.Monad.Except
   ( Except,
     ExceptT,
     MonadError (catchError, throwError),
-    foldM,
-    forM,
-    forM_,
     runExcept,
     runExceptT,
   )

--- a/inferno-core/src/Inferno/Instances/Arbitrary.hs
+++ b/inferno-core/src/Inferno/Instances/Arbitrary.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 

--- a/inferno-core/src/Inferno/Utils/QQ/Script.hs
+++ b/inferno-core/src/Inferno/Utils/QQ/Script.hs
@@ -8,7 +8,8 @@ module Inferno.Utils.QQ.Script where
 import Control.Monad.Catch (MonadCatch (..), MonadThrow (..))
 import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.Reader (ReaderT (..))
-import Control.Monad.Writer (WriterT (..), appEndo)
+import Control.Monad.Writer (WriterT (..))
+import Data.Monoid (appEndo)
 import qualified Crypto.Hash as Crypto
 import Data.ByteArray (convert)
 import Data.ByteString (ByteString, unpack)


### PR DESCRIPTION
`mtl` no longer re-exports some common monad functions so import them from their place