### PR TITLE
[inferno-ml] New testing route and other improvements

### DIFF
--- a/inferno-ml-server-types/CHANGELOG.md
+++ b/inferno-ml-server-types/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Revision History for inferno-ml-server-types
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.10.0
+* Change `Id` to `UUID`
+* Add new testing endpoint to override models, script, etc...
+
 ## 0.9.1
 * `Ord`/`VCHashUpdate` instances for `ScriptInputType`
 

--- a/inferno-ml-server-types/inferno-ml-server-types.cabal
+++ b/inferno-ml-server-types/inferno-ml-server-types.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          inferno-ml-server-types
-version:       0.9.1
+version:       0.10.0
 synopsis:      Types for Inferno ML server
 description:   Types for Inferno ML server
 homepage:      https://github.com/plow-technologies/inferno.git#readme

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Client.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Client.hs
@@ -18,7 +18,7 @@ import Servant.Client.Streaming (ClientM, client)
 
 -- | Get the status of the server. @Nothing@ indicates that an inference job
 -- is being evaluated. @Just ()@ means the server is idle
-statusC :: ClientM (Maybe ())
+statusC :: ClientM ServerStatus
 
 -- | Run an inference parameter
 inferenceC ::

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Client.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Client.hs
@@ -27,9 +27,9 @@ cancelC = client $ Proxy @CancelAPI
 
 -- | Run an inference parameter
 inferenceC ::
-  forall uid gid p s.
+  forall gid p s.
   -- | SQL identifier of the inference parameter to be run
-  Id (InferenceParam uid gid p s) ->
+  Id (InferenceParam gid p s) ->
   -- | Optional resolution for scripts that use e.g. @valueAt@; defaults to
   -- the param\'s stored resolution if not provided. This lets users override
   -- the resolution on an ad-hoc basis without needing to alter the stored
@@ -44,16 +44,16 @@ inferenceC ::
   -- (not defined in this repository) to verify this before directing
   -- the writes to their final destination
   ClientM (WriteStream IO)
-inferenceC = client $ Proxy @(InferenceAPI uid gid p s)
+inferenceC = client $ Proxy @(InferenceAPI gid p s)
 
 -- | Run an inference parameter
 inferenceTestC ::
-  forall uid gid p s.
+  forall gid p s.
   ToJSON p =>
   -- | SQL identifier of the inference parameter to be run
-  Id (InferenceParam uid gid p s) ->
+  Id (InferenceParam gid p s) ->
   Maybe Int64 ->
   UUID ->
   EvaluationEnv gid p ->
   ClientM (WriteStream IO)
-inferenceTestC = client $ Proxy @(InferenceTestAPI uid gid p s)
+inferenceTestC = client $ Proxy @(InferenceTestAPI gid p s)

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Client.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Client.hs
@@ -1,27 +1,33 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE NoMonomorphismRestriction #-}
 
 module Inferno.ML.Server.Client
   ( statusC,
     inferenceC,
+    inferenceTestC,
     cancelC,
   )
 where
 
+import Data.Aeson (ToJSON)
 import Data.Int (Int64)
 import Data.Proxy (Proxy (Proxy))
 import Data.UUID (UUID)
 import Inferno.ML.Server.Types
-import Servant ((:<|>) ((:<|>)))
 import Servant.Client.Streaming (ClientM, client)
 
 -- | Get the status of the server. @Nothing@ indicates that an inference job
 -- is being evaluated. @Just ()@ means the server is idle
 statusC :: ClientM ServerStatus
+statusC = client $ Proxy @StatusAPI
+
+-- | Cancel the existing inference job, if it exists
+cancelC :: ClientM ()
+cancelC = client $ Proxy @CancelAPI
 
 -- | Run an inference parameter
 inferenceC ::
+  forall uid gid p s.
   -- | SQL identifier of the inference parameter to be run
   Id (InferenceParam uid gid p s) ->
   -- | Optional resolution for scripts that use e.g. @valueAt@; defaults to
@@ -38,11 +44,16 @@ inferenceC ::
   -- (not defined in this repository) to verify this before directing
   -- the writes to their final destination
   ClientM (WriteStream IO)
+inferenceC = client $ Proxy @(InferenceAPI uid gid p s)
 
--- | Cancel the existing inference job, if it exists
-cancelC :: ClientM ()
-statusC :<|> inferenceC :<|> cancelC =
-  client api
-
-api :: Proxy (InfernoMlServerAPI uid gid p s t)
-api = Proxy
+-- | Run an inference parameter
+inferenceTestC ::
+  forall uid gid p s.
+  ToJSON p =>
+  -- | SQL identifier of the inference parameter to be run
+  Id (InferenceParam uid gid p s) ->
+  Maybe Int64 ->
+  UUID ->
+  EvaluationEnv gid p ->
+  ClientM (WriteStream IO)
+inferenceTestC = client $ Proxy @(InferenceTestAPI uid gid p s)

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
@@ -787,13 +787,7 @@ instance
 -- linked to it indirectly via its script. This is provided for convenience
 data InferenceParamWithModels gid p s = InferenceParamWithModels
   { param :: InferenceParam gid p s,
-    models ::
-      Map
-        Ident
-        ( Id (ModelVersion gid Oid),
-          -- Name of parent model
-          Text
-        )
+    models :: Map Ident (Id (ModelVersion gid Oid))
   }
   deriving stock (Show, Eq, Generic)
 
