### PR TITLE
[inferno-ml-server] Persistent traces

### DIFF
--- a/inferno-ml-server-types/CHANGELOG.md
+++ b/inferno-ml-server-types/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Revision History for inferno-ml-server-types
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.15.0
+* Added some context to RemoteError constructors
+
 ## 0.14.1
 * Add `CouldntMoveTensor` warning trace
 

--- a/inferno-ml-server-types/inferno-ml-server-types.cabal
+++ b/inferno-ml-server-types/inferno-ml-server-types.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          inferno-ml-server-types
-version:       0.14.1
+version:       0.15.0
 synopsis:      Types for Inferno ML server
 description:   Types for Inferno ML server
 homepage:      https://github.com/plow-technologies/inferno.git#readme

--- a/inferno-ml-server/CHANGELOG.md
+++ b/inferno-ml-server/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Revision History for `inferno-ml-server`
 
+## 2025.3.11
+* Persist error traces in DB if instance-id is provided in the config
+
 ## 2025.3.6
 * Add `toDevice` impl with logging on failure to move tensor
 

--- a/inferno-ml-server/inferno-ml-server.cabal
+++ b/inferno-ml-server/inferno-ml-server.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               inferno-ml-server
-version:            2025.3.6
+version:            2025.3.11
 synopsis:           Server for Inferno ML
 description:        Server for Inferno ML
 homepage:           https://github.com/plow-technologies/inferno.git#readme

--- a/inferno-ml-server/src/Inferno/ML/Server/Log.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Log.hs
@@ -1,20 +1,37 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Inferno.ML.Server.Log where
 
 import Control.Exception (displayException)
+import Control.Monad (when)
+import Control.Monad.Reader (runReaderT)
+import qualified Data.ByteString.Lazy as LBS
 import Data.Functor.Contravariant (contramap)
+import Data.Pool (Pool)
 import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.Encoding as T
+import Data.Time (getCurrentTime)
+import Database.PostgreSQL.Simple
+  ( Connection,
+  )
+import Database.PostgreSQL.Simple.SqlQQ (sql)
 import GHC.Generics (Generic)
 import Inferno.ML.Server.Types
-import Plow.Logging (IOTracer (IOTracer), withEitherTracer)
+import Inferno.ML.Server.Utils (executeStore)
+import qualified Network.HTTP.Client as HTTP
+import Plow.Logging
+  ( IOTracer (IOTracer),
+    Tracer (Tracer),
+    withEitherTracer,
+  )
 import Plow.Logging.Async (withAsyncHandleTracer)
 import Plow.Logging.Message
   ( LogLevel (LevelError, LevelInfo, LevelWarn),
   )
-import UnliftIO (MonadUnliftIO)
+import UnliftIO (MonadIO, MonadUnliftIO, liftIO)
 import UnliftIO.IO (Handle, stderr, stdout)
 
 traceRemote :: RemoteTrace -> Message
@@ -73,10 +90,17 @@ data StdStream a
 withRemoteTracer ::
   forall m a.
   (MonadUnliftIO m) =>
+  InstanceId ->
+  Pool Connection ->
   (IOTracer RemoteTrace -> m a) ->
   m a
-withRemoteTracer f = withAsyncHandleIOTracers stdout stderr $
-  \tso tse -> f $ mkRemoteTracer tso tse
+withRemoteTracer instanceId pool f = withAsyncHandleIOTracers stdout stderr $
+  \tso tse -> do
+    mInstanceId <- case instanceId of
+      InstanceId instanceId' -> pure $ Just instanceId'
+      Auto -> Just <$> queryInstanceId
+      NoDbLogging -> pure Nothing
+    f $ mkRemoteTracer mInstanceId tso tse
   where
     withAsyncHandleIOTracers ::
       (MonadUnliftIO m) =>
@@ -90,12 +114,42 @@ withRemoteTracer f = withAsyncHandleIOTracers stdout stderr $
         inner = withAsyncHandleTracer h2 100 . g
 
     mkRemoteTracer ::
