### PR TITLE
[inferno-ml] Don't `error` when moving tensors

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -28,13 +28,11 @@ source-repository-package
     tag: f9e3e485409c5a1de1de99a8ec0f35226c79da79
     --sha256: j+SZk5AZsNP674fb+1aiA7vrsk6Eq5BQM2losQSnaeE=
 
--- NOTE Fork due to issues with `error`s when moving tensors.
--- Modifications will almost certainly not be accepted upstream.
 source-repository-package
     type: git
-    location: https://github.com/plow-technologies/hasktorch.git
-    tag: a70a3c788615ff1d9b8012b192b574ea12d17c26
-    --sha256: sha256-nlGg9YcBhYKS+3E6uGYYE2DM1iceraIHSRorc0uV8Xo=
+    location: https://github.com/hasktorch/hasktorch.git
+    tag: 51894a2abd95d50af147997b76b473edc15385b1
+    --sha256: sha256-o9y/sa26q27Jgu9ozntYdl7ZQdTOxxuDN5hqmBy+ecE=
     subdir:
       libtorch-ffi
       libtorch-ffi-helper

--- a/cabal.project
+++ b/cabal.project
@@ -28,11 +28,13 @@ source-repository-package
     tag: f9e3e485409c5a1de1de99a8ec0f35226c79da79
     --sha256: j+SZk5AZsNP674fb+1aiA7vrsk6Eq5BQM2losQSnaeE=
 
+-- NOTE Fork due to issues with `error`s when moving tensors.
+-- Modifications will almost certainly not be accepted upstream.
 source-repository-package
     type: git
-    location: https://github.com/hasktorch/hasktorch.git
-    tag: 51894a2abd95d50af147997b76b473edc15385b1
-    --sha256: sha256-o9y/sa26q27Jgu9ozntYdl7ZQdTOxxuDN5hqmBy+ecE=
+    location: https://github.com/plow-technologies/hasktorch.git
+    tag: a70a3c788615ff1d9b8012b192b574ea12d17c26
+    --sha256: sha256-nlGg9YcBhYKS+3E6uGYYE2DM1iceraIHSRorc0uV8Xo=
     subdir:
       libtorch-ffi
       libtorch-ffi-helper

--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -2,3 +2,9 @@ indentation: 2
 import-export-style: trailing
 haddock-style: single-line
 indent-wheres: true
+fixities:
+  - infixl 1 &
+  - infixr 4 .~
+  - infixr 4 ?~
+  - infixr 4 %~
+  - infixr 4 <>~

--- a/inferno-ml-server-types/CHANGELOG.md
+++ b/inferno-ml-server-types/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Revision History for inferno-ml-server-types
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.14.1
+* Add `CouldntMoveTensor` warning trace
+
 ## 0.14.0
 * Made RemoteTrace and RemoteError polymorphic so we can remove shims
 * Removed shims

--- a/inferno-ml-server-types/inferno-ml-server-types.cabal
+++ b/inferno-ml-server-types/inferno-ml-server-types.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          inferno-ml-server-types
-version:       0.14.0
+version:       0.14.1
 synopsis:      Types for Inferno ML server
 description:   Types for Inferno ML server
 homepage:      https://github.com/plow-technologies/inferno.git#readme

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
@@ -1135,6 +1135,14 @@ data TraceInfo p mv
 
 data TraceWarn p
   = CancelingInference (Id p)
+  | -- | The tensor could not be moved from the device. The device is represented
+    -- as a string here so that we don't need to use @Device@ from Hasktorch
+    -- (which would pose build problems for us elsewhere)
+    --
+    -- Normally this would occur if a CPU-only @inferno-ml-server@ tried
+    -- moving a tensor from \"cpu:0\" to \"cuda:0\". We don\'t throw any
+    -- exceptions in that case, but the log is still helpful
+    CouldntMoveTensor String
   | OtherWarn Text
   deriving stock (Show, Eq, Generic)
   deriving anyclass (ToJSON, FromJSON)

--- a/inferno-ml-server/CHANGELOG.md
+++ b/inferno-ml-server/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Revision History for `inferno-ml-server`
 
+## 2025.3.6
+* Add `toDevice` impl with logging on failure to move tensor
+
 ## 2025.3.3
 * Brought back shims from inferno-ml-server-types
 

--- a/inferno-ml-server/inferno-ml-server.cabal
+++ b/inferno-ml-server/inferno-ml-server.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               inferno-ml-server
-version:            2025.3.3
+version:            2025.3.6
 synopsis:           Server for Inferno ML
 description:        Server for Inferno ML
 homepage:           https://github.com/plow-technologies/inferno.git#readme

--- a/inferno-ml-server/src/Inferno/ML/Server/Log.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Log.hs
@@ -46,6 +46,12 @@ traceRemote = \case
         [ "Canceling inference job for param:"
         , tshow i
         ]
+    CouldntMoveTensor dev ->
+      Text.pack $
+        unwords
+          [ "Couldn't move tensor to device"
+          , dev
+          ]
     OtherWarn t -> t
   ErrorTrace e -> err . Text.pack $ displayException e
   where

--- a/inferno-ml/CHANGELOG.md
+++ b/inferno-ml/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Revision History for inferno-ml
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.7.0.0 -- 2025-03-06
+* Added parameterized version of `mlModules` to provide specific `toDevice` primitive
+
 ## 0.6.0.0 -- 2025-02-28
 * Breaking change: Moved Inferno.ML.Module.Value to inferno-ml-server-types
 

--- a/inferno-ml/inferno-ml.cabal
+++ b/inferno-ml/inferno-ml.cabal
@@ -31,6 +31,7 @@ library
     , containers
     , exceptions
     , hasktorch
+    , libtorch-ffi
     , inferno-core
     , inferno-types
     , prettyprinter

--- a/inferno-ml/inferno-ml.cabal
+++ b/inferno-ml/inferno-ml.cabal
@@ -31,7 +31,6 @@ library
     , containers
     , exceptions
     , hasktorch
-    , libtorch-ffi
     , inferno-core
     , inferno-types
     , prettyprinter

--- a/inferno-ml/inferno-ml.cabal
+++ b/inferno-ml/inferno-ml.cabal
@@ -1,6 +1,6 @@
 cabal-version:      >=1.10
 name:               inferno-ml
-version:            0.6.0.0
+version:            0.7.0.0
 synopsis:           Machine Learning primitives for Inferno
 description:        Machine Learning primitives for Inferno
 homepage:           https://github.com/plow-technologies/inferno.git#readme

--- a/inferno-ml/src/Inferno/ML/Module/Prelude.hs
+++ b/inferno-ml/src/Inferno/ML/Module/Prelude.hs
@@ -7,6 +7,7 @@
 module Inferno.ML.Module.Prelude
   ( mlPrelude,
     mkMlPrelude,
+    getDevice,
   ) where
 
 import Control.Monad.Catch


### PR DESCRIPTION
We currently have a problem where the "pure" `toDevice` throws an `error` when a tensor can't be moved.

This fixes the `toDevice` primitive used by `inferno-ml-server` to handle that case. We discussed this and decided not to throw a synchronous exception when this happens. Instead, we can log the failure.

This has the advantage of allowing `toDevice` to be run without script modification on different `inferno-ml-server` instances (i.e. with or without CUDA).

We do need to at least log the failure though, so I've made `mlPrelude` parameterized by a `toDevice` implementation -- we can't properly log in `inferno-ml`, so the implementation has been moved to `inferno-ml-server`.