### PR TITLE
[inferno-ml] Simplify model permissions, add more metadata

### DIFF
--- a/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
@@ -409,6 +409,7 @@ data ModelVersion uid gid c = ModelVersion
     -- | Foreign key of the @model@ table, which contains invariant metadata
     -- related to the model, i.e. name, permissions, user
     model :: Id (Model uid gid),
+    description :: Text,
     card :: ModelCard,
     -- | The actual contents of version of the model. Normally this will be
     -- an 'Oid' pointing to the serialized bytes of the model imported into
@@ -435,6 +436,7 @@ instance
   fromRow =
     ModelVersion
       <$> field
+      <*> field
       <*> field
       <*> field
       <*> field
@@ -468,6 +470,7 @@ instance
     ModelVersion
       <$> o .:? "id"
       <*> o .: "model"
+      <*> o .: "description"
       <*> o .: "card"
       <*> fmap (Oid . fromIntegral @Word64) (o .: "contents")
       <*> o .: "version"
@@ -500,6 +503,7 @@ instance Arbitrary c => Arbitrary (ModelVersion uid gid c) where
   arbitrary =
     ModelVersion
       <$> arbitrary
+      <*> arbitrary
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
@@ -937,24 +937,6 @@ instance Arbitrary (EvaluationInfo uid gid p) where
       <*> arbitrary
       <*> arbitrary
 
