### PR TITLE
[inferno-ml] Change parameter input/output representation

### DIFF
--- a/inferno-ml-server-types/CHANGELOG.md
+++ b/inferno-ml-server-types/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Revision History for inferno-ml-server-types
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.11.0
+* Split parameter inputs and outputs
+
 ## 0.10.0
 * Change `Id` to `UUID`
 * Add new testing endpoint to override models, script, etc...

--- a/inferno-ml-server-types/inferno-ml-server-types.cabal
+++ b/inferno-ml-server-types/inferno-ml-server-types.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          inferno-ml-server-types
-version:       0.10.0
+version:       0.11.0
 synopsis:      Types for Inferno ML server
 description:   Types for Inferno ML server
 homepage:      https://github.com/plow-technologies/inferno.git#readme

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Client.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Client.hs
@@ -27,9 +27,9 @@ cancelC = client $ Proxy @CancelAPI
 
 -- | Run an inference parameter
 inferenceC ::
-  forall gid p s.
+  forall gid p .
   -- | SQL identifier of the inference parameter to be run
-  Id (InferenceParam gid p s) ->
+  Id (InferenceParam gid p ) ->
   -- | Optional resolution for scripts that use e.g. @valueAt@; defaults to
   -- the param\'s stored resolution if not provided. This lets users override
   -- the resolution on an ad-hoc basis without needing to alter the stored
@@ -44,16 +44,16 @@ inferenceC ::
   -- (not defined in this repository) to verify this before directing
   -- the writes to their final destination
   ClientM (WriteStream IO)
-inferenceC = client $ Proxy @(InferenceAPI gid p s)
+inferenceC = client $ Proxy @(InferenceAPI gid p)
 
 -- | Run an inference parameter
 inferenceTestC ::
-  forall gid p s.
+  forall gid p .
   ToJSON p =>
   -- | SQL identifier of the inference parameter to be run
-  Id (InferenceParam gid p s) ->
+  Id (InferenceParam gid p ) ->
   Maybe Int64 ->
   UUID ->
   EvaluationEnv gid p ->
   ClientM (WriteStream IO)
-inferenceTestC = client $ Proxy @(InferenceTestAPI gid p s)
+inferenceTestC = client $ Proxy @(InferenceTestAPI gid p)

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Client.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Client.hs
@@ -27,9 +27,9 @@ cancelC = client $ Proxy @CancelAPI
 
 -- | Run an inference parameter
 inferenceC ::
-  forall gid p .
+  forall gid p.
   -- | SQL identifier of the inference parameter to be run
-  Id (InferenceParam gid p ) ->
+  Id (InferenceParam gid p) ->
   -- | Optional resolution for scripts that use e.g. @valueAt@; defaults to
   -- the param\'s stored resolution if not provided. This lets users override
   -- the resolution on an ad-hoc basis without needing to alter the stored
@@ -48,10 +48,10 @@ inferenceC = client $ Proxy @(InferenceAPI gid p)
 
 -- | Run an inference parameter
 inferenceTestC ::
-  forall gid p .
+  forall gid p.
   ToJSON p =>
   -- | SQL identifier of the inference parameter to be run
-  Id (InferenceParam gid p ) ->
+  Id (InferenceParam gid p) ->
   Maybe Int64 ->
   UUID ->
   EvaluationEnv gid p ->

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
@@ -70,9 +70,7 @@ import GHC.Generics (Generic)
 import Inferno.Instances.Arbitrary ()
 import Inferno.Types.Syntax (Ident)
 import Inferno.Types.VersionControl
-  ( VCHashUpdate,
-    VCHashUpdateViaShow (VCHashUpdateViaShow),
-    VCObjectHash,
+  ( VCObjectHash,
     byteStringToVCObjectHash,
     vcObjectHashToByteString,
   )
@@ -791,40 +789,6 @@ data InferenceParamWithModels gid p s = InferenceParamWithModels
     models :: Map Ident (Id (ModelVersion gid Oid))
   }
   deriving stock (Show, Eq, Generic)