-      IOTracer Text -> IOTracer Text -> IOTracer RemoteTrace
-    mkRemoteTracer (IOTracer traceStdout) (IOTracer traceStderr) =
-      IOTracer $
-        contramap (printMessage . traceRemote) $
-          withEitherTracer traceStdout traceStderr
+      Maybe Text -> IOTracer Text -> IOTracer Text -> IOTracer RemoteTrace
+    mkRemoteTracer mInstanceId (IOTracer traceStdout) (IOTracer traceStderr) =
+      IOTracer $ consoleTracer <> maybe mempty databaseTracer mInstanceId
       where
+        databaseTracer :: forall m'. (MonadIO m') => Text -> Tracer m' RemoteTrace
+        databaseTracer instanceId' = Tracer $ \t ->
+          when (shallPersist t) $
+            liftIO $ do
+              ts <- getCurrentTime
+              flip runReaderT pool $
+                executeStore
+                  [sql|INSERT INTO traces (instance_id, ts, trace) VALUES (?, ?, ?)|]
+                  (instanceId', ts, t)
+
+        consoleTracer :: forall m'. (MonadIO m') => Tracer m' RemoteTrace
+        consoleTracer =
+          contramap (printMessage . traceRemote) $
+            withEitherTracer traceStdout traceStderr
+
+        shallPersist :: RemoteTrace -> Bool
+        shallPersist = \case
+          InfoTrace _ -> False
+          WarnTrace _ -> False
+          ErrorTrace err -> case err of
+            CacheSizeExceeded -> False
+            NoSuchModel{} -> True
+            NoSuchScript{} -> True
+            NoSuchParameter{} -> True
+            InvalidScript{} -> True
+            InvalidOutput{} -> True
+            InfernoError{} -> True
+            NoBridgeSaved{} -> True
+            ScriptTimeout{} -> True
+            ClientError{} -> True
+            OtherRemoteError{} -> False
+
         printMessage :: Message -> Either Text Text
         printMessage (Message level stream) = case stream of
           Stderr t -> printWithLevel Right t
@@ -106,3 +160,11 @@ withRemoteTracer f = withAsyncHandleIOTracers stdout stderr $
             printWithLevel ::
               (Text -> Either Text Text) -> Text -> Either Text Text
             printWithLevel ctor = ctor . (mconcat ["[", tshow level, "] "] <>)
+
+-- | Retrieve EC2 instance id from EC2 environment. See
+-- https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
+queryInstanceId :: (MonadIO m) => m Text
+queryInstanceId = liftIO $ do
+  req <- HTTP.parseRequest "http://169.254.169.254/latest/meta-data/instance-id"
+  mgr <- HTTP.newManager HTTP.defaultManagerSettings
+  T.decodeUtf8Lenient . LBS.toStrict . HTTP.responseBody <$> HTTP.httpLbs req mgr

