### PR TITLE
[inferno-ml] Fix `toDevice` primitive

### DIFF
--- a/inferno-ml/CHANGELOG.md
+++ b/inferno-ml/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Revision History for inferno-ml
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.5.0.0 -- 2025-02-27
+* Breaking change: old `toDevice` renamed to `unsafeToDevice`
+* Breaking change: new `toDevice` primitive
+
 ## 0.4.0.1 -- 2025-02-13
 * Fourmolu
 

--- a/inferno-ml/inferno-ml.cabal
+++ b/inferno-ml/inferno-ml.cabal
@@ -1,6 +1,6 @@
 cabal-version:      >=1.10
 name:               inferno-ml
-version:            0.4.0.1
+version:            0.5.0.0
 synopsis:           Machine Learning primitives for Inferno
 description:        Machine Learning primitives for Inferno
 homepage:           https://github.com/plow-technologies/inferno.git#readme


### PR DESCRIPTION
Currently, `toDevice` takes a user-supplied `Text` as the name of the device to move the tensor. This is not ideal since it's easy to make a mistake and get some nasty Torch error. This changes `toDevice` to take a `{#cpu,#cuda}` enum as an argument and renames the existing primitive to `toDeviceUnsafe`