### PR TITLE
[inferno-ml] Fix `forward` primitive

### DIFF
--- a/inferno-ml/CHANGELOG.md
+++ b/inferno-ml/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Revision History for inferno-ml
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.7.0.1 -- 2025-04-08
+* Catch C++ exceptions in `forward` primitive
+
 ## 0.7.0.0 -- 2025-03-06
 * Added parameterized version of `mlModules` to provide specific `toDevice` primitive
 

--- a/inferno-ml/inferno-ml.cabal
+++ b/inferno-ml/inferno-ml.cabal
@@ -1,6 +1,6 @@
 cabal-version:      >=1.10
 name:               inferno-ml
-version:            0.7.0.0
+version:            0.7.0.1
 synopsis:           Machine Learning primitives for Inferno
 description:        Machine Learning primitives for Inferno
 homepage:           https://github.com/plow-technologies/inferno.git#readme

--- a/inferno-ml/inferno-ml.cabal
+++ b/inferno-ml/inferno-ml.cabal
@@ -30,9 +30,11 @@ library
       base
     , containers
     , exceptions
+    , extra
     , hasktorch
     , inferno-core
     , inferno-types
+    , inline-c-cpp
     , prettyprinter
     , template-haskell
     , text

--- a/inferno-ml/src/Inferno/ML/Module/Prelude.hs
+++ b/inferno-ml/src/Inferno/ML/Module/Prelude.hs
@@ -176,7 +176,7 @@ forwardFun = VFun $ \case
   VCustom (VModel model) -> pure . VFun $ \case
     VArray mts ->
       getTensors mts >>= \tensors ->
-        -- Note that we are using `forwardIO` here so any CPP exception can be
+        -- Note that we are using `forwardIO` here so any C++ exception can be
         -- caught, otherwise the operation will fail silently (besides printing
         -- to stderr)
         fmap (VArray . fmap (VCustom . VTensor)) . liftIO $
@@ -189,7 +189,7 @@ forwardFun = VFun $ \case
           VCustom (VTensor t) -> pure t
           _ -> throwM expectedTensors
 
-        -- Rethrow the CPP exception as a `RuntimeError` so we can at least
+        -- Rethrow the C++ exception as a `RuntimeError` so we can at least
         -- see it in error messages more clearly
         torchHandler :: CppException -> IO [Tensor]
         torchHandler =

--- a/inferno-ml/src/Inferno/ML/Module/Prelude.hs
+++ b/inferno-ml/src/Inferno/ML/Module/Prelude.hs
@@ -10,13 +10,16 @@ module Inferno.ML.Module.Prelude
     getDevice,
   ) where
 
+import Control.Exception (evaluate)
 import Control.Monad.Catch
   ( Exception (displayException),
     MonadCatch,
     MonadThrow (throwM),
     SomeException,
+    catch,
     try,
   )
+import Control.Monad.Extra (concatMapM)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Data.Functor ((<&>))
 import qualified Data.Map as Map
@@ -29,6 +32,7 @@ import Inferno.Module.Cast (FromValue (fromValue), ToValue (toValue))
 import qualified Inferno.Module.Prelude as Prelude
 import Inferno.Types.Syntax (Ident)
 import Inferno.Types.Value (ImplEnvM, Value (..))
+import Language.C.Inline.Cpp.Exception (CppException)
 import Prettyprinter (Pretty)
 import Torch
 import qualified Torch.DType as TD
@@ -166,15 +170,53 @@ loadModelFun = VFun $ \case
       loadModel = TS.loadScript TS.WithoutRequiredGrad mn
   _ -> throwM $ RuntimeError "Expected a modelName"
 
-forwardFun :: ScriptModule -> [Tensor] -> [Tensor]
-forwardFun m ts =
-  unIV $ forward m (map IVTensor ts)
+forwardFun ::
+  forall m x. (Pretty x, MonadIO m, MonadThrow m) => Value (MlValue x) m
+forwardFun = VFun $ \case
+  VCustom (VModel model) -> pure . VFun $ \case
+    VArray mts ->
+      getTensors mts >>= \tensors ->
+        -- Note that we are using `forwardIO` here so any CPP exception can be
+        -- caught, otherwise the operation will fail silently (besides printing
+        -- to stderr)
+        fmap (VArray . fmap (VCustom . VTensor)) . liftIO $
+          forwardIO model tensors `catch` torchHandler
+      where
+        -- Unfortunately we need to unwrap all of the constructors to get the
+        -- tensors inside
+        getTensors :: [Value (MlValue x) m] -> m [Tensor]
+        getTensors = traverse $ \case
+          VCustom (VTensor t) -> pure t
+          _ -> throwM expectedTensors
+
+        -- Rethrow the CPP exception as a `RuntimeError` so we can at least
+        -- see it in error messages more clearly
+        torchHandler :: CppException -> IO [Tensor]
+        torchHandler =
+          throwM
+            . RuntimeError
+            . ("forward: exception from Torchscript interpreter " <>)
+            . displayException
+    _ -> throwM expectedTensors
+  _ -> throwM $ RuntimeError "expected a model"
   where
+    expectedTensors :: EvalError
+    expectedTensors = RuntimeError "expected an array of tensors"
+
+-- Lifts Hasktorch's `forward` to `IO` (via `evaluate`) so we can catch
+-- any `CppStdException`s in case the Torchscript interpreter fails;
+-- `forward` has a "pure" interface but internally uses `unsafePerformIO`,
+-- so we need to `evaluate` it to be able to catch the exception in the Inferno
+-- primitive
+forwardIO :: ScriptModule -> [Tensor] -> IO [Tensor]
+forwardIO m ts = unIV =<< evaluate (forward m (fmap IVTensor ts))
+  where
+    unIV :: IValue -> IO [Tensor]
     unIV = \case
-      IVTensor t' -> [t']
-      IVTensorList ts' -> ts'
-      IVTuple ivs -> concatMap unIV ivs
-      res -> error $ "expected tensor result, got " ++ show res
+      IVTensor t -> pure [t]
+      IVTensorList tl -> pure tl
+      IVTuple ivs -> concatMapM unIV ivs
+      res -> throwM . RuntimeError $ "expected tensor result, got " <> show res
 
 randnIOFun ::
   forall m x.
@@ -307,7 +349,7 @@ module ML
 
   unsafeLoadScript : text -> model := ###unsafeLoadScriptFun###;
 
-  forward : model -> array of tensor -> array of tensor := ###forwardFun###;
+  forward : model -> array of tensor -> array of tensor := ###!forwardFun###;
 
 |]
 


### PR DESCRIPTION
Similar to other issues we've had in the past, Hasktorch's `forward` is presented as a "pure" function but actually uses `unsafePerformIO` internally. This leads to use not catching `CppException`s in case the Torch interpreter runs into a problem. This fixes the primitive by using `evaluate` to lift Hasktorch's `forward` into `IO` and then catching/rethrowing the exception as an Inferno `EvalError`. `inferno-ml-server` should then send a proper error response in case of an exception.

I've run this against both sets of Inferno ML integration tests that we have an it works with existing (good) scripts. I also tried running some known-bad Torchscript `ScriptModules` and the exception is caught.