### PR TITLE
[inferno-ml] Store model version size

### DIFF
--- a/inferno-ml-server-types/CHANGELOG.md
+++ b/inferno-ml-server-types/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Revision History for inferno-ml-server-types
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.17.0
+* Breaking change: add `size` field to `ModelVersion`
+
 ## 0.16.0
 * Breaking change: swap order of `makeWrites` elements
 

--- a/inferno-ml-server-types/inferno-ml-server-types.cabal
+++ b/inferno-ml-server-types/inferno-ml-server-types.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          inferno-ml-server-types
-version:       0.16.0
+version:       0.17.0
 synopsis:      Types for Inferno ML server
 description:   Types for Inferno ML server
 homepage:      https://github.com/plow-technologies/inferno.git#readme

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
@@ -1055,6 +1055,7 @@ data RemoteError p m mv
     InfernoError (Id p) SomeInfernoError
   | NoBridgeSaved (Id p)
   | ScriptTimeout (Id p) Int
+  | DbError String
   | ClientError (Id p) String
   | OtherRemoteError Text
   deriving stock (Show, Eq, Generic)
@@ -1121,6 +1122,11 @@ instance (Typeable p, Typeable m, Typeable mv) => Exception (RemoteError p m mv)
         , "timed out after"
         , show $ t `div` 1000000
         , "seconds"
+        ]
+    DbError e ->
+      unwords
+        [ "Database error:"
+        , e
         ]
     ClientError ipid ce ->
       unwords

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
@@ -720,12 +720,6 @@ data InferenceParam gid p = InferenceParam
   { id :: Maybe (Id (InferenceParam gid p))
   , script :: VCObjectHash
   -- ^ The script of the parameter
-  --
-  -- For new parameters, this will be textual or some other identifier
-  -- (e.g. a UUID for use with @inferno-lsp@)
-  --
-  -- For existing inference params, this is the foreign key for the specific
-  -- script in the 'InferenceScript' table (i.e. a @VCObjectHash@)
   , inputs :: Inputs p
   -- ^ Mapping the input\/output to the Inferno identifier helps ensure that
   -- Inferno identifiers are always pointing to the correct input\/output;
@@ -754,8 +748,6 @@ instance (FromJSON p, FromJSON gid) => FromJSON (InferenceParam gid p) where
       <*> o .:? "terminated"
       <*> o .: "gid"
 
--- We only want this instance if the `script` is a `VCObjectHash` (because it
--- should not be possible to store a new param with a raw script)
 instance
   ( FromJSON p
   , FromField gid

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
@@ -375,10 +375,9 @@ instance (ToField gid) => ToRow (Model gid) where
     , toField Default
     ]
 
-{- ORMOLU_DISABLE -}
 instance
-  ( FromJSON gid,
-    Ord gid
+  ( FromJSON gid
+  , Ord gid
   ) =>
   FromJSON (Model gid)
   where
@@ -394,7 +393,6 @@ instance
       -- If a new model is being serialized, it does not really make
       -- sense to require a `"terminated": null` field
       <*> o .:? "terminated"
-{- ORMOLU_ENABLE -}
 
 instance (ToJSON gid) => ToJSON (Model gid) where
   toJSON m =
@@ -497,7 +495,7 @@ instance (ToField gid) => ToRow (ModelVersion gid Oid) where
     , toField Default
     ]
 
-instance FromJSON gid => FromJSON (ModelVersion gid Oid) where
+instance (FromJSON gid) => FromJSON (ModelVersion gid Oid) where
   parseJSON = withObject "ModelVersion" $ \o ->
     ModelVersion
       <$> o .:? "id"
@@ -580,14 +578,12 @@ data ModelSummary = ModelSummary
   deriving stock (Show, Eq, Generic)
   deriving anyclass (ToJSON, NFData, ToADTArbitrary)
 
-{- ORMOLU_DISABLE -}
 instance FromJSON ModelSummary where
   parseJSON = withObject "ModelSummary" $ \o ->
     ModelSummary
       <$> o .: "summary"
       <*> o .:? "uses" .!= mempty
       <*> o .:? "evaluation" .!= mempty
-{- ORMOLU_ENABLE -}
 
 instance Arbitrary ModelSummary where
   arbitrary = genericArbitrary
@@ -745,9 +741,7 @@ data InferenceParam gid p = InferenceParam
   deriving stock (Show, Eq, Generic)
   deriving anyclass (NFData, ToJSON)
 
-{- ORMOLU_DISABLE -}
-instance (FromJSON p, FromJSON gid) => FromJSON (InferenceParam gid p)
-  where
+instance (FromJSON p, FromJSON gid) => FromJSON (InferenceParam gid p) where
   parseJSON = withObject "InferenceParam" $ \o ->
     InferenceParam
       -- The ID needs to be included when deserializing
@@ -759,7 +753,6 @@ instance (FromJSON p, FromJSON gid) => FromJSON (InferenceParam gid p)
       -- We shouldn't require this field
       <*> o .:? "terminated"
       <*> o .: "gid"
-{- ORMOLU_ENABLE -}
 
 -- We only want this instance if the `script` is a `VCObjectHash` (because it
 -- should not be possible to store a new param with a raw script)

--- a/inferno-ml-server/CHANGELOG.md
+++ b/inferno-ml-server/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Revision History for `inferno-ml-server`
 
+## 2025.4.21
+* Update for new `size` field in `ModelVersion`
+
 ## 2025.3.28
 * Update for new order of `makeWrites` elements
 

--- a/inferno-ml-server/inferno-ml-server.cabal
+++ b/inferno-ml-server/inferno-ml-server.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               inferno-ml-server
-version:            2025.3.28
+version:            2025.4.21
 synopsis:           Server for Inferno ML
 description:        Server for Inferno ML
 homepage:           https://github.com/plow-technologies/inferno.git#readme

--- a/inferno-ml-server/src/Inferno/ML/Server.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server.hs
@@ -104,8 +104,7 @@ infernoMlRemote env = serve api $ hoistServer api (`toHandler` env) server
       traceWith tracer (ErrorTrace err) >> throwM err
 
     toServantErr :: RemoteError -> IO a
-    toServantErr =
-      throwM . translateError
+    toServantErr = throwM . translateError
       where
         errWith :: ServerError -> RemoteError -> ServerError
         errWith se e =
@@ -114,6 +113,8 @@ infernoMlRemote env = serve api $ hoistServer api (`toHandler` env) server
                 ByteString.Lazy.Char8.pack . displayException $
                   e
             }