-
--- | Controls input interaction within a script, i.e. ability to read from
--- and\/or write to this input. Although the term \"input\" is used, those with
--- writes enabled can also be described as \"outputs\"
-data ScriptInputType
-  = -- | Script input can be read, but not written
-    Readable
-  | -- | Script input can be written, i.e. can be used in array of
-    -- write objects returned from script evaluation
-    Writable
-  | -- | Script input can be both read from and written to; this allows
-    -- the same script identifier to point to the same PID with both
-    -- types of access enabled
-    ReadableWritable
-  deriving stock (Show, Eq, Ord, Generic)
-  deriving anyclass (NFData, ToADTArbitrary)
-  deriving (VCHashUpdate) via (VCHashUpdateViaShow ScriptInputType)
-
-instance FromJSON ScriptInputType where
-  parseJSON = withText "ScriptInputType" $ \case
-    "r" -> pure Readable
-    "w" -> pure Writable
-    "rw" -> pure ReadableWritable
-    s -> fail $ "Invalid script input type: " <> Text.unpack s
-
-instance ToJSON ScriptInputType where
-  toJSON =
-    String . \case
-      Readable -> "r"
-      Writable -> "w"
-      ReadableWritable -> "rw"
-
-instance Arbitrary ScriptInputType where
-  arbitrary = genericArbitrary
 
 -- | Information about execution time and resource usage. This is saved by
 -- @inferno-ml-server@ after script evaluation completes and can be queried

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
@@ -752,8 +752,7 @@ instance (ToJSON p, ToField gid) => ToRow (InferenceParam gid p) where
     ]
 
 -- Not derived generically in order to use special `Gen UTCTime`
-instance (Arbitrary gid, Arbitrary p) => Arbitrary (InferenceParam gid p)
-  where
+instance (Arbitrary gid, Arbitrary p) => Arbitrary (InferenceParam gid p) where
   arbitrary =
     InferenceParam
       <$> arbitrary
@@ -765,8 +764,7 @@ instance (Arbitrary gid, Arbitrary p) => Arbitrary (InferenceParam gid p)
       <*> arbitrary
 
 -- Can't be derived because there is (intentially) no `Arbitrary UTCTime` in scope
-instance (Arbitrary gid, Arbitrary p) => ToADTArbitrary (InferenceParam gid p)
-  where
+instance (Arbitrary gid, Arbitrary p) => ToADTArbitrary (InferenceParam gid p) where
   toADTArbitrarySingleton _ =
     ADTArbitrarySingleton "Inferno.ML.Server.Types" "InferenceParam"
       . ConstructorArbitraryPair "InferenceParam"

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
@@ -190,7 +190,10 @@ data ServerStatus
   = Idle
   | EvaluatingScript
   deriving stock (Show, Eq, Generic)
-  deriving anyclass (FromJSON, ToJSON)
+  deriving anyclass (FromJSON, ToJSON, ToADTArbitrary, NFData)
+
+instance Arbitrary ServerStatus where
+  arbitrary = genericArbitrary
 
 -- | Information for contacting a bridge server that implements the 'BridgeAPI'
 data BridgeInfo gid p = BridgeInfo
@@ -1010,7 +1013,10 @@ data EvaluationEnv gid p = EvaluationEnv
     models :: Map Ident (Id (ModelVersion gid Oid))
   }
   deriving stock (Show, Eq, Generic)
