### PR TITLE
[nix] Bump haskell.nix and nixpkgs again

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,15 +170,32 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1736037006,
-        "narHash": "sha256-d2QIA5ZHvgkMBB9N5h6Ofu6zRemQP3tgabRbBHWSphE=",
+        "lastModified": 1739838228,
+        "narHash": "sha256-+kZ03uO98AptybUT/Lh8vq0ZriMYIH7HqQCZUEeRhCg=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "e7013e464246d62c517fd15b368e37b699d11720",
+        "rev": "72003a1528053982088956d110a45a378e78f072",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackage-for-stackage": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1739838218,
+        "narHash": "sha256-7v4NfNRsLSVr1Fp+YozFtuCEuBkxP96lmCfBjpPvhKc=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "b518d04c1d52f744fd3680295443ddbe7f873039",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "for-stackage",
         "repo": "hackage.nix",
         "type": "github"
       }
@@ -193,6 +210,7 @@
         "flake-compat": "flake-compat_2",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
         "hackage": "hackage",
+        "hackage-for-stackage": "hackage-for-stackage",
         "hls-1.10": "hls-1.10",
         "hls-2.0": "hls-2.0",
         "hls-2.2": "hls-2.2",
@@ -204,36 +222,31 @@
         "hls-2.8": "hls-2.8",
         "hls-2.9": "hls-2.9",
         "hpc-coveralls": "hpc-coveralls",
-        "hydra": "hydra",
         "iserv-proxy": "iserv-proxy",
         "nixpkgs": [
           "haskell-nix",
           "nixpkgs-unstable"
         ],
-        "nixpkgs-2003": "nixpkgs-2003",
-        "nixpkgs-2105": "nixpkgs-2105",
-        "nixpkgs-2111": "nixpkgs-2111",
-        "nixpkgs-2205": "nixpkgs-2205",
-        "nixpkgs-2211": "nixpkgs-2211",
         "nixpkgs-2305": "nixpkgs-2305",
         "nixpkgs-2311": "nixpkgs-2311",
         "nixpkgs-2405": "nixpkgs-2405",
+        "nixpkgs-2411": "nixpkgs-2411",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "old-ghc-nix": "old-ghc-nix",
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1736038283,
-        "narHash": "sha256-/vRGKnuE7W7fXgXD05/1v7cRLNm9nXATvxUsDQc1axc=",
+        "lastModified": 1739839897,
+        "narHash": "sha256-kSrotcTzBGRiMSnWeZAhwQBzB3qRS9YnRVZdt3vkz+k=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "1397170d29a6740b0582dbc1834c2591de827134",
+        "rev": "2df64d53246fa188ece83e1897e503b935e0f156",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "1397170d29a6740b0582dbc1834c2591de827134",
+        "rev": "2df64d53246fa188ece83e1897e503b935e0f156",
         "type": "github"
       }
     },
@@ -439,29 +452,6 @@
         "type": "github"
       }
     },
