### PR TITLE
[inferno-vc-server] Use unbounded-delays for threadDelay so it doesn't overflow on armv7l

### DIFF
--- a/inferno-vc/CHANGELOG.md
+++ b/inferno-vc/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Revision History for inferno-vc
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.3.7.1 -- 2024-09-23
+* Fix overflowing threadDelay on armv7l
+
 ## 0.3.7.0 -- 2024-08-19
 * Cached client now serializes requests to server for the same script ids in
   order to avoid DOSing the server when the same script is requested many times

--- a/inferno-vc/inferno-vc.cabal
+++ b/inferno-vc/inferno-vc.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                inferno-vc
-version:             0.3.7.0
+version:             0.3.7.1
 synopsis:            Version control server for Inferno
 description:         A version control server for Inferno scripts
 category:            DSL,Scripting

--- a/inferno-vc/inferno-vc.cabal
+++ b/inferno-vc/inferno-vc.cabal
@@ -68,6 +68,7 @@ library
     , hspec
     , QuickCheck
     , stm
+    , unbounded-delays
 
   default-language: Haskell2010
   default-extensions:

--- a/inferno-vc/src/Inferno/VersionControl/Server.hs
+++ b/inferno-vc/src/Inferno/VersionControl/Server.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -17,8 +18,8 @@ module Inferno.VersionControl.Server
   )
 where
 
-import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (link, withAsync)
+import Control.Concurrent.Thread.Delay (delay)
 import Control.Exception (Exception)
 import Control.Lens (to, (^.))
 import Control.Monad (forM, forever)
@@ -179,7 +180,7 @@ runServerConfig middleware withEnv runOp serverConfig = do
             Right _ -> pure ()
     print ("running..." :: String)
     -- Cleanup stale autosave scripts in a separate thread every hour:
-    withLinkedAsync_ (forever $ threadDelay 3600000000 >> cleanup) $
+    withLinkedAsync_ (forever $ delay 3_600_000_000 >> cleanup) $
       -- And run the server:
       runSettings (setPort port $ setHost host settingsWithTimeout) $
         ungzipRequest $


### PR DESCRIPTION
We had a `threadDelay` to perform cleanup every hour and the number of usecs was overflowing on 32 bit arch causing 100% CPU load