### PR TITLE
[inferno-ml] Fix precision for entity ID columns

### DIFF
--- a/inferno-ml-server/CHANGELOG.md
+++ b/inferno-ml-server/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Revision History for `inferno-ml-server`
 
+## 2023.9.27
+* Change entity DB representation to `numeric`
+
 ## 2023.7.2
 * Use new `loadModel` primitive and pass model names to script evaluator
 

--- a/inferno-ml-server/inferno-ml-server.cabal
+++ b/inferno-ml-server/inferno-ml-server.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               inferno-ml-server
-version:            2023.6.19
+version:            2023.9.27
 synopsis:           Server for Inferno ML
 description:        Server for Inferno ML
 homepage:           https://github.com/plow-technologies/inferno.git#readme

--- a/inferno-ml-server/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Types.hs
@@ -172,7 +172,7 @@ instance Typeable a => FromField (EntityId a) where
     maybe (returnError UnexpectedNull f mempty) $
       maybe
         (returnError ConversionFailed f mempty)
-        (pure . entityIdFromInteger . round @_ @Integer)
+        (pure . entityIdFromInteger . round)
           -- `numeric` column
         . readMaybe @Scientific
         . ByteString.Char8.unpack

--- a/inferno-ml-server/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Types.hs
@@ -48,6 +48,7 @@ import Data.Generics.Labels ()
 import Data.Generics.Wrapped (wrappedTo)
 import Data.Int (Int64)
 import Data.Map.Strict (Map)
+import Data.Scientific (Scientific)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Read as Text.Read
@@ -107,7 +108,6 @@ import UnliftIO (Async)
 import UnliftIO.IORef (IORef)
 import UnliftIO.MVar (MVar)
 import Web.HttpApiData (FromHttpApiData, ToHttpApiData)
-import Data.Scientific (Scientific)
 
 type RemoteM = ReaderT Env IO
 

--- a/inferno-ml-server/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Types.hs
@@ -161,7 +161,7 @@ instance FromJSON (EntityId a) where
       fmap entityIdFromInteger
         . either fail (pure . fst)
         . Text.Read.hexadecimal
-          -- Drop leading 'o'
+        -- Drop leading 'o'
         . Text.drop 1
 
 instance ToJSON (EntityId a) where
@@ -173,7 +173,7 @@ instance Typeable a => FromField (EntityId a) where
       maybe
         (returnError ConversionFailed f mempty)
         (pure . entityIdFromInteger . round)
-          -- `numeric` column
+        -- `numeric` column
         . readMaybe @Scientific
         . ByteString.Char8.unpack
 

--- a/nix/inferno-ml/migrations/v1-create-tables.sql
+++ b/nix/inferno-ml/migrations/v1-create-tables.sql
@@ -19,7 +19,7 @@ create extension lo;
 create table if not exists models
   ( id serial primary key
   , name text not null
-  , gid bigint not null
+  , gid numeric not null
   , visibility jsonb
     -- May be missing, if there is no model version yet
   , updated timestamptz
@@ -77,7 +77,7 @@ create table if not exists params
   , resolution integer not null
     -- See note above
   , terminated timestamptz
-  , uid bigint not null
+  , uid numeric not null
   );
 
 -- Execution info for inference evaluation


### PR DESCRIPTION
Currently some entity IDs (group/user IDs) may overflow. So this changes the column type to a `numeric` to fix that