### PR TITLE
Make VCHashUpdate @CTime always encode as 64 bits

### DIFF
--- a/inferno-types/CHANGELOG.md
+++ b/inferno-types/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Revision History for inferno-types
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.4.6.1 -- 2025-1-21
+* Change VCUpdateHash @CTime so it produces the same output in both 32bit and
+  64bit architectures
+
 ## 0.4.6.0 -- 2024-07-25
 * mtl 2.3 compatibility
 

--- a/inferno-types/inferno-types.cabal
+++ b/inferno-types/inferno-types.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                inferno-types
-version:             0.4.6.0
+version:             0.4.6.1
 synopsis:            Core types for Inferno
 description:         Core types for the Inferno language
 category:            DSL,Scripting

--- a/inferno-types/src/Inferno/Types/VersionControl.hs
+++ b/inferno-types/src/Inferno/Types/VersionControl.hs
@@ -128,7 +128,7 @@ deriving via (VCHashUpdateViaShow InfixFixity) instance VCHashUpdate InfixFixity
 deriving via (VCHashUpdateViaShow Fixity) instance VCHashUpdate Fixity
 
 instance VCHashUpdate CTime where
-  ctxt &< (CTime t) = ctxt &< ("CTime" :: ByteString) &< t
+  ctxt &< (CTime t) = ctxt &< ("CTime" :: ByteString) &< (fromIntegral @_ @Int64 t)
 
 instance VCHashUpdate a => VCHashUpdate (Maybe a) where
   ctxt &< Nothing = ctxt


### PR DESCRIPTION
This makes vcHash for VCMeta produce the same hash on 32bit and 64 bit plarforms