### PR TITLE
[inferno-ml] Re-add `nonReinstallablePkgs` and fix `inferno-ml` shell environment

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,6 +14,7 @@ allow-newer: all
 constraints:
     lsp < 1.7
   , lsp-types < 1.7
+  , entropy == 0.4.1.0
 
 source-repository-package
     type: git

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -61,6 +61,8 @@ pkgs.haskell-nix.cabalProject {
     buildInputs = [
       pkgs.postgresql
       config.treefmt.build.wrapper
+      pkgs.torch
+      pkgs.torch.dev
     ]
     ++ builtins.attrValues config.treefmt.build.programs;
     shellHook =
@@ -79,9 +81,14 @@ pkgs.haskell-nix.cabalProject {
             esac
             export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$llp"
           '';
+
+        # Setting the `LD_LIBRARY_PATH` and `CPLUS_INCLUDE_PATH` manually is
+        # needed for `cabal repl` to be able to find the libs for Hasktorch
+        # (ghci doesn't invoke GCC)
         torchHook = ''
           ${setpath}
           export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${inputs.tokenizers}/lib"
+          export CPLUS_INCLUDE_PATH=${lib.getDev pkgs.torch}/include/torch/csrc/api/include
         '';
       in
       ''

--- a/nix/modules.nix
+++ b/nix/modules.nix
@@ -31,4 +31,40 @@
     postgresql-libpq-configure.components.library.libs =
       lib.mkForce [ pkgs.postgresql ];
   };
+
+  nonReinstallablePkgs = lib.mkForce
+    [
+      "system-cxx-std-lib"
+      "rts"
+      "ghc-prim"
+      "integer-gmp"
+      "integer-simple"
+      "base"
+      "containers"
+      "binary"
+      "bytestring"
+      "text"
+      "deepseq"
+      "exceptions"
+      "array"
+      "ghc-boot-th"
+      "ghc-internal"
+      "entropy"
+      "Cabal"
+      "Cabal-syntax"
+      "cabal-doctest"
+      "file-io"
+      "pretty"
+      "template-haskell"
+      "ghc-bignum"
+      "filepath"
+      "directory"
+      "process"
+      "transformers"
+      "stm"
+      "exceptions"
+      "mtl"
+      "time"
+      "unix"
+    ];
 }


### PR DESCRIPTION
The recent GHC/nixpkgs upgrade broke using `cabal repl`, so this fixes it:
- adds `nonReinstallablePkgs` back
- exports `CPLUS_INCLUDE_PATH` so that `libtorch-ffi` can find the `libtorch` headers in ghci sessions