### PR TITLE
[inferno-ml] Move `inferno-ml-server` to system service

### DIFF
--- a/nix/inferno-ml/images/common/cpu.nix
+++ b/nix/inferno-ml/images/common/cpu.nix
@@ -12,7 +12,7 @@
     configuration = {
       port = 8080;
       cache = {
-        path = "/home/inferno/.cache/inferno-ml-server/models";
+        path = "/home/inferno/.cache/models";
         max-size = 10 * 1073741824;
       };
       # NOTE This should be overridden for real deployments

--- a/nix/inferno-ml/images/common/gpu.nix
+++ b/nix/inferno-ml/images/common/gpu.nix
@@ -29,7 +29,7 @@
     configuration = {
       port = 8080;
       cache = {
-        path = "/home/inferno/.cache/inferno-ml-server/models";
+        path = "/home/inferno/.cache/models";
         max-size = 10 * 1073741824;
       };
       # NOTE This should be overridden for real deployments

--- a/nix/inferno-ml/images/default.nix
+++ b/nix/inferno-ml/images/default.nix
@@ -38,7 +38,7 @@ in
           {
             imports = [ ./common/gpu.nix ];
             # The big one
-            amazonImage.sizeMB = 107374;
+            amazonImage.sizeMB = 53687;
           }
         ];
       };
@@ -63,7 +63,7 @@ in
           {
             imports = [ ./common/cpu.nix ];
             # The big one
-            amazonImage.sizeMB = 107374;
+            amazonImage.sizeMB = 53687;
           }
         ];
       };

--- a/nix/inferno-ml/images/qcow2.nix
+++ b/nix/inferno-ml/images/qcow2.nix
@@ -10,7 +10,7 @@
       # Ten minute timeout
       timeout = 600;
       cache = {
-        path = "/home/inferno/.cache/inferno-ml-server/models";
+        path = "/home/inferno/.cache/models";
         max-size = 10 * 1073741824;
       };
       # NOTE This can be overridden, unless you plan on running the VM and

--- a/nix/inferno-ml/modules/inferno-ml-server.nix
+++ b/nix/inferno-ml/modules/inferno-ml-server.nix
@@ -144,6 +144,12 @@ in
         }.${builtins.typeOf cfg.configuration};
       in
       {
+        # FIXME Ideally we should have a system user to run this. However,
+        # we are doing some urgent testing and that would require more work.
+        # We will fix having this run as `inferno` once we finalize the image
+        # config
+        #
+        # See https://github.com/plow-technologies/inferno/issues/151
         systemd.services.inferno-ml-server = {
           description = "Start `inferno-ml-server` server";
           wantedBy = [ "default.target" ];

--- a/nix/inferno-ml/modules/inferno-ml-server.nix
+++ b/nix/inferno-ml/modules/inferno-ml-server.nix
@@ -144,7 +144,7 @@ in
         }.${builtins.typeOf cfg.configuration};
       in
       {
-        systemd.user.services.inferno-ml-server = {
+        systemd.services.inferno-ml-server = {
           description = "Start `inferno-ml-server` server";
           wantedBy = [ "default.target" ];
           after = [ "network-online.target" ];
@@ -153,6 +153,11 @@ in
             ExecStart = "${cfg.package}/bin/inferno-ml-server --config ${configFile}";
             Restart = "always";
             RestartSec = 5;
+            User = "inferno";
+            Group = "inferno";
+            PrivateTmp = "yes";
+            ProtectDevices = "yes";
+            NoNewPrivileges = "yes";
           };
         };
 
@@ -171,10 +176,6 @@ in
                 mkdir -p ${path}
                 chown -R ${cfg.user}:${cfg.group} ${path}
                 chmod u+rwx ${path}
-
-                mkdir -p /home/${cfg.user}/.cache/bridge
-                chown -R ${cfg.user}:${cfg.group} /home/${cfg.user}/.cache/bridge
-                chmod u+rwx /home/${cfg.user}/.cache/bridge
               '';
         };
       }


### PR DESCRIPTION
Currently `inferno-ml-server.service` runs as a systemd user service. However, this doesn't actually work when testing the EC2 instances, as a shell must be opened for the `inferno` user before the service starts. We need it to start immediately after init

I've tested this with a real EC2 built using a testing image config and it fixes the problem

NOTE: We should eventually create an `inferno-ml-server` system user to run the service. However, for debugging and permissions purposes, it's easier to continue to run it as `inferno` for now. I've made an issue to fix this: https://github.com/plow-technologies/inferno/issues/151. But this fix is needed urgently and I don't want to hold things up fixing that.