@@ -1055,13 +1049,7 @@ instance Ord a => Ord (SingleOrMany a) where
 data EvaluationEnv gid p = EvaluationEnv
   { script :: VCObjectHash,
     inputs :: Map Ident (SingleOrMany p, ScriptInputType),
-    models ::
-      Map
-        Ident
-        ( Id (ModelVersion gid Oid),
-          -- Name of parent model
-          Text
-        )
+    models :: Map Ident (Id (ModelVersion gid Oid))
   }
   deriving stock (Show, Eq, Generic)
   deriving anyclass (FromJSON, ToJSON)

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
@@ -122,13 +122,8 @@ import Web.HttpApiData
 
 -- API type for `inferno-ml-server`
 type InfernoMlServerAPI uid gid p s t =
-  -- Check if the server is up and if any job is currently running:
-  --
-  --  * `Nothing` -> The server is evaluating a script
-  --  * `Just ()` -> The server is not doing anything and can be killed
-  --
-  -- This can be implemented using an `MVar ()`
-  "status" :> Get '[JSON] (Maybe ())
+  -- Check if the server is up and if any job is currently running
+  "status" :> Get '[JSON] ServerStatus
     -- Evaluate an inference script
     :<|> "inference"
       :> Capture "id" (Id (InferenceParam uid gid p s))
@@ -166,6 +161,12 @@ type BridgeAPI p t =
 -- @(1, [ (100, 5.0) .. (500, 2500.0) ]), (1, [ (501, 2501.0) .. (10000, 5000.0) ])@.
 -- This means the same output may appear more than once in the stream
 type WriteStream m = ConduitT () (Int, [(EpochTime, IValue)]) m ()
+
+data ServerStatus
+  = Idle
+  | EvaluatingParam
+  deriving stock (Show, Eq, Generic)
+  deriving anyclass (FromJSON, ToJSON)
 
 -- | Information for contacting a bridge server that implements the 'BridgeAPI'
 data BridgeInfo uid gid p s = BridgeInfo

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
@@ -140,6 +140,7 @@ type CancelAPI = "inference" :> "cancel" :> Put '[JSON] ()
 
 type InferenceAPI gid p s =
   "inference"
+    :> "run"
     :> Capture "id" (Id (InferenceParam gid p s))
     :> QueryParam "res" Int64
     :> QueryParam' '[Required] "uuid" UUID
@@ -148,6 +149,7 @@ type InferenceAPI gid p s =
 type InferenceTestAPI gid p s =
   -- Evaluate an inference script
   "inference"
+    :> "test"
     :> Capture "id" (Id (InferenceParam gid p s))
     :> QueryParam "res" Int64
     :> QueryParam' '[Required] "uuid" UUID

--- a/inferno-ml-server/CHANGELOG.md
+++ b/inferno-ml-server/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Revision History for `inferno-ml-server`
 
+## 2023.10.18
+* Add new testing route
+* Some improvements to model caching
+* Make `/status` not awful and confusing
+
 ## 2023.9.27
 * Change entity DB representation to `numeric`
 

--- a/inferno-ml-server/exe/ParseAndSave.hs
+++ b/inferno-ml-server/exe/ParseAndSave.hs
@@ -105,7 +105,7 @@ saveScriptAndParam ipid x now inputs conn = insertScript *> insertParam
               RETURNING id
             )
             INSERT INTO mselections (script, model, ident)
-              SELECT id, 1::integer, 'mnist'
+              SELECT id, '00000006-0000-0000-0000-000000000000'::uuid, 'mnist'
             FROM ins
           |]
 

--- a/inferno-ml-server/exe/ParseAndSave.hs
+++ b/inferno-ml-server/exe/ParseAndSave.hs
@@ -134,7 +134,7 @@ saveScriptAndParam ipid x now inputs conn = insertScript *> insertParam
                   , inputs
                   , resolution
                   , terminated
-                  , uid
+                  , gid
                   )
                 VALUES (?, ?, ?, ?, ?, ?)
               |]

--- a/inferno-ml-server/exe/ParseAndSave.hs
+++ b/inferno-ml-server/exe/ParseAndSave.hs
@@ -22,14 +22,13 @@ import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text.IO as Text.IO
 import Data.Time.Clock.POSIX (getPOSIXTime)
+import qualified Data.UUID as UUID
 import Database.PostgreSQL.Simple
   ( Connection,
-    Only (fromOnly),
     Query,
     close,
     connectPostgreSQL,
     execute,
-    query,
     withTransaction,
   )
 import Database.PostgreSQL.Simple.SqlQQ (sql)
@@ -52,7 +51,6 @@ import Inferno.VersionControl.Types
     VCObjectPred (Init),
     VCObjectVisibility (VCObjectPublic),
   )
-import Lens.Micro.Platform
 import System.Environment (getArgs)
 import System.Exit (die)
 import UnliftIO.Exception (bracket, throwString)
@@ -60,32 +58,36 @@ import UnliftIO.Exception (bracket, throwString)
 main :: IO ()
 main =
   getArgs >>= \case