--- a/inferno-ml-server/src/Inferno/ML/Server/Utils.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Utils.hs
@@ -1,8 +1,10 @@
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Inferno.ML.Server.Utils
-  ( throwInfernoError,
+  ( HasPool,
+    throwInfernoError,
     throwRemoteError,
     firstOrThrow,
     queryStore,
@@ -14,8 +16,10 @@ where
 import Control.Monad (void)
 import Control.Monad.Catch (Exception, MonadThrow (throwM))
 import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Reader (MonadReader)
 import Data.Generics.Labels ()
-import Data.Pool (withResource)
+import Data.Generics.Product (HasType (typed))
+import Data.Pool (Pool, withResource)
 import Data.Vector (Vector, (!?))
 import Database.PostgreSQL.Simple
   ( Connection,
@@ -33,20 +37,26 @@ import UnliftIO (MonadUnliftIO (withRunInIO))
 throwRemoteError :: RemoteError -> RemoteM a
 throwRemoteError = throwM
 
-throwInfernoError :: (Exception e) => e -> RemoteM a
-throwInfernoError = throwRemoteError . InfernoError . SomeInfernoError . show
+throwInfernoError :: (Exception e) => Id InferenceParam -> e -> RemoteM a
+throwInfernoError ipid = throwRemoteError . InfernoError ipid . SomeInfernoError . show
 
-queryStore :: (ToRow b, FromRow a) => Query -> b -> RemoteM (Vector a)
+type HasPool r m = (MonadUnliftIO m, MonadReader r m, HasType (Pool Connection) r)
+
+queryStore :: forall b a m r. (HasPool r m, ToRow b, FromRow a) => Query -> b -> m (Vector a)
 queryStore q x = withConns $ \conn -> liftIO $ query conn q x
+{-# INLINE queryStore #-}
 
-executeStore :: (ToRow a) => Query -> a -> RemoteM ()
+executeStore :: forall a m r. (HasPool r m, ToRow a) => Query -> a -> m ()
 executeStore q x =
   withConns $ \conn ->
     liftIO . withTransaction conn . void $
       execute conn q x
+{-# INLINE executeStore #-}
 
 firstOrThrow :: (MonadThrow m) => RemoteError -> Vector a -> m a
 firstOrThrow e = maybe (throwM e) pure . (!? 0)
+{-# INLINE firstOrThrow #-}
 
-withConns :: (Connection -> RemoteM b) -> RemoteM b
-withConns f = view #store >>= \cs -> withRunInIO $ \r -> withResource cs $ r . f
+withConns :: (HasPool r m) => (Connection -> m b) -> m b
+withConns f = view typed >>= \cs -> withRunInIO $ \r -> withResource cs $ r . f
+{-# INLINE withConns #-}

--- a/nix/inferno-ml/images/common/cpu.nix
+++ b/nix/inferno-ml/images/common/cpu.nix
@@ -7,6 +7,7 @@
     enable = true;
     configuration = {
       port = 8080;
+      instanceId = "auto";
       cache = {
         path = "/home/inferno/.cache/models";
         max-size = 10 * 1073741824;

--- a/nix/inferno-ml/images/common/gpu.nix
+++ b/nix/inferno-ml/images/common/gpu.nix
@@ -26,6 +26,7 @@
     enable = true;
     configuration = {
       port = 8080;
+      instanceId = "auto";
       cache = {
         path = "/home/inferno/.cache/models";
         max-size = 10 * 1073741824;

--- a/nix/inferno-ml/images/common/qcow2.nix
+++ b/nix/inferno-ml/images/common/qcow2.nix
@@ -9,6 +9,7 @@
       port = 8080;
       # Ten minute timeout
       timeout = 600;
+      instanceId = "i-11111111111111111";
       cache = {
         path = "/home/inferno/.cache/models";
         max-size = 10 * 1073741824;

--- a/nix/inferno-ml/migrations/v1-create-tables.sql
+++ b/nix/inferno-ml/migrations/v1-create-tables.sql
@@ -108,3 +108,15 @@ create table if not exists bridges
 
 create trigger "manage-mversion-lo" before update or delete on mversions
   for each row execute function lo_manage(contents);
+
+create table if not exists traces
+  ( -- the EC2 instance id where the server that that produced the trace was running.
+    instance_id text not null,
+    -- Timestamp
+    ts timestamptz not null,
+    -- The RemoteTrace
+    trace jsonb not null
+  );
+-- For queries where we want to see what happened on an instance during a time
+-- range
+create index trace_instance_ts_ix on traces ( instance_id, ts );

--- a/nix/inferno-ml/modules/inferno-ml-server.nix
+++ b/nix/inferno-ml/modules/inferno-ml-server.nix
@@ -63,6 +63,13 @@ in
                   "Number of seconds for script eval timeout";
               };
 
+              instanceId = lib.mkOption {
+                type = lib.types.nullOr lib.types.str;
+                default = null;
+                description = lib.mdDoc
+                  "The instance-id for DB logs. Use 'auto' to introspect it from EC2, null for no DB logging";
+              };
+
               cache = lib.mkOption {
                 description = lib.mdDoc ''
                   Options for the cache itself

--- a/nix/inferno-ml/tests/server.nix
+++ b/nix/inferno-ml/tests/server.nix
@@ -214,7 +214,7 @@ pkgs.nixosTest {
       'pg_isready -U inferno -d inferno -h 127.0.0.1 -p 5432'
     )
     node.succeed(
-      'psql -U inferno -d inferno -f ${../migrations/v1-create-tables.sql}'
+      'psql -U inferno -d inferno -f ${../migrations/v1-create-tables.sql} -v "ON_ERROR_STOP=1"'
     )
     node.succeed('insert-mnist-model')
     node.wait_for_unit("inferno-ml-server.service")


### PR DESCRIPTION
If the `instanceId` field is present in the config, inferno-ml-server will persist error traces in the database.