-    "hydra": {
-      "inputs": {
-        "nix": "nix",
-        "nixpkgs": [
-          "haskell-nix",
-          "hydra",
-          "nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1671755331,
-        "narHash": "sha256-hXsgJj0Cy0ZiCiYdW2OdBz5WmFyOMKuw4zyxKpgUKm4=",
-        "owner": "NixOS",
-        "repo": "hydra",
-        "rev": "f48f00ee6d5727ae3e488cbf9ce157460853fea8",
-        "type": "github"
-      },
-      "original": {
-        "id": "hydra",
-        "type": "indirect"
-      }
-    },
     "iserv-proxy": {
       "flake": false,
       "locked": {
@@ -479,25 +469,9 @@
         "type": "github"
       }
     },
-    "lowdown-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1633514407,
-        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "type": "github"
-      }
-    },
     "naersk": {
       "inputs": {
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs"
       },
       "locked": {
         "lastModified": 1736429655,
@@ -515,7 +489,7 @@
     },
     "naersk_2": {
       "inputs": {
-        "nixpkgs": "nixpkgs_4"
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
         "lastModified": 1692351612,
@@ -531,121 +505,17 @@
         "type": "github"
       }
     },
-    "nix": {
-      "inputs": {
-        "lowdown-src": "lowdown-src",
-        "nixpkgs": "nixpkgs",
-        "nixpkgs-regression": "nixpkgs-regression"
-      },
-      "locked": {
-        "lastModified": 1661606874,
-        "narHash": "sha256-9+rpYzI+SmxJn+EbYxjGv68Ucp22bdFUSy/4LkHkkDQ=",
-        "owner": "NixOS",
-        "repo": "nix",
-        "rev": "11e45768b34fdafdcf019ddbd337afa16127ff0f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "2.11.0",
-        "repo": "nix",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1657693803,
-        "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "365e1b3a859281cf11b94f87231adeabbdd878a2",
-        "type": "github"
+        "lastModified": 1730189606,
+        "narHash": "sha256-LgkEB/b9JRWdGHx95mxSWPV5PaSPp8Aau+lsbDUXb44=",
+        "path": "/nix/store/v4m1bdwbkk77fgf9gknclznll2z7xprz-source",
+        "rev": "6aa8749b515f9dec000b24794b2787b64037db51",
+        "type": "path"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixos-22.05-small",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2003": {
-      "locked": {
-        "lastModified": 1620055814,
-        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-20.03-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2105": {
-      "locked": {
-        "lastModified": 1659914493,
-        "narHash": "sha256-lkA5X3VNMKirvA+SUzvEhfA7XquWLci+CGi505YFAIs=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "022caabb5f2265ad4006c1fa5b1ebe69fb0c3faf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-21.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2111": {
-      "locked": {
-        "lastModified": 1659446231,
-        "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "eabc38219184cc3e04a974fe31857d8e0eac098d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-21.11-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2205": {
-      "locked": {
-        "lastModified": 1685573264,
-        "narHash": "sha256-Zffu01pONhs/pqH07cjlF10NnMDLok8ix5Uk4rhOnZQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "380be19fbd2d9079f677978361792cb25e8a3635",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-22.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2211": {
-      "locked": {
-        "lastModified": 1688392541,
-        "narHash": "sha256-lHrKvEkCPTUO+7tPfjIcb7Trk6k31rz18vkyqmkeJfY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-22.11-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
+        "id": "nixpkgs",
+        "type": "indirect"
       }
     },
     "nixpkgs-2305": {
@@ -682,16 +552,32 @@
     },
     "nixpkgs-2405": {
       "locked": {
-        "lastModified": 1729242558,
-        "narHash": "sha256-VgcLDu4igNT0eYua6OAl9pWCI0cYXhDbR+pWP44tte0=",
+        "lastModified": 1735564410,
+        "narHash": "sha256-HB/FA0+1gpSs8+/boEavrGJH+Eq08/R2wWNph1sM1Dg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4a3f2d3195b60d07530574988df92e049372c10e",
+        "rev": "1e7a8f391f1a490460760065fa0630b5520f9cf8",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-24.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2411": {
+      "locked": {
+        "lastModified": 1737255904,
+        "narHash": "sha256-r3fxHvh+M/mBgCZXOACzRFPsJdix2QSsKazb7VCXXo0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "eacdab35066b0bb1c9413c96898e326b76398a81",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-24.11-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -708,29 +594,13 @@
         "url": "https://github.com/NixOS/nixpkgs/archive/072a6db25e947df2f31aab9eccd0ab75d5b2da11.tar.gz"
       }
     },
-    "nixpkgs-regression": {
-      "locked": {
-        "lastModified": 1643052045,
-        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      }
-    },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1729980323,
-        "narHash": "sha256-eWPRZAlhf446bKSmzw6x7RWEE4IuZgAp8NW3eXZwRAY=",
+        "lastModified": 1737110817,
+        "narHash": "sha256-DSenga8XjPaUV5KUFW/i3rNkN7jm9XmguW+qQ1ZJTR4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "86e78d3d2084ff87688da662cf78c2af085d8e73",
+        "rev": "041c867bad68dfe34b78b2813028a2e2ea70a23c",
         "type": "github"
       },
       "original": {
@@ -742,11 +612,12 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1730189606,
-        "narHash": "sha256-LgkEB/b9JRWdGHx95mxSWPV5PaSPp8Aau+lsbDUXb44=",
-        "path": "/nix/store/v4m1bdwbkk77fgf9gknclznll2z7xprz-source",
-        "rev": "6aa8749b515f9dec000b24794b2787b64037db51",
-        "type": "path"
+        "lastModified": 1653917367,
+        "narHash": "sha256-04MsJC0g9kE01nBuXThMppZK+yvCZECQnUaZKSU+HJo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "437c8e6554911095f0557d524e9d2ffe1c26e33a",
+        "type": "github"
       },
       "original": {
         "id": "nixpkgs",
@@ -755,11 +626,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1653917367,
-        "narHash": "sha256-04MsJC0g9kE01nBuXThMppZK+yvCZECQnUaZKSU+HJo=",
+        "lastModified": 1692557222,
+        "narHash": "sha256-TCOtZaioLf/jTEgfa+nyg0Nwq5Uc610Z+OFV75yUgGw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "437c8e6554911095f0557d524e9d2ffe1c26e33a",
+        "rev": "0b07d4957ee1bd7fd3bdfd12db5f361bd70175a6",
         "type": "github"
       },
       "original": {
@@ -777,27 +648,13 @@
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_5": {
-      "locked": {
-        "lastModified": 1692557222,
-        "narHash": "sha256-TCOtZaioLf/jTEgfa+nyg0Nwq5Uc610Z+OFV75yUgGw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "0b07d4957ee1bd7fd3bdfd12db5f361bd70175a6",
-        "type": "github"
-      },
-      "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
-    "nixpkgs_6": {
+    "nixpkgs_5": {
       "locked": {
         "lastModified": 1735554305,
         "narHash": "sha256-zExSA1i/b+1NMRhGGLtNfFGXgLtgo+dcuzHzaWA6w3Q=",
@@ -815,7 +672,7 @@
     },
     "npm-buildpackage": {
       "inputs": {
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1686315622,
@@ -862,7 +719,7 @@
         "npm-buildpackage": "npm-buildpackage",
         "stable": [
           "haskell-nix",
-          "nixpkgs-2405"
+          "nixpkgs-2411"
         ],
         "tokenizers": "tokenizers",
         "treefmt-nix": "treefmt-nix"
@@ -871,11 +728,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1736035946,
-        "narHash": "sha256-hUA8ri7Pqh6HU/79tBy+gPufZAS5YqoYJXd8tK3wlwk=",
+        "lastModified": 1739837494,
+        "narHash": "sha256-PK09kZu2D0RGO/p/v9GZ2KsaOVa6iIc4/O3ZYmhxi6c=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "e46766bba06e4b7c506683c3157a12ec7f57dc52",
+        "rev": "6199c58970670be8e99429089fd42237c4274faf",
         "type": "github"
       },
       "original": {
@@ -888,7 +745,7 @@
       "inputs": {
         "flake-compat": "flake-compat_3",
         "naersk": "naersk_2",
-        "nixpkgs": "nixpkgs_5"
+        "nixpkgs": "nixpkgs_4"
       },
       "locked": {
         "lastModified": 1714852682,
@@ -906,7 +763,7 @@
     },
     "treefmt-nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_6"
+        "nixpkgs": "nixpkgs_5"
       },
       "locked": {
         "lastModified": 1738070913,

--- a/flake.nix
+++ b/flake.nix
@@ -259,6 +259,22 @@
             (import ./nix/overlays/deepspeed.nix)
             (import ./nix/overlays/environments.nix)
           ];
+
+          # For building Inferno ML images. The V100 drivers are required
+          # for GPU images, while the `inferno-ml-server` packages are
+          # required by anything using the `inferno-ml-server` NixOS module
+          #
+          # NOTE This requires instantiating the nixpkgs instance used to
+          # create the flake's `legacyPackages` -- use at your own risk
+          image = nixpkgs.lib.composeManyExtensions [
+            (import ./nix/overlays/nvidia/v100.nix)
+            (
+              _: prev: {
+                inherit (self.legacyPackages.${prev.system})
+                  inferno-ml-server;
+              }
+            )
+          ];
         };
       };
 

--- a/flake.nix
+++ b/flake.nix
@@ -248,11 +248,6 @@
           combined = nixpkgs.lib.composeManyExtensions [
             self.overlays.ml-project
             inputs.npm-buildpackage.overlays.default
-            # NOTE To test building the NVIDIA drivers, uncomment this
-            # and `nix build .#linuxPackages.nvidia_x11`; it's not included
-            # by default because it's not really needed in the combined
-            # overlay
-            # (import ./nix/overlays/nvidia/v100.nix)
             (
               _: prev: {
                 inherit (self.legacyPackages.${prev.system}.hsPkgs)

--- a/flake.nix
+++ b/flake.nix
@@ -18,12 +18,12 @@
 
   inputs = {
     nixpkgs.follows = "haskell-nix/nixpkgs-unstable";
-    stable.follows = "haskell-nix/nixpkgs-2405";
+    stable.follows = "haskell-nix/nixpkgs-2411";
     flake-parts.url = "github:hercules-ci/flake-parts";
     treefmt-nix.url = "github:numtide/treefmt-nix";
     # haskell.nix has far better support for multi-component projects, so it's
     # preferable over nixpkgs' Haskell support
-    haskell-nix.url = "github:input-output-hk/haskell.nix/1397170d29a6740b0582dbc1834c2591de827134";
+    haskell-nix.url = "github:input-output-hk/haskell.nix/2df64d53246fa188ece83e1897e503b935e0f156";
     npm-buildpackage.url = "github:serokell/nix-npm-buildpackage";
     flake-compat = {
       url = "github:edolstra/flake-compat";

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -55,7 +55,8 @@ pkgs.haskell-nix.cabalProject {
     withHoogle = false;
     tools = {
       cabal = { };
-      haskell-language-server = {};
+      haskell-language-server = { };
+      hlint = { };
     };
     buildInputs = [
       pkgs.postgresql

--- a/nix/legacy-packages.nix
+++ b/nix/legacy-packages.nix
@@ -15,8 +15,18 @@
     {
       legacyPackages = pkgs
         // inferno.versions.${defaultCompiler}
-        // { stable = inputs.stable.legacyPackages.${system}; }
         // {
+        stable = import inputs.stable {
+          inherit system;
+          config.allowUnfree = true;
+          # NOTE To test building the NVIDIA drivers, uncomment this
+          # and `nix build .#stable.linuxPackages.nvidia_x11`
+          overlays = [
+            (import ./overlays/nvidia/v100.nix)
+          ];
+
+        };
+
         # Putting these in `legacyPackages` rather than `packages` for
         # better namespacing (i.e. everything can be under an `inferno-ml-server`
         # attribute rather than all of them at the top level)

--- a/nix/nixos-modules.nix
+++ b/nix/nixos-modules.nix
@@ -7,6 +7,9 @@
   flake.nixosModules = {
     # NOTE This should always be imported by images. This isn't done
     # automatically to reduce the amount of implicit magic going on
+    #
+    # NOTE This also itself imports two other `nixosModules` from this flake:
+    # `cuda` and `inferno-ml-server`
     image-common = ./inferno-ml/images/configuration.nix;
     # For CPU-only images
     image-cpu = ./inferno-ml/images/common/cpu.nix;


### PR DESCRIPTION
Bumps haskell.nix flake input to a slightly newer commit than in #159 so that we can use 24.11 as a new stable branch. Also adds a few small changes (adding `hlint` to the shell env, etc...).

The new nixpkgs for building images is working (I've confirmed elsewhere).

No Haskell changes.