-    scriptp : pstr : conns : _ ->
-      either throwString (parseAndSave scriptp (Char8.pack conns))
-        . eitherDecode
-        $ Lazy.Char8.pack pstr
-    _ -> die "Usage ./parse <SCRIPT-PATH> <PID-MAP-JSON> <DB-STR>"
+    ustr : scriptp : pstr : conns : _ -> do
+      pids <- either throwString pure $ eitherDecode (Lazy.Char8.pack pstr)
+      ipid <-
+        maybe (throwString "Invalid inference param Id") pure $
+          UUID.fromString ustr
+      parseAndSave (Id ipid) scriptp (Char8.pack conns) pids
+    _ -> die "Usage ./parse <UUID> <SCRIPT-PATH> <PID-MAP-JSON> <DB-STR>"
 
 parseAndSave ::
+  Id InferenceParam ->
   FilePath ->
   ByteString ->
   Map Ident (SingleOrMany PID, ScriptInputType) ->
   IO ()
-parseAndSave p conns inputs = do
+parseAndSave ipid p conns inputs = do
   t <- Text.IO.readFile p
   now <- fromIntegral @Int . round <$> getPOSIXTime
   ast <-
     either (throwString . displayException) pure . (`parse` t)
       =<< mkInferno @_ @BridgeMlValue (mkBridgePrelude funs) customTypes
-  bracket (connectPostgreSQL conns) close (saveScriptAndParam ast now inputs)
+  bracket (connectPostgreSQL conns) close (saveScriptAndParam ipid ast now inputs)
 
 saveScriptAndParam ::
+  Id InferenceParam ->
   (Expr (Pinned VCObjectHash) (), TCScheme) ->
   CTime ->
   Map Ident (SingleOrMany PID, ScriptInputType) ->
   Connection ->
   IO ()
-saveScriptAndParam x now inputs conn = insertScript *> insertParam
+saveScriptAndParam ipid x now inputs conn = insertScript *> insertParam
   where
     insertScript :: IO ()
     insertScript =
@@ -108,17 +110,15 @@ saveScriptAndParam x now inputs conn = insertScript *> insertParam
           |]
 
     insertParam :: IO ()
-    insertParam =
-      maybe (throwString "Can't get param ID") (saveBridgeInfo . fromOnly)
-        . preview _head
-        =<< saveParam
+    insertParam = saveParam *> saveBridgeInfo
       where
-        saveParam :: IO [Only (Id InferenceParam)]
+        saveParam :: IO ()
         saveParam =
-          withTransaction conn
-            . query conn q
+          void
+            . withTransaction conn
+            . execute conn q
             . InferenceParam
-              Nothing
+              (Just ipid)
               hash
               inputs
               128
@@ -129,12 +129,18 @@ saveScriptAndParam x now inputs conn = insertScript *> insertParam
             q =
               [sql|
                 INSERT INTO params
+                  ( id
+                  , script
+                  , inputs
+                  , resolution
+                  , terminated
+                  , uid
+                  )
                 VALUES (?, ?, ?, ?, ?, ?)
-                RETURNING id
               |]
 
-        saveBridgeInfo :: Id InferenceParam -> IO ()
-        saveBridgeInfo ipid =
+        saveBridgeInfo :: IO ()
+        saveBridgeInfo =
           void
             . withTransaction conn
             . execute conn q
@@ -161,7 +167,8 @@ saveScriptAndParam x now inputs conn = insertScript *> insertParam
           MLInferenceScript
             . InferenceOptions
             . Map.singleton "mnist"
-            $ Id 1
+            . Id
+            $ UUID.fromWords 6 0 0 0
 
     uid :: EntityId UId
     uid = entityIdFromInteger 0

--- a/inferno-ml-server/inferno-ml-server.cabal
+++ b/inferno-ml-server/inferno-ml-server.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               inferno-ml-server
-version:            2023.9.27
+version:            2023.10.18
 synopsis:           Server for Inferno ML
 description:        Server for Inferno ML
 homepage:           https://github.com/plow-technologies/inferno.git#readme

--- a/inferno-ml-server/inferno-ml-server.cabal
+++ b/inferno-ml-server/inferno-ml-server.cabal
@@ -110,6 +110,7 @@ executable tests
     , base
     , bytestring
     , containers
+    , filepath
     , generic-lens
     , hspec
     , inferno-ml-server
@@ -118,8 +119,8 @@ executable tests
     , mtl
     , plow-log
     , text
-    , uuid
     , unliftio
+    , uuid
     , vector
 
 executable test-client

--- a/inferno-ml-server/inferno-ml-server.cabal
+++ b/inferno-ml-server/inferno-ml-server.cabal
@@ -118,6 +118,7 @@ executable tests
     , mtl
     , plow-log
     , text
+    , uuid
     , unliftio
     , vector
 
@@ -184,4 +185,5 @@ executable parse-and-save
     , text
     , time
     , unliftio
+    , uuid
     , vector

--- a/inferno-ml-server/src/Inferno/ML/Server.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server.hs
@@ -126,10 +126,12 @@ api = Proxy
 server :: ServerT InfernoMlServerAPI RemoteM
 server = getStatus :<|> runInferenceParam :<|> cancelInference
   where