-  deriving anyclass (FromJSON, ToJSON)
+  deriving anyclass (FromJSON, ToJSON, ToADTArbitrary)
+
+instance Arbitrary p => Arbitrary (EvaluationEnv gid p) where
+  arbitrary = genericArbitrary
 
 tshow :: Show a => a -> Text
 tshow = Text.pack . show

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
@@ -742,6 +742,7 @@ instance (ToJSON p, ToField gid) => ToRow (InferenceParam gid p VCObjectHash) wh
     [ ip.id & maybe (toField Default) toField,
       ip.script & VCObjectHashRow & toField,
       ip.inputs & Aeson & toField,
+      ip.outputs & Aeson & toField,
       ip.resolution & Aeson & toField,
       toField Default,
       ip.gid & toField

--- a/inferno-ml-server/src/Inferno/ML/Server/Inference.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Inference.hs
@@ -120,7 +120,7 @@ runInferenceParam ipid mres uuid =
   where
     mkScriptEnv :: InferenceParamWithModels -> RemoteM ScriptEnv
     mkScriptEnv pwm =
-      ScriptEnv pwm.param pwm.models pwm.param.inputs undefined
+      ScriptEnv pwm.param pwm.models pwm.param.inputs pwm.param.outputs
         <$> getVcObject pwm.param.script
         ?? pwm.param.script
         ?? mres
@@ -146,7 +146,7 @@ testInferenceParam ipid mres uuid eenv =
     -- for script eval come from the `EvaluationEnv`
     mkScriptEnv :: InferenceParam -> RemoteM ScriptEnv
     mkScriptEnv param =
-      ScriptEnv param eenv.models eenv.inputs undefined
+      ScriptEnv param eenv.models eenv.inputs eenv.outputs
         <$> getVcObject eenv.script
         ?? eenv.script
         ?? mres

--- a/inferno-ml-server/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Types.hs
@@ -438,13 +438,14 @@ pattern InferenceScript h o = Types.InferenceScript h o
 pattern InferenceParam ::
   Maybe (Id InferenceParam) ->
   VCObjectHash ->
-  Map Ident (SingleOrMany PID, ScriptInputType) ->
+  Map Ident (SingleOrMany PID) ->
+  Map Ident (SingleOrMany PID) ->
   Word64 ->
   Maybe UTCTime ->
   EntityId GId ->
   InferenceParam
-pattern InferenceParam iid s ios res mt gid =
-  Types.InferenceParam iid s ios res mt gid
+pattern InferenceParam iid s is os res mt gid =
+  Types.InferenceParam iid s is os res mt gid
 
 pattern InferenceParamWithModels ::
   InferenceParam -> Map Ident (Id ModelVersion) -> InferenceParamWithModels

--- a/inferno-ml-server/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Types.hs
@@ -413,14 +413,11 @@ infixl 4 ??
 (??) :: Functor f => f (a -> b) -> a -> f b
 f ?? x = ($ x) <$> f
 
-type InferenceParam =
-  Types.InferenceParam (EntityId GId) PID VCObjectHash
+type InferenceParam = Types.InferenceParam (EntityId GId) PID
 
-type InferenceParamWithModels =
-  Types.InferenceParamWithModels (EntityId GId) PID VCObjectHash
+type InferenceParamWithModels = Types.InferenceParamWithModels (EntityId GId) PID
 
-type BridgeInfo =
-  Types.BridgeInfo (EntityId GId) PID VCObjectHash
+type BridgeInfo = Types.BridgeInfo (EntityId GId) PID
 
 type EvaluationInfo = Types.EvaluationInfo (EntityId GId) PID
 
@@ -477,8 +474,7 @@ pattern EvaluationInfo ::
   EvaluationInfo
 pattern EvaluationInfo u i s e m c = Types.EvaluationInfo u i s e m c
 
-type InfernoMlServerAPI =
-  Types.InfernoMlServerAPI (EntityId GId) PID VCObjectHash
+type InfernoMlServerAPI = Types.InfernoMlServerAPI (EntityId GId) PID
 
 type EvaluationEnv = Types.EvaluationEnv (EntityId GId) PID
 

--- a/nix/inferno-ml/migrations/v1-create-tables.sql
+++ b/nix/inferno-ml/migrations/v1-create-tables.sql
@@ -69,10 +69,11 @@ create table if not exists params
   ( id uuid primary key default gen_random_uuid()
     -- Script hash from `inferno-vc`
   , script bytea not null references scripts (id)
-    -- Strictly speaking, this includes both inputs and outputs. The
-    -- corresponding Haskell type contains `(p, ScriptInputType)`, with
-    -- the second element determining readability and writability
+    -- Inputs and outputs are a `Map Ident (SingleOrMany p)` on the Haskell
+    -- side. Stored as JSONB for convenience (e.g. Postgres subarrays must all
+    -- be the same length, making `SingleOrMany` harder to represent)
   , inputs jsonb not null
+  , outputs jsonb not null
     -- Resolution passed to script evaluator
   , resolution integer not null
     -- See note above

--- a/nix/inferno-ml/tests/scripts/contrived.inferno
+++ b/nix/inferno-ml/tests/scripts/contrived.inferno
@@ -1,5 +1,5 @@
-fun input0 mnist ->
+fun input0 output0 mnist ->
   let t = Time.toTime (Time.seconds 200) in
   let ?resolution = (toResolution 128) in
   let v = valueAt input0 t ? 0.0 in
-  [makeWrites input0 [(Time.toTime (Time.seconds 300), v + 5.0)]]
+  [makeWrites output0 [(Time.toTime (Time.seconds 300), v + 5.0)]]

--- a/nix/inferno-ml/tests/scripts/mnist.inferno
+++ b/nix/inferno-ml/tests/scripts/mnist.inferno
@@ -1,4 +1,4 @@
-fun input0 input1 mnist ->
+fun input0 output0 output1 mnist ->
   let input = ML.asTensor4 ML.#float [[[
     [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
     [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -34,7 +34,7 @@ fun input0 input1 mnist ->
   match ML.forward model [input] with {
     | [scores] ->
         let m = ML.toType ML.#double (ML.argmax 1 #false scores) in
-        [makeWrites input0 [(t, ML.asDouble m)], makeWrites input1 [(t, ML.asDouble m + 1.0)]]
+        [makeWrites output0 [(t, ML.asDouble m)], makeWrites output1 [(t, ML.asDouble m + 1.0)]]
     | _ ->
-        [makeWrites input0 [(t, -1.0)], makeWrites input1 [(t, -1.0)]]
+        [makeWrites output0 [(t, -1.0)], makeWrites output1 [(t, -1.0)]]
   }

--- a/nix/inferno-ml/tests/scripts/ones.inferno
+++ b/nix/inferno-ml/tests/scripts/ones.inferno
@@ -1,8 +1,8 @@
-fun input0 mnist ->
+fun input0 output0 mnist ->
   let mkV = fun t -> valueAt input0 (Time.toTime (Time.seconds t)) ? 0.0 in
   let ts = [150, 250] in
   let vs = Array.map mkV ts in
   let xs = ML.ones ML.#double [2] in
   let ts1 = Array.map (fun t -> Time.toTime (Time.seconds (t + 1))) ts in
   let vs1 = ML.asArray1 (ML.add xs (ML.asTensor1 ML.#double vs)) in
-  [makeWrites input0 (zip ts1 vs1)]
+  [makeWrites output0 (zip ts1 vs1)]

--- a/nix/inferno-ml/tests/server.nix
+++ b/nix/inferno-ml/tests/server.nix
@@ -90,12 +90,21 @@ pkgs.nixosTest {
               dbstr = "host='127.0.0.1' dbname='inferno' user='inferno' password=''";
               ios =
                 builtins.mapAttrs (_: builtins.toJSON) {
-                  ones = { input0 = [ 1 "rw" ]; };
-                  contrived = { input0 = [ 2 "rw" ]; };
+                  ones = {
+                    inputs.input0 = 1;
+                    inputs.output0 = 1;
+                  };
+                  contrived = {
+                    inputs.input0 = 2;
+                    outputs.output0 = 2;
+                  };
                   # This test uses two outputs
                   mnist = {
-                    input0 = [ 3 "rw" ];
-                    input1 = [ 4 "w" ];
+                    inputs.input0 = 3;
+                    outputs = {
+                      output0 = 3;
+                      output1 = 4;
+                    };
                   };
                 };
             in

--- a/nix/inferno-ml/tests/server.nix
+++ b/nix/inferno-ml/tests/server.nix
@@ -92,7 +92,7 @@ pkgs.nixosTest {
                 builtins.mapAttrs (_: builtins.toJSON) {
                   ones = {
                     inputs.input0 = 1;
-                    inputs.output0 = 1;
+                    outputs.output0 = 1;
                   };
                   contrived = {
                     inputs.input0 = 2;


### PR DESCRIPTION
The previous way that parameter inputs/outputs were stored, with both condensed into a single `Map Ident ...`, turned out to be quite nightmarish to work with. We are going to be doing things like filtering or querying parameters by output, so we need it to be easier to look outputs up. So this changes the inputs/outputs back to the way they used to be, e.g. two separate `Map`s