+
+        translateError :: RemoteError -> ServerError
         translateError =
           \case
             e@OtherRemoteError{} -> errWith err500 e
@@ -126,6 +127,7 @@ infernoMlRemote env = serve api $ hoistServer api (`toHandler` env) server
             e@InfernoError{} -> errWith err500 e
             e@NoBridgeSaved{} -> errWith err500 e
             e@ScriptTimeout{} -> errWith err500 e
+            e@DbError{} -> errWith err500 e
             e@ClientError{} -> errWith err500 e
 
 api :: Proxy InfernoMlServerAPI

--- a/inferno-ml-server/src/Inferno/ML/Server/Inference/Model.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Inference/Model.hs
@@ -1,9 +1,10 @@
+{-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Inferno.ML.Server.Inference.Model
   ( getModelsAndVersions,
-    getModelVersionSizeAndContents,
+    getModelVersionContents,
   )
 where
 
@@ -13,13 +14,12 @@ import Data.Foldable (toList)
 import Data.Vector (Vector)
 import Database.PostgreSQL.Simple
   ( In (In),
-    Only (Only, fromOnly),
+    Only (Only),
     Query,
     withTransaction,
   )
 import Database.PostgreSQL.Simple.LargeObjects
   ( IOMode (ReadMode),
-    Oid,
     loClose,
     loOpen,
     loRead,
@@ -27,10 +27,6 @@ import Database.PostgreSQL.Simple.LargeObjects
 import Database.PostgreSQL.Simple.SqlQQ (sql)
 import Inferno.ML.Server.Types
 import Inferno.ML.Server.Utils
-  ( firstOrThrow,
-    queryStore,
-    withConns,
-  )
 import UnliftIO (MonadUnliftIO (withRunInIO))
 import UnliftIO.Exception (bracket)
 
@@ -60,26 +56,11 @@ getModelsAndVersions =
 -- | Get the actual serialized bytes of the model, which is stored in the Postgres
 -- large object table (and must be explicitly imported using 'loImport'), along
 -- with the number of bytes
-getModelVersionSizeAndContents :: Oid -> RemoteM (Integer, ByteString)
-getModelVersionSizeAndContents m =
+getModelVersionContents :: ModelVersion -> RemoteM ByteString
+getModelVersionContents mversion =
   withConns $ \conn -> withRunInIO $ \r ->
     withTransaction conn . r $ do
-      size <- getModelVersionSize m
-      bs <-
-        liftIO
-          . bracket (loOpen conn m ReadMode) (loClose conn)
-          . flip (loRead conn)
-          $ fromIntegral size
-      pure (size, bs)
-
--- | Get the size of the model contents themselves (byte count of large object).
--- It is better to do this via Postgres rather than using @ByteString.length@
--- on the returned bytes
-getModelVersionSize :: Oid -> RemoteM Integer
-getModelVersionSize oid =
-  fmap fromOnly $
-    firstOrThrow (OtherRemoteError "Could not get model size")
-      =<< queryStore q (Only oid)
-  where
-    q :: Query
-    q = [sql| SELECT length(lo_get(?)) |]
+      liftIO
+        . bracket (loOpen conn mversion.contents ReadMode) (loClose conn)
+        . flip (loRead conn)
+        $ fromIntegral mversion.size

--- a/inferno-ml-server/src/Inferno/ML/Server/Log.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Log.hs
@@ -147,6 +147,7 @@ withRemoteTracer instanceId pool f = withAsyncHandleIOTracers stdout stderr $
             InfernoError{} -> True
             NoBridgeSaved{} -> True
             ScriptTimeout{} -> True
+            DbError{} -> True
             ClientError{} -> True
             OtherRemoteError{} -> False
 

--- a/nix/inferno-ml/migrations/v1-create-tables.sql
+++ b/nix/inferno-ml/migrations/v1-create-tables.sql
@@ -26,7 +26,7 @@ create table if not exists models
   , updated timestamptz
     -- See note above
   , terminated timestamptz
-  , unique (name, gid)
+  , unique nulls not distinct (name, gid, terminated)
   );
 
 create table if not exists mversions

--- a/nix/inferno-ml/migrations/v1-create-tables.sql
+++ b/nix/inferno-ml/migrations/v1-create-tables.sql
@@ -42,6 +42,10 @@ create table if not exists mversions
     -- that saving a model version requires as its first step `lo_import`ing
     -- the contents
   , contents oid not null
+    -- The size of the `contents` above in bytes. This could be calculated
+    -- on-demand, but since the `contents` are immutable, we can calculate
+    -- this once and store it here
+  , size bigint not null
   , version text not null
   , created timestamptz default now()
     -- See note above

--- a/nix/inferno-ml/tests/server.nix
+++ b/nix/inferno-ml/tests/server.nix
@@ -63,16 +63,18 @@ pkgs.nixosTest {
                 , description
                 , card
                 , contents
+                , size
                 , version
                 )
-                VALUES
-                ( '00000006-0000-0000-0000-000000000000'::uuid
+                SELECT
+                  '00000006-0000-0000-0000-000000000000'::uuid
                 , '00000005-0000-0000-0000-000000000000'::uuid
                 , 'My first model'
                 , '${card}'::jsonb
                 , :LASTOID
+                , length(lo_get(:LASTOID))
                 , 'v1'
-                );
+                ;
               EOF
             '';
         }


### PR DESCRIPTION
Since the `contents` of a `ModelVersion` are immutable, we can calculate its size once and store it in the DB. Currently we only need the size once in `inferno-ml-server` (when caching a model version) but now we want to display them elsewhere. Calculating it each time is wasteful.

This also includes a few other changes:
- `SqlError`s are now caught and rethrown so they show up as error traces and in error responses 
- The `unique` constraint on `models` has been changed so that a new model can be created with the same name as (a) previously terminated model(s)