-    -- If the server is currently evaluating a script, this will return `Nothing`,
-    -- otherwise `Just ()`
-    getStatus :: RemoteM (Maybe ())
-    getStatus = tryReadMVar =<< view #lock
+    -- If the server is currently evaluating a script, the var will be taken,
+    -- i.e. evaluate to `Nothing`, otherwise `Just ()`
+    getStatus :: RemoteM ServerStatus
+    getStatus =
+      fmap (maybe EvaluatingScript (const Idle)) $
+        tryReadMVar =<< view #lock
 
     -- When an inference request is run, the server will store the `Async` in
     -- the `job` `MVar`. Canceling the request throws to the `Async` thread

--- a/inferno-ml-server/src/Inferno/ML/Server.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server.hs
@@ -124,7 +124,11 @@ api :: Proxy InfernoMlServerAPI
 api = Proxy
 
 server :: ServerT InfernoMlServerAPI RemoteM
-server = getStatus :<|> runInferenceParam :<|> undefined :<|> cancelInference
+server =
+  getStatus
+    :<|> runInferenceParam
+    :<|> testInferenceParam
+    :<|> cancelInference
   where
     -- If the server is currently evaluating a script, the var will be taken,
     -- i.e. evaluate to `Nothing`, otherwise `Just ()`

--- a/inferno-ml-server/src/Inferno/ML/Server.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server.hs
@@ -124,7 +124,7 @@ api :: Proxy InfernoMlServerAPI
 api = Proxy
 
 server :: ServerT InfernoMlServerAPI RemoteM
-server = getStatus :<|> runInferenceParam :<|> cancelInference
+server = getStatus :<|> runInferenceParam :<|> undefined :<|> cancelInference
   where
     -- If the server is currently evaluating a script, the var will be taken,
     -- i.e. evaluate to `Nothing`, otherwise `Just ()`

--- a/inferno-ml-server/src/Inferno/ML/Server/Bridge.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Bridge.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE QuasiQuotes #-}
 
 module Inferno.ML.Server.Bridge
@@ -69,9 +70,4 @@ callBridge bi c =
     mkEnv = asks $ (`mkClientEnv` url) . view #manager
       where
         url :: BaseUrl