--- | A user, parameterized by the user and group types
-data User uid gid = User
-  { id :: uid,
-    groups :: Vector gid
-  }
-  deriving stock (Show, Generic, Eq)
-  deriving anyclass
-    ( FromRow,
-      ToRow,
-      FromJSON,
-      ToJSON,
-      NFData,
-      ToADTArbitrary
-    )
-
-instance (Arbitrary uid, Arbitrary gid) => Arbitrary (User uid gid) where
-  arbitrary = genericArbitrary
-
 -- | IPv4 address with some useful instances
 newtype IPv4 = IPv4 Data.IP.IPv4
   deriving stock (Generic)

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
@@ -429,6 +429,7 @@ instance ToField gid => ToRow (ModelVersion gid Oid) where
   toRow mv =
     [ toField Default,
       mv.model & toField,
+      mv.description & toField,
       mv.card & Aeson & toField,
       mv.contents & toField,
       mv.version & toField,

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
@@ -456,6 +456,7 @@ instance ToJSON gid => ToJSON (ModelVersion gid Oid) where
     object
       [ "id" .= mv.id,
         "model" .= mv.model,
+        "description" .= mv.description,
         "contents" .= unOid mv.contents,
         "version" .= mv.version,
         "card" .= mv.card,

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
@@ -284,9 +284,6 @@ data Model uid gid = Model
     -- text (which is required to use @hstore@). So using @jsonb@ allows
     -- for greater potential flexibility
     permissions :: Map gid ModelPermissions,
-    -- | The user who owns the model, if any. Note that owning a model
-    -- will implicitly set permissions
-    user :: Maybe uid,
     -- | The time that this model was \"deleted\", if any. For active models,
     -- this will be @Nothing@
     terminated :: Maybe UTCTime
@@ -312,7 +309,6 @@ instance
       <*> field
       <*> fmap getAeson field
       <*> field
-      <*> field
 
 instance
   ( ToField uid,
@@ -326,7 +322,6 @@ instance
     [ toField Default,
       m ^. the @"name" & toField,
       m ^. the @"permissions" & Aeson & toField,
-      m ^. the @"user" & toField,
       -- The `ToRow` instance is only for new rows, so we don't want
       -- to set the `terminated` field to anything by default
       --
@@ -349,7 +344,6 @@ instance
       <$> o .:? "id"
       <*> (ensureNotNull =<< o .: "name")
       <*> o .: "permissions"
-      <*> o .:? "user"
       -- If a new model is being serialized, it does not really make
       -- sense to require a `"terminated": null` field
       <*> o .:? "terminated"
@@ -372,7 +366,6 @@ instance
       [ "id" .= view (the @"id") m,
         "name" .= view (the @"name") m,
         "permissions" .= view (the @"permissions") m,
-        "user" .= view (the @"user") m,
         "terminated" .= view (the @"terminated") m
       ]
 
@@ -387,7 +380,6 @@ instance
   arbitrary =
     Model
       <$> arbitrary
-      <*> arbitrary
       <*> arbitrary
       <*> arbitrary
       <*> genMUtc

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
@@ -490,7 +490,7 @@ instance Arbitrary c => ToADTArbitrary (ModelVersion gid c) where
 -- | Full description and metadata of the model
 data ModelCard = ModelCard
   { -- | High-level, structured overview of model details and summary
-    description :: ModelDescription,
+    summary :: ModelSummary,
     metadata :: ModelMetadata
   }
   deriving stock (Show, Eq, Generic)
@@ -500,9 +500,10 @@ data ModelCard = ModelCard
 instance Arbitrary ModelCard where
   arbitrary = genericArbitrary
 
--- | Structured description of a model
-data ModelDescription = ModelDescription
-  { -- | General summary of model, cannot be empty
+-- | Structured summary of a model
+data ModelSummary = ModelSummary
+  { -- | General summary of model (longer than top-level @description@ field
+    -- of 'ModelVersion' type)
     summary :: Text,
     -- | How the model is intended to be used
     uses :: Text,
@@ -512,15 +513,15 @@ data ModelDescription = ModelDescription
   deriving anyclass (ToJSON, NFData, ToADTArbitrary)
 
 {- ORMOLU_DISABLE -}
-instance FromJSON ModelDescription where
-  parseJSON = withObject "ModelDescription" $ \o ->
-    ModelDescription
+instance FromJSON ModelSummary where
+  parseJSON = withObject "ModelSummary" $ \o ->
+    ModelSummary
       <$> o .: "summary"
       <*> o .:? "uses" .!= mempty
       <*> o .:? "evaluation" .!= mempty
 {- ORMOLU_ENABLE -}
 
-instance Arbitrary ModelDescription where
+instance Arbitrary ModelSummary where
   arbitrary = genericArbitrary
 
 -- | Metadata for the model, inspired by Hugging Face model card format

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
@@ -564,10 +564,6 @@ data ModelDescription = ModelDescription
     summary :: Text,
     -- | How the model is intended to be used
     uses :: Text,
-    -- | Applicable limitations, risks, biases, etc...
-    risks :: Text,
-    -- | Details on training data, speed\/size of training elements, etc...
-    training :: Text,
     evaluation :: Text
   }
   deriving stock (Show, Eq, Generic)
@@ -579,8 +575,6 @@ instance FromJSON ModelDescription where
     ModelDescription
       <$> o .: "summary"
       <*> o .:? "uses" .!= mempty
-      <*> o .:? "risks" .!= mempty
-      <*> o .:? "training" .!= mempty
       <*> o .:? "evaluation" .!= mempty
 {- ORMOLU_ENABLE -}
 
@@ -590,8 +584,8 @@ instance Arbitrary ModelDescription where
 -- | Metadata for the model, inspired by Hugging Face model card format
 data ModelMetadata = ModelMetadata
   { categories :: Vector Int,
-    datasets :: Vector Text,
-    metrics :: Vector Text,
+    datasets :: Text,
+    metrics :: Text,
     baseModel :: Maybe Text
   }
   deriving stock (Show, Eq, Generic)

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
@@ -272,56 +272,41 @@ instance
 -- versions, e.g. model name and permissions. A second table, 'ModelVersion',
 -- contains the specific versions of each model (and the actual model contents),
 -- along with other metadata that may change between versions
-data Model uid gid = Model
-  { id :: Maybe (Id (Model uid gid)),
+data Model gid = Model
+  { id :: Maybe (Id (Model gid)),
     name :: Text,
-    -- | Permissions for reading or updating the model, keyed by the group ID
-    -- type
-    --
-    -- NOTE: This is stored as a @jsonb@ rather than as @hstore@. It could
-    -- currently be stored as an @hstore@, but later we might want to
-    -- use a more complex type that we could not easily convert to\/from
-    -- text (which is required to use @hstore@). So using @jsonb@ allows
-    -- for greater potential flexibility
-    permissions :: Map gid ModelPermissions,
+    -- | The group that owns this model
+    gid :: gid,
     -- | The time that this model was \"deleted\", if any. For active models,
     -- this will be @Nothing@
     terminated :: Maybe UTCTime
   }
   deriving stock (Show, Eq, Generic)
 
-instance NFData (Model uid gid) where
+instance NFData (Model gid) where
   rnf = rwhnf
 
 instance
   ( Typeable gid,
-    FromField uid,
     FromField gid,
-    FromJSONKey gid,
     Ord gid
   ) =>
-  FromRow (Model uid gid)
+  FromRow (Model gid)
   where
   -- NOTE: Order of fields must align exactly with DB schema
   fromRow =
     Model
       <$> field
       <*> field
-      <*> fmap getAeson field
+      <*> field
       <*> field
 
-instance
-  ( ToField uid,
-    ToField gid,
-    ToJSONKey gid
-  ) =>
-  ToRow (Model uid gid)
-  where
+instance ToField gid => ToRow (Model gid) where
   -- NOTE: Order of fields must align exactly with DB schema
   toRow m =
     [ toField Default,
       m ^. the @"name" & toField,
-      m ^. the @"permissions" & Aeson & toField,
+      m ^. the @"gid" & toField,
       -- The `ToRow` instance is only for new rows, so we don't want
       -- to set the `terminated` field to anything by default
       --
@@ -332,18 +317,17 @@ instance
 
 {- ORMOLU_DISABLE -}
 instance
-  ( FromJSON uid,
-    FromJSONKey gid,
+  ( FromJSON gid,
     Ord gid
   ) =>
-  FromJSON (Model uid gid)
+  FromJSON (Model gid)
   where
   parseJSON = withObject "Model" $ \o ->
     Model
       -- If a new model is being created, its ID will not be present
       <$> o .:? "id"
       <*> (ensureNotNull =<< o .: "name")
-      <*> o .: "permissions"
+      <*> o .: "gid"
       -- If a new model is being serialized, it does not really make
       -- sense to require a `"terminated": null` field
       <*> o .:? "terminated"
@@ -355,28 +339,17 @@ instance
           | otherwise = pure t
 {- ORMOLU_ENABLE -}
 
-instance
-  ( ToJSON uid,
-    ToJSONKey gid
-  ) =>
-  ToJSON (Model uid gid)
-  where
+instance ToJSON gid => ToJSON (Model gid) where
   toJSON m =
     object
       [ "id" .= view (the @"id") m,
         "name" .= view (the @"name") m,
-        "permissions" .= view (the @"permissions") m,
+        "gid" .= view (the @"gid") m,
         "terminated" .= view (the @"terminated") m
       ]
 
 -- Not derived generically in order to use special `Gen UTCTime`
-instance
-  ( Ord gid,
-    Arbitrary gid,
-    Arbitrary uid
-  ) =>
-  Arbitrary (Model uid gid)
-  where
+instance (Ord gid, Arbitrary gid) => Arbitrary (Model gid) where
   arbitrary =
     Model
       <$> arbitrary
@@ -385,10 +358,7 @@ instance
       <*> genMUtc
 
 -- Can't be derived because there is (intentially) no `Arbitrary UTCTime` in scope
-instance
-  (Arbitrary uid, Arbitrary gid, Ord gid) =>
-  ToADTArbitrary (Model uid gid)
-  where
+instance (Arbitrary gid, Ord gid) => ToADTArbitrary (Model gid) where
   toADTArbitrarySingleton _ =
     ADTArbitrarySingleton "Inferno.ML.Server.Types" "Model"
       . ConstructorArbitraryPair "Model"
@@ -404,11 +374,11 @@ instance
 -- content, which will normally be an 'Oid' (Postgres large object). Other
 -- model metadata is contained here as well, e.g. the model card, as this
 -- might change between versions
-data ModelVersion uid gid c = ModelVersion
-  { id :: Maybe (Id (ModelVersion uid gid c)),
+data ModelVersion gid c = ModelVersion
+  { id :: Maybe (Id (ModelVersion gid c)),
     -- | Foreign key of the @model@ table, which contains invariant metadata
     -- related to the model, i.e. name, permissions, user
-    model :: Id (Model uid gid),
+    model :: Id (Model gid),
     description :: Text,
     card :: ModelCard,
     -- | The actual contents of version of the model. Normally this will be
@@ -424,12 +394,7 @@ data ModelVersion uid gid c = ModelVersion
   -- NOTE: This may require an orphan instance for the `c` type variable
   deriving anyclass (NFData)
 
-instance
-  ( FromField uid,
-    FromField gid
-  ) =>
-  FromRow (ModelVersion uid gid Oid)
-  where
+instance FromField gid => FromRow (ModelVersion gid Oid) where
   -- NOTE: Order of fields must align exactly with DB schema. This instance
   -- could just be `anyclass` derived but it's probably better to be as
   -- explicit as possible
@@ -443,12 +408,7 @@ instance
       <*> field
       <*> field
 
-instance
-  ( ToField uid,
-    ToField gid
-  ) =>
-  ToRow (ModelVersion uid gid Oid)
-  where
+instance ToField gid => ToRow (ModelVersion gid Oid) where
   -- NOTE: Order of fields must align exactly with DB schema
   toRow mv =
     [ toField Default,
@@ -460,12 +420,7 @@ instance
     ]
 
 {- ORMOLU_DISABLE -}
-instance
-  ( FromJSON uid,
-    FromJSON gid
-  ) =>
-  FromJSON (ModelVersion uid gid Oid)
-  where
+instance FromJSON gid => FromJSON (ModelVersion gid Oid) where
   parseJSON = withObject "ModelVersion" $ \o ->
     ModelVersion
       <$> o .:? "id"
@@ -479,12 +434,7 @@ instance
       <*> o .:? "terminated"
 {- ORMOLU_ENABLE -}
 
-instance
-  ( ToJSON uid,
-    ToJSON gid
-  ) =>
-  ToJSON (ModelVersion uid gid Oid)
-  where
+instance ToJSON gid => ToJSON (ModelVersion gid Oid) where
   toJSON mv =
     object
       [ "id" .= view (the @"id") mv,
@@ -499,7 +449,7 @@ instance
       unOid (Oid (CUInt x)) = x
 
 -- Not derived generically in order to use special `Gen UTCTime`
-instance Arbitrary c => Arbitrary (ModelVersion uid gid c) where
+instance Arbitrary c => Arbitrary (ModelVersion gid c) where
   arbitrary =
     ModelVersion
       <$> arbitrary
@@ -511,7 +461,7 @@ instance Arbitrary c => Arbitrary (ModelVersion uid gid c) where
       <*> genMUtc
 
 -- Can't be derived because there is (intentially) no `Arbitrary UTCTime` in scope
-instance (Arbitrary c) => ToADTArbitrary (ModelVersion uid gid c) where
+instance Arbitrary c => ToADTArbitrary (ModelVersion gid c) where
   toADTArbitrarySingleton _ =
     ADTArbitrarySingleton "Inferno.ML.Server.Types" "ModelVersion"
       . ConstructorArbitraryPair "ModelVersion"
@@ -520,30 +470,6 @@ instance (Arbitrary c) => ToADTArbitrary (ModelVersion uid gid c) where
   toADTArbitrary _ =
     ADTArbitrary "Inferno.ML.Server.Types" "ModelVersion"
       <$> sequence [ConstructorArbitraryPair "ModelVersion" <$> arbitrary]
-
--- | Permissions for reading or writing a model
-data ModelPermissions
-  = -- | The model can be read e.g. for inference
-    ReadModel
-  | -- | The model can be updated e.g. during training
-    WriteModel
-  deriving stock (Show, Eq, Generic)
-  deriving anyclass (NFData, ToADTArbitrary)
-
-instance FromJSON ModelPermissions where
-  parseJSON = withText "ModelPermissions" $ \case
-    "read" -> pure ReadModel
-    "write" -> pure WriteModel
-    t -> fail $ unwords ["Invalid model permissions:", Text.unpack t]
-
-instance ToJSON ModelPermissions where
-  toJSON =
-    String . \case
-      ReadModel -> "read"
-      WriteModel -> "write"
-
-instance Arbitrary ModelPermissions where
-  arbitrary = genericArbitrary
 
 -- | Full description and metadata of the model
 data ModelCard = ModelCard
@@ -736,7 +662,7 @@ data InferenceParam uid gid p s = InferenceParam
     -- | The time that this parameter was \"deleted\", if any. For active
     -- parameters, this will be @Nothing@
     terminated :: Maybe UTCTime,
-    user :: uid
+    uid :: uid
   }
   deriving stock (Show, Eq, Generic)
   deriving anyclass (NFData, ToJSON)
@@ -758,7 +684,7 @@ instance
       <*> o .:? "resolution" .!= 128
       -- We shouldn't require this field
       <*> o .:? "terminated"
-      <*> o .: "user"
+      <*> o .: "uid"
 {- ORMOLU_ENABLE -}
 
 -- We only want this instance if the `script` is a `VCObjectHash` (because it
@@ -794,7 +720,7 @@ instance
       ip ^. the @"inputs" & Aeson & toField,
       ip ^. the @"resolution" & Aeson & toField,
       toField Default,
-      ip ^. the @"user" & toField
+      ip ^. the @"uid" & toField
     ]
 
 -- Not derived generically in order to use special `Gen UTCTime`
@@ -838,7 +764,7 @@ data InferenceParamWithModels uid gid p s = InferenceParamWithModels
     models ::
       Map
         Ident
-        ( Id (ModelVersion uid gid Oid),
+        ( Id (ModelVersion gid Oid),
           -- Name of parent model
           Text
         )

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
@@ -336,19 +336,13 @@ instance
     Model
       -- If a new model is being created, its ID will not be present
       <$> o .:? "id"
-      <*> (ensureNotNull =<< o .: "name")
+      <*> o .: "name"
       <*> o .: "gid"
       <*> o .: "visibility"
       <*> o .:? "updated"
       -- If a new model is being serialized, it does not really make
       -- sense to require a `"terminated": null` field
       <*> o .:? "terminated"
-    where
-      ensureNotNull :: Text -> Parser Text
-      ensureNotNull
-        t
-          | Text.null t = fail "Field cannot be empty"
-          | otherwise = pure t
 {- ORMOLU_ENABLE -}
 
 instance ToJSON gid => ToJSON (Model gid) where

--- a/inferno-ml-server/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Types.hs
@@ -414,9 +414,9 @@ type BridgeInfo =
 
 type EvaluationInfo = Types.EvaluationInfo (EntityId UId) (EntityId GId) PID
 
-type Model = Types.Model (EntityId UId) (EntityId GId)
+type Model = Types.Model (EntityId GId)
 
-type ModelVersion = Types.ModelVersion (EntityId UId) (EntityId GId) Oid
+type ModelVersion = Types.ModelVersion (EntityId GId) Oid
 
 type InferenceScript = Types.InferenceScript ScriptMetadata (EntityId GId)
 

--- a/inferno-ml-server/test/Main.hs
+++ b/inferno-ml-server/test/Main.hs
@@ -107,7 +107,6 @@ mkDbSpec env = Hspec.describe "Database" $ do
         | Just (model, mversion) <- v ^? _head -> do
             view #name model `Hspec.shouldBe` "mnist"
             view (#version . to showVersion) mversion `Hspec.shouldBe` "v1"
-            view #user model `Hspec.shouldBe` Nothing
         | otherwise -> Hspec.expectationFailure "No models were retrieved"
 
   Hspec.it "gets model size and contents" $ do

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -86,8 +86,11 @@ pkgs.haskell-nix.cabalProject {
         );
       };
     };
-    buildInputs = [ config.treefmt.build.wrapper ]
-      ++ builtins.attrValues config.treefmt.build.programs;
+    buildInputs = [
+      pkgs.postgresql
+      config.treefmt.build.wrapper
+    ]
+    ++ builtins.attrValues config.treefmt.build.programs;
     shellHook =
       let
         setpath = lib.optionalString cudaSupport

--- a/nix/inferno-ml/migrations/v1-create-tables.sql
+++ b/nix/inferno-ml/migrations/v1-create-tables.sql
@@ -31,10 +31,8 @@ create table if not exists models
     -- might allow us to include a more complex structure in the future more
     -- easily
   , permissions jsonb not null
-  , "user" integer references users (id)
     -- See note above
   , terminated timestamptz
-  , unique (name, "user")
   );
 
 create table if not exists mversions

--- a/nix/inferno-ml/migrations/v1-create-tables.sql
+++ b/nix/inferno-ml/migrations/v1-create-tables.sql
@@ -25,11 +25,14 @@ create table if not exists models
   , updated timestamptz
     -- See note above
   , terminated timestamptz
+  , unique (name, gid)
   );
 
 create table if not exists mversions
   ( id serial primary key
   , model integer references models (id)
+    -- Short, high-level model description
+  , description text not null
     -- Model card (description and metadata) serialized as JSON
   , card jsonb not null
     -- The model contents are not stored directly because it might exceed

--- a/nix/inferno-ml/migrations/v1-create-tables.sql
+++ b/nix/inferno-ml/migrations/v1-create-tables.sql
@@ -20,6 +20,9 @@ create table if not exists models
   ( id serial primary key
   , name text not null
   , gid bigint not null
+  , visibility jsonb
+    -- May be missing, if there is no model version yet
+  , updated timestamptz
     -- See note above
   , terminated timestamptz
   );

--- a/nix/inferno-ml/migrations/v1-create-tables.sql
+++ b/nix/inferno-ml/migrations/v1-create-tables.sql
@@ -19,11 +19,7 @@ create extension lo;
 create table if not exists models
   ( id serial primary key
   , name text not null
-    -- Represented as a map from group IDs to model permissions (read or write),
-    -- serialized to JSON. This is a bit more flexible than using an `hstore` and
-    -- might allow us to include a more complex structure in the future more
-    -- easily
-  , permissions jsonb not null
+  , gid bigint not null
     -- See note above
   , terminated timestamptz
   );
@@ -75,7 +71,7 @@ create table if not exists params
   , resolution integer not null
     -- See note above
   , terminated timestamptz
-  , "user" bigint not null
+  , uid bigint not null
   );
 
 -- Execution info for inference evaluation

--- a/nix/inferno-ml/migrations/v1-create-tables.sql
+++ b/nix/inferno-ml/migrations/v1-create-tables.sql
@@ -16,13 +16,6 @@ create extension lo;
 -- caching models, etc... If the field is not null, then the entity has been
 -- "deleted" and cannot be used any longer
 
-create table if not exists users
-  ( -- Note: this is the bson object ID represented as an integer
-    id integer primary key
-    -- Also a list of bson object IDs. This determines model access (see below)
-  , groups integer[] not null
-  );
-
 create table if not exists models
   ( id serial primary key
   , name text not null
@@ -82,7 +75,7 @@ create table if not exists params
   , resolution integer not null
     -- See note above
   , terminated timestamptz
-  , "user" integer references users (id)
+  , "user" bigint not null
   );
 
 -- Execution info for inference evaluation


### PR DESCRIPTION
Includes several changes to the `Model` and related types:

- Model permissions are now expressed as a single group ID (which simplifies things considerably)
- Models now contain `visibility` and `updated` fields, similar to Inferno VC scripts
- Some smaller changes to `ModelVersion` (adding a high-level description, etc...)
- Removal of `users` table, which isn't necessary

Since we don't need to support GHC 8 any longer, I've switched to using `-XOverloadedRecordDot` in some places. I'm going to remove GHC 8 support entirely when I finish the compiler upgrade (blocked on NVIDIA pain at the moment).