-        url =
-          BaseUrl
-            Http
-            (view (#host . to show) bi)
-            (view (#port . to fromIntegral) bi)
-            mempty
+        url = BaseUrl Http (show bi.host) (fromIntegral bi.port) mempty

--- a/inferno-ml-server/src/Inferno/ML/Server/Inference.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Inference.hs
@@ -147,7 +147,7 @@ runInferenceParam ipid mres uuid =
       -- need to be updated to use an absolute path to a versioned model,
       -- e.g. `loadModel "~/inferno/.cache/..."`)
       withCurrentDirectory (view #path cache) $ do
-        logInfo $ EvaluatingScript ipid
+        logInfo $ EvaluatingParam ipid
         traverse_ linkVersionedModel
           =<< getAndCacheModels cache (view #models param)
         runEval interpreter param t obj

--- a/inferno-ml-server/src/Inferno/ML/Server/Inference.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Inference.hs
@@ -505,7 +505,9 @@ getAndCacheModels cache =
       where
         mkPath :: RemoteM FilePath
         mkPath =
-          maybe (throwM (OtherRemoteError "todo")) (pure . mkModelPath) $
+          maybe
+            (throwM (OtherRemoteError "Missing model version ID"))
+            (pure . mkModelPath)
             mversion.id
 
     -- Checks that the configured cache size will not be exceeded by

--- a/inferno-ml-server/src/Inferno/ML/Server/Inference.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Inference.hs
@@ -126,6 +126,10 @@ runInferenceParam ipid mres uuid =
         ?? pwm.param.script
         ?? mres
 
+-- | Test an inference param. This requires a script object to be saved to
+-- the DB, but it is does not need to be linked to the parameter itself. It
+-- also allows for overriding models and inputs, which normally need to be
+-- fixed to the script or param, respectively
 testInferenceParam ::
   Id InferenceParam ->
   Maybe Int64 ->
@@ -150,7 +154,7 @@ testInferenceParam ipid mres uuid eenv =
 
     getParam :: RemoteM InferenceParam
     getParam =
-      firstOrThrow (NoSuchParameter (wrappedTo ipid))
+      firstOrThrow (NoSuchParameter ipid)
         =<< queryStore q (Only ipid)
       where
         q :: Query
@@ -464,7 +468,7 @@ getParameterWithModels ipid =
         . fmap (getAeson . fromOnly)
         . joinToTuple
     )
-    . firstOrThrow (NoSuchParameter (wrappedTo ipid))
+    . firstOrThrow (NoSuchParameter ipid)
     =<< queryStore q (Only ipid)
   where
     -- This query is somewhat complex in order to get all relevent information

--- a/inferno-ml-server/src/Inferno/ML/Server/Log.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Log.hs
@@ -29,7 +29,7 @@ traceRemote = \case
           tshow $ t `div` 1000000,
           "(seconds)"
         ]
-    EvaluatingScript s ->
+    EvaluatingParam s ->
       Text.unwords
         [ "Evaluating inferno script for parameter:",
           tshow s

--- a/inferno-ml-server/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Types.hs
@@ -375,7 +375,7 @@ data RemoteTrace
 data TraceInfo
   = StartingServer
   | RunningInference (Id InferenceParam) Int
-  | EvaluatingScript (Id InferenceParam)
+  | EvaluatingParam (Id InferenceParam)
   | CopyingModel (Id ModelVersion)
   | OtherInfo Text
   deriving stock (Show, Eq, Generic)

--- a/inferno-ml-server/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Types.hs
@@ -447,9 +447,7 @@ pattern InferenceParam iid s ios res mt gid =
   Types.InferenceParam iid s ios res mt gid
 
 pattern InferenceParamWithModels ::
-  InferenceParam ->
-  Map Ident (Id ModelVersion, Text) ->
-  InferenceParamWithModels
+  InferenceParam -> Map Ident (Id ModelVersion) -> InferenceParamWithModels
 pattern InferenceParamWithModels ip mvs = Types.InferenceParamWithModels ip mvs
 
 pattern BridgeInfo :: Id InferenceParam -> IPv4 -> Word64 -> BridgeInfo

--- a/inferno-ml-server/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Types.hs
@@ -297,9 +297,8 @@ newtype InferenceOptions = InferenceOptions
 
 data RemoteError
   = CacheSizeExceeded
-  | -- | Either the requested model version does not exist, or the
-    -- parent model row corresponding to the model version does not
-    -- exist
+  | -- | Either parent model row corresponding to the model version, or the
+    -- the requested model version itself, does not exist
     NoSuchModel (Either (Id Model) (Id ModelVersion))
   | NoSuchScript VCObjectHash
   | NoSuchParameter (Id InferenceParam)
@@ -415,15 +414,15 @@ infixl 4 ??
 f ?? x = ($ x) <$> f
 
 type InferenceParam =
-  Types.InferenceParam (EntityId UId) (EntityId GId) PID VCObjectHash
+  Types.InferenceParam (EntityId GId) PID VCObjectHash
 
 type InferenceParamWithModels =
-  Types.InferenceParamWithModels (EntityId UId) (EntityId GId) PID VCObjectHash
+  Types.InferenceParamWithModels (EntityId GId) PID VCObjectHash
 
 type BridgeInfo =
-  Types.BridgeInfo (EntityId UId) (EntityId GId) PID VCObjectHash
+  Types.BridgeInfo (EntityId GId) PID VCObjectHash
 
-type EvaluationInfo = Types.EvaluationInfo (EntityId UId) (EntityId GId) PID
+type EvaluationInfo = Types.EvaluationInfo (EntityId GId) PID
 
 type Model = Types.Model (EntityId GId)
 
@@ -442,10 +441,10 @@ pattern InferenceParam ::
   Map Ident (SingleOrMany PID, ScriptInputType) ->
   Word64 ->
   Maybe UTCTime ->
-  EntityId UId ->
+  EntityId GId ->
   InferenceParam
-pattern InferenceParam iid s ios res mt uid =
-  Types.InferenceParam iid s ios res mt uid
+pattern InferenceParam iid s ios res mt gid =
+  Types.InferenceParam iid s ios res mt gid
 
 pattern InferenceParamWithModels ::
   InferenceParam ->
@@ -480,11 +479,7 @@ pattern EvaluationInfo ::
 pattern EvaluationInfo u i s e m c = Types.EvaluationInfo u i s e m c
 
 type InfernoMlServerAPI =
-  Types.InfernoMlServerAPI
-    (EntityId UId)
-    (EntityId GId)
-    PID
-    VCObjectHash
+  Types.InfernoMlServerAPI (EntityId GId) PID VCObjectHash
 
 type EvaluationEnv = Types.EvaluationEnv (EntityId GId) PID
 
@@ -499,6 +494,8 @@ instance ToField VCObjectHash where
 deriving newtype instance ToHttpApiData EpochTime
 
 deriving newtype instance FromHttpApiData EpochTime
+
+-- Etc
 
 joinToTuple :: (a :. b) -> (a, b)
 joinToTuple (a :. b) = (a, b)

--- a/inferno-ml-server/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Types.hs
@@ -479,7 +479,6 @@ type InfernoMlServerAPI =
     (EntityId GId)
     PID
     VCObjectHash
-    EpochTime
 
 -- Orphans
 

--- a/inferno-ml-server/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Types.hs
@@ -76,6 +76,7 @@ import Inferno.Core (Interpreter)
 import Inferno.ML.Server.Module.Types as M
 import "inferno-ml-server-types" Inferno.ML.Server.Types as M hiding
   ( BridgeInfo,
+    EvaluationEnv,
     EvaluationInfo,
     InferenceParam,
     InferenceParamWithModels,
@@ -479,6 +480,8 @@ type InfernoMlServerAPI =
     (EntityId GId)
     PID
     VCObjectHash
+
+type EvaluationEnv = Types.EvaluationEnv (EntityId GId) PID
 
 -- Orphans
 

--- a/inferno-ml-server/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Types.hs
@@ -46,7 +46,6 @@ import qualified Data.ByteString.Char8 as ByteString.Char8
 import Data.Data (Typeable)
 import Data.Generics.Labels ()
 import Data.Generics.Wrapped (wrappedTo)
-import Data.Int (Int64)
 import Data.Map.Strict (Map)
 import Data.Scientific (Scientific)
 import Data.Text (Text)
@@ -301,9 +300,9 @@ data RemoteError
   | -- | Either the requested model version does not exist, or the
     -- parent model row corresponding to the model version does not
     -- exist
-    NoSuchModel Int64
+    NoSuchModel (Either (Id Model) (Id ModelVersion))
   | NoSuchScript VCObjectHash
-  | NoSuchParameter Int64
+  | NoSuchParameter (Id InferenceParam)
   | InvalidScript Text
   | InvalidOutput Text
   | -- | Any error condition returned by Inferno script evaluation
@@ -317,10 +316,16 @@ data RemoteError
 instance Exception RemoteError where
   displayException = \case
     CacheSizeExceeded -> "Model exceeds maximum cache size"
-    NoSuchModel m ->
+    NoSuchModel (Left m) ->
       unwords
         [ "Model:",
           "'" <> show m <> "'",
+          "does not exist in the store"
+        ]
+    NoSuchModel (Right mv) ->
+      unwords
+        [ "Model version:",
+          "'" <> show mv <> "'",
           "does not exist in the store"
         ]
     NoSuchScript vch ->

--- a/inferno-ml-server/test/Client.hs
+++ b/inferno-ml-server/test/Client.hs
@@ -50,8 +50,8 @@ main =
 verifyWrites :: UUID -> WriteStream IO -> IO ()
 verifyWrites ipid c = do
   expected <- getExpected
-  -- Note that there is only one chunk per PID in the output stream, so we
-  -- don't need to concatenate the results by PID. We can just sink it into
+  -- Note that there are only one or two chunks per PID in the output stream, so
+  -- we don't need to concatenate the results by PID. We can just sink it into
   -- a list directly
   result <- runConduit $ c .| sinkList
   unless (result == expected) . throwString . unwords $

--- a/inferno-ml-server/test/Client.hs
+++ b/inferno-ml-server/test/Client.hs
@@ -9,8 +9,9 @@ module Client (main) where
 import Conduit
 import Control.Monad (unless)
 import Data.Coerce (coerce)
-import Data.Int (Int64)
 import qualified Data.Map as Map
+import Data.UUID (UUID)
+import qualified Data.UUID as UUID
 import Inferno.ML.Server.Client (inferenceC)
 import Inferno.ML.Server.Types
   ( IValue (IDouble),
@@ -46,7 +47,7 @@ main =
     _ -> die "Usage: test-client <inference-parameter-id>"
 
 -- Check that the returned write stream matches the expected value
-verifyWrites :: Int64 -> WriteStream IO -> IO ()
+verifyWrites :: UUID -> WriteStream IO -> IO ()
 verifyWrites ipid c = do
   expected <- getExpected
   -- Note that there is only one chunk per PID in the output stream, so we
@@ -64,17 +65,18 @@ verifyWrites ipid c = do
   where
     getExpected :: IO [(Int, [(EpochTime, IValue)])]
     getExpected =
-      maybe (throwString "Missing PID") pure . Map.lookup ipid $
-        Map.fromList
-          [ ( 1,
+      maybe (throwString "Missing output PID for parameter") pure
+        . Map.lookup ipid
+        $ Map.fromList
+          [ ( UUID.fromWords 1 0 0 0,
               [ (1, [(151, IDouble 2.5), (251, IDouble 3.5)])
               ]
             ),
-            ( 2,
+            ( UUID.fromWords 2 0 0 0,
               [ (2, [(300, IDouble 25.0)])
               ]
             ),
-            ( 3,
+            ( UUID.fromWords 3 0 0 0,
               [ (3, [(100, IDouble 7.0)]),
                 (4, [(100, IDouble 8.0)])
               ]

--- a/inferno-ml-server/test/Main.hs
+++ b/inferno-ml-server/test/Main.hs
@@ -15,6 +15,7 @@ import Data.Foldable (toList, traverse_)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
+import qualified Data.UUID as UUID
 import Data.Vector (Vector)
 import qualified Data.Vector as Vector
 import Data.Word (Word8)
@@ -127,7 +128,7 @@ getWithContents env = flip runReaderT env $ do
     v : _ -> getModelVersionSizeAndContents $ view #contents v
 
 mnistV1 :: Id ModelVersion
-mnistV1 = Id 1
+mnistV1 = Id $ UUID.fromWords 6 0 0 0
 
 models :: Vector (Id ModelVersion)
 models = Vector.singleton mnistV1

--- a/inferno-ml-server/test/Main.hs
+++ b/inferno-ml-server/test/Main.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE NoFieldSelectors #-}
+
 -- These test items do not run a full `inferno-ml-server` instance and only
 -- check that a limited subset of server operations work as intended (e.g. model
 -- fetching and caching). For full server tests, see `tests/server.nix`.
@@ -12,32 +15,24 @@ import Data.Aeson (eitherDecodeFileStrict)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as ByteString
 import Data.Foldable (toList, traverse_)
+import Data.Generics.Wrapped (wrappedTo)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import Data.Text (Text)
 import qualified Data.UUID as UUID
 import Data.Vector (Vector)
 import qualified Data.Vector as Vector
 import Data.Word (Word8)
 import Inferno.ML.Server (runInEnv)
-import Inferno.ML.Server.Inference
-  ( getAndCacheModels,
-    linkVersionedModel,
-  )
+import Inferno.ML.Server.Inference (getAndCacheModels)
 import Inferno.ML.Server.Inference.Model
   ( getModelVersionSizeAndContents,
     getModelsAndVersions,
   )
 import Inferno.ML.Server.Types
-  ( Config,
-    Env,
-    Id (Id),
-    ModelVersion,
-    showVersion,
-  )
 import Inferno.Types.Syntax (Ident)
 import Lens.Micro.Platform
 import Plow.Logging.Message (LogLevel (LevelWarn))
+import System.FilePath ((<.>))
 import Test.Hspec (Spec)
 import qualified Test.Hspec as Hspec
 import UnliftIO (throwString)
@@ -69,22 +64,21 @@ mkCacheSpec :: Env -> Spec
 mkCacheSpec env = Hspec.before_ clearCache . Hspec.describe "Model cache" $ do
   Hspec.it "caches a model" . cdCache $ do
     cacheModel
-    dir <- env ^. #config . #cache . #path & listDirectory
-    dir `Hspec.shouldMatchList` ["mnist.v1", "mnist.ts.pt"]
-    contents <- ByteString.readFile "mnist.ts.pt"
+    dir <- listDirectory env.config.cache.path
+    dir `Hspec.shouldMatchList` [mnistV1Path]
+    contents <- ByteString.readFile mnistV1Path
     ByteString.length contents `Hspec.shouldBe` mnistV1Size
     getZipMagic contents `Hspec.shouldBe` zipMagic
 
   Hspec.it "doesn't re-cache" . cdCache $ do
-    atime1 <- cacheModel *> getModificationTime "mnist.ts.pt"
-    atime2 <- cacheModel *> getModificationTime "mnist.ts.pt"
+    atime1 <- cacheModel *> getModificationTime mnistV1Path
+    atime2 <- cacheModel *> getModificationTime mnistV1Path
     atime2 `Hspec.shouldBe` atime1
   where
     cacheModel :: IO ()
     cacheModel =
       void . flip runReaderT env $
-        traverse_ linkVersionedModel
-          =<< (`getAndCacheModels` modelsWithIdents)
+        (`getAndCacheModels` modelsWithIdents)
           =<< view (#config . #cache)
 
     clearCache :: IO ()
@@ -95,19 +89,19 @@ mkCacheSpec env = Hspec.before_ clearCache . Hspec.describe "Model cache" $ do
           =<< getCurrentDirectory
 
     cdCache :: IO a -> IO a
-    cdCache = env ^. #config . #cache . #path & withCurrentDirectory
+    cdCache = withCurrentDirectory env.config.cache.path
 
-modelsWithIdents :: Map Ident (Id ModelVersion, Text)
-modelsWithIdents = Map.singleton "dummy" (mnistV1, "mnist")
+modelsWithIdents :: Map Ident (Id ModelVersion)
+modelsWithIdents = Map.singleton "dummy" mnistV1
 
 mkDbSpec :: Env -> Spec
 mkDbSpec env = Hspec.describe "Database" $ do
   Hspec.it "gets a model" $ do
-    runReaderT (getModelsAndVersions models) env >>= \case
+    runReaderT (getModelsAndVersions modelVersions) env >>= \case
       v
         | Just (model, mversion) <- v ^? _head -> do
-            view #name model `Hspec.shouldBe` "mnist"
-            view (#version . to showVersion) mversion `Hspec.shouldBe` "v1"
+            model.name `Hspec.shouldBe` "mnist"
+            showVersion mversion.version `Hspec.shouldBe` "v1"
         | otherwise -> Hspec.expectationFailure "No models were retrieved"
 
   Hspec.it "gets model size and contents" $ do
@@ -123,15 +117,18 @@ mkDbSpec env = Hspec.describe "Database" $ do
 
 getWithContents :: Env -> IO (Integer, ByteString)
 getWithContents env = flip runReaderT env $ do
-  (getModelsAndVersions models >>=) . (. fmap snd . toList) $ \case
+  (getModelsAndVersions modelVersions >>=) . (. fmap snd . toList) $ \case
     [] -> throwString "No model was retrieved"
-    v : _ -> getModelVersionSizeAndContents $ view #contents v
+    v : _ -> getModelVersionSizeAndContents v.contents
 
 mnistV1 :: Id ModelVersion
 mnistV1 = Id $ UUID.fromWords 6 0 0 0
 
-models :: Vector (Id ModelVersion)
-models = Vector.singleton mnistV1
+mnistV1Path :: FilePath
+mnistV1Path = UUID.toString (wrappedTo mnistV1) <.> "ts" <.> "pt"
+
+modelVersions :: Vector (Id ModelVersion)
+modelVersions = Vector.singleton mnistV1
 
 mnistV1Size :: Int
 mnistV1Size = 4808991

--- a/inferno-ml/inferno-ml.cabal
+++ b/inferno-ml/inferno-ml.cabal
@@ -34,7 +34,6 @@ library
     , template-haskell
     , text
     , prettyprinter
-    , filepath
   default-language: Haskell2010
   default-extensions:
       LambdaCase

--- a/inferno-ml/src/Inferno/ML/Module/Prelude.hs
+++ b/inferno-ml/src/Inferno/ML/Module/Prelude.hs
@@ -25,7 +25,6 @@ import qualified Inferno.Module.Prelude as Prelude
 import Inferno.Types.Syntax (Ident)
 import Inferno.Types.Value (Value (..))
 import Prettyprinter (Pretty)
-import System.FilePath ((<.>))
 import Torch
 import qualified Torch.DType as TD
 import Torch.Functional
@@ -143,7 +142,7 @@ loadModelFun = VFun $ \case
       =<< liftIO (try @_ @SomeException loadModel)
     where
       loadModel :: IO ScriptModule
-      loadModel = TS.loadScript TS.WithoutRequiredGrad $ mn <.> "ts.pt"
+      loadModel = TS.loadScript TS.WithoutRequiredGrad mn
   _ -> throwM $ RuntimeError "Expected a modelName"
 
 forwardFun :: ScriptModule -> [Tensor] -> [Tensor]

--- a/nix/inferno-ml/migrations/v1-create-tables.sql
+++ b/nix/inferno-ml/migrations/v1-create-tables.sql
@@ -30,7 +30,7 @@ create table if not exists models
 
 create table if not exists mversions
   ( id uuid primary key default gen_random_uuid()
-  , model integer references models (id)
+  , model uuid references models (id)
     -- Short, high-level model description
   , description text not null
     -- Model card (description and metadata) serialized as JSON
@@ -59,7 +59,7 @@ create table if not exists scripts
 -- between `scripts` and `mversions`)
 create table if not exists mselections
   ( script bytea not null references scripts (id)
-  , model integer not null references mversions (id)
+  , model uuid not null references mversions (id)
     -- Inferno identifier linked to this specific model version
   , ident text not null
   , unique (script, model)
@@ -83,7 +83,7 @@ create table if not exists params
 -- Execution info for inference evaluation
 create table if not exists evalinfo
   ( id uuid primary key
-  , param integer not null references params (id)
+  , param uuid not null references params (id)
     -- When inference evaluation began
   , started timestamptz not null
     -- When inference evaluation ended

--- a/nix/inferno-ml/migrations/v1-create-tables.sql
+++ b/nix/inferno-ml/migrations/v1-create-tables.sql
@@ -77,7 +77,7 @@ create table if not exists params
   , resolution integer not null
     -- See note above
   , terminated timestamptz
-  , uid numeric not null
+  , gid numeric not null
   );
 
 -- Execution info for inference evaluation

--- a/nix/inferno-ml/migrations/v1-create-tables.sql
+++ b/nix/inferno-ml/migrations/v1-create-tables.sql
@@ -17,7 +17,7 @@ create extension lo;
 -- "deleted" and cannot be used any longer
 
 create table if not exists models
-  ( id serial primary key
+  ( id uuid primary key default gen_random_uuid()
   , name text not null
   , gid numeric not null
   , visibility jsonb
@@ -29,7 +29,7 @@ create table if not exists models
   );
 
 create table if not exists mversions
-  ( id serial primary key
+  ( id uuid primary key default gen_random_uuid()
   , model integer references models (id)
     -- Short, high-level model description
   , description text not null
@@ -66,7 +66,7 @@ create table if not exists mselections
   );
 
 create table if not exists params
-  ( id serial primary key
+  ( id uuid primary key default gen_random_uuid()
     -- Script hash from `inferno-vc`
   , script bytea not null references scripts (id)
     -- Strictly speaking, this includes both inputs and outputs. The
@@ -97,7 +97,7 @@ create table if not exists evalinfo
 -- Stores information required to call the data bridge
 create table if not exists bridges
   ( -- Same ID as the referenced param
-    id integer not null references params (id)
+    id uuid not null references params (id)
     -- Host of the bridge server
   , ip inet not null
   , port integer check (port > 0)

--- a/nix/inferno-ml/tests/server.nix
+++ b/nix/inferno-ml/tests/server.nix
@@ -101,11 +101,11 @@ pkgs.nixosTest {
             in
             ''
               parse-and-save \
-                ${./scripts/ones.inferno} '${ids.ones}' '${ios.ones}' ${dbstr}
+                '${ids.ones}' ${./scripts/ones.inferno} '${ios.ones}' ${dbstr}
               parse-and-save \
-                ${./scripts/contrived.inferno} '${ids.contrived}' '${ios.contrived}' ${dbstr}
+                '${ids.contrived}' ${./scripts/contrived.inferno} '${ios.contrived}' ${dbstr}
               parse-and-save \
-                ${./scripts/mnist.inferno} '${ids.mnist}' '${ios.mnist}' ${dbstr}
+                '${ids.mnist}' ${./scripts/mnist.inferno} '${ios.mnist}' ${dbstr}
             '';
         }
       )


### PR DESCRIPTION
Several improvements to `inferno-ml-server` (and its types package):
- Adds a new testing route with ability to override scripts, models, inputs
- Purges last vestiges of user IDs (now everything uses group IDs)
- Switches to UUIDs instead of integers for IDs
- Makes `/status` much clearer
- Removes some unnecessary parts of model caching; model versions are now saved to a filepath corresponding to their ID