### PR TITLE
[inferno-ml] Allow non-double `Writes` and more value types

### DIFF
--- a/inferno-ml-server-types/CHANGELOG.md
+++ b/inferno-ml-server-types/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Revision History for inferno-ml-server-types
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.18.0
+* Breaking changes:
+  - Make `Writes` polymorphic
+  - Add more value types to `IValue` and change JSON representation
+
 ## 0.17.0
 * Breaking change: add `size` field to `ModelVersion`
 

--- a/inferno-ml-server-types/inferno-ml-server-types.cabal
+++ b/inferno-ml-server-types/inferno-ml-server-types.cabal
@@ -58,7 +58,6 @@ library
     , QuickCheck
     , quickcheck-arbitrary-adt
     , quickcheck-instances
-    , scientific
     , servant-client
     , servant-conduit
     , servant-server

--- a/inferno-ml-server-types/inferno-ml-server-types.cabal
+++ b/inferno-ml-server-types/inferno-ml-server-types.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          inferno-ml-server-types
-version:       0.17.0
+version:       0.18.0
 synopsis:      Types for Inferno ML server
 description:   Types for Inferno ML server
 homepage:      https://github.com/plow-technologies/inferno.git#readme

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
@@ -21,10 +21,8 @@ import Control.Applicative (asum, optional)
 import Control.Category ((>>>))
 import Control.DeepSeq (NFData (rnf), rwhnf)
 import Control.Exception (Exception, displayException)
-import Control.Monad (void, (<=<))
+import Control.Monad (void)
 import Data.Aeson hiding (Value)
-import qualified Data.Aeson
-import Data.Aeson.Types (Parser)
 import qualified Data.Attoparsec.ByteString.Char8 as Attoparsec
 import Data.Bool (bool)
 import Data.ByteString (ByteString)
@@ -40,7 +38,6 @@ import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NonEmpty
 import Data.Map.Strict (Map)
 import Data.Ord (comparing)
-import Data.Scientific (toRealFloat)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text.Encoding
@@ -48,8 +45,7 @@ import Data.Time (UTCTime)
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import Data.UUID (UUID)
 import Data.Vector (Vector)
-import qualified Data.Vector as Vector
-import Data.Word (Word32, Word64)
+import Data.Word (Word16, Word32, Word64)
 import Database.PostgreSQL.Simple.FromField
   ( Conversion,
     Field,
@@ -191,7 +187,7 @@ type BridgeAPI p t =
 type WriteStream m = ConduitT () (Int, [(IValue, EpochTime)]) m ()
 
 -- | Convenience synonym for the consumed 'WriteStream'
-type Writes p = Map p [(Double, EpochTime)]
+type Writes p = Map p [(IValue, EpochTime)]
 
 -- | Just a convenience synonym for cleaning up type signatures
 type Inputs p = Map Ident (SingleOrMany p)
@@ -936,67 +932,31 @@ fromIPv4 =
 -- which cannot have sensible @ToJSON@ and @FromJSON@ instances
 data IValue
   = IText Text
+  | IInt Int64
+  | IWord16 Word16
+  | IWord32 Word32
+  | IWord64 Word64
   | IDouble Double
-  | ITuple (IValue, IValue)
   | ITime EpochTime
-  | IEmpty
   | IArray (Vector IValue)
+  | ITuple (IValue, IValue)
+  | IEmpty
   deriving stock (Show, Eq, Generic)
   deriving anyclass (NFData)
 
 instance FromJSON IValue where
-  parseJSON = \case
-    String t -> pure $ IText t
-    Number n -> pure . IDouble $ toRealFloat n
-    -- It's easier to just mark the time explicitly in an object,
-    -- rather than try to deal with distinguishing times and doubles
-    Object o ->
-      asum
-        [ ITime <$> o .: "time"
-        , fmap IArray $ arrayP =<< o .: "array"
-        ]
-    -- Note that this preserves a plain JSON array for tuples. But we need
-    -- some straightforward way of distinguishing tuples and arrays; since
-    -- the bridge often transmits a large number of individual tuples (times
-    -- and values), it's better to use arrays for the tuples and a tagged object
-    -- for arrays themselves; we often will only deal with one large array, and
-    -- adding a few bytes to this is better than adding a few bytes to thousands
-    -- of encoded tuples
-    Array a
-      | [x, y] <- Vector.toList a ->
-          fmap ITuple $ (,) <$> parseJSON x <*> parseJSON y
-      | otherwise -> fail "Only two-element tuples are supported"
-    Null -> pure IEmpty
-    _ -> fail "Expected one of: string, double, time, tuple, null, array"
-    where
-      arrayP :: Vector Data.Aeson.Value -> Parser (Vector IValue)
-      arrayP a =
-        -- This is a bit tedious, but we want to make sure that the array elements
-        -- are homogeneous; parsing all elements to `IValue`s first can't guarantee
-        -- this
-        asum
-          [ -- This alternative means that `null` will be correctly parsed to NaN
-            -- when inside an array of doubles
-            fmap IDouble <$> traverse parseJSON a
-          , fmap ITuple <$> traverse parseJSON a
-          , fmap IText <$> traverse parseJSON a
-          , fmap ITime <$> traverse (withObject "EpochTime" (.: "time")) a
-          , -- Nested array support
-            fmap IArray
-              <$> traverse (withObject "IArray" (arrayP <=< (.: "array"))) a
-          , fail "Expected a heterogeneous array"
-          ]
+  parseJSON =
+    genericParseJSON
+      defaultOptions
+        { sumEncoding = TaggedObject "type" "value"
+        }
 
 instance ToJSON IValue where
-  toJSON = \case
-    IDouble d -> toJSON d
-    IText t -> toJSON t
-    ITuple t -> toJSON t
-    -- See `FromJSON` instance above
-    ITime t -> object ["time" .= t]
-    -- See `FromJSON` instance above
-    IArray is -> object ["array" .= is]
-    IEmpty -> toJSON Null
+  toJSON =
+    genericToJSON
+      defaultOptions
+        { sumEncoding = TaggedObject "type" "value"
+        }
 
 -- | Used to represent inputs to the script. 'Many' allows for an array input
 data SingleOrMany a

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
@@ -949,14 +949,18 @@ instance FromJSON IValue where
   parseJSON =
     genericParseJSON
       defaultOptions
-        { sumEncoding = TaggedObject "type" "value"
+        { -- `t` for type and `v` for value; it may seem a bit cryptic but
+          -- this is not for human consumption and using the abbreviations
+          -- reduces space for each item in the stream
+          sumEncoding = TaggedObject "t" "v"
         }
 
 instance ToJSON IValue where
   toJSON =
     genericToJSON
       defaultOptions
-        { sumEncoding = TaggedObject "type" "value"
+        { -- See note above
+          sumEncoding = TaggedObject "t" "v"
         }
 
 -- | Used to represent inputs to the script. 'Many' allows for an array input

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
@@ -937,6 +937,7 @@ data IValue
   | IWord32 Word32
   | IWord64 Word64
   | IDouble Double
+  | IBool Bool
   | ITime EpochTime
   | IArray (Vector IValue)
   | ITuple (IValue, IValue)

--- a/inferno-ml-server/CHANGELOG.md
+++ b/inferno-ml-server/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Revision History for `inferno-ml-server`
 
+## 2025.4.23
+* Update for new polymorphic writes
+
 ## 2025.4.21
 * Update for new `size` field in `ModelVersion`
 

--- a/inferno-ml-server/inferno-ml-server.cabal
+++ b/inferno-ml-server/inferno-ml-server.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               inferno-ml-server
-version:            2025.4.21
+version:            2025.4.23
 synopsis:           Server for Inferno ML
 description:        Server for Inferno ML
 homepage:           https://github.com/plow-technologies/inferno.git#readme

--- a/inferno-ml-server/src/Inferno/ML/Server/Inference.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Inference.hs
@@ -490,12 +490,12 @@ getInferenceParamWithModels ipid =
     q =
       [sql|
         SELECT
-          P.*,
-          coalesce
-            ( jsonb_object_agg(MS.ident, MS.model)
-                FILTER (WHERE MS.ident IS NOT NULL)
-            , '{}'::jsonb
-            ) mversions
+          P.*
+        , coalesce
+          ( jsonb_object_agg(MS.ident, MS.model)
+              FILTER (WHERE MS.ident IS NOT NULL)
+          , '{}'::jsonb
+          ) mversions
         FROM params P
           LEFT OUTER JOIN scripts S ON P.script = S.id
           LEFT OUTER JOIN mselections MS ON MS.script = S.id

--- a/inferno-ml-server/src/Inferno/ML/Server/Module/Bridge.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Module/Bridge.hs
@@ -11,7 +11,7 @@ import Inferno.ML.Server.Types
 import Inferno.Module.Cast (ToValue (toValue))
 import Inferno.Types.Value
   ( ImplicitCast (ImplicitCast),
-    Value (VDouble, VOne, VTuple),
+    Value (VDouble, VOne, VText, VTuple),
     liftImplEnvM,
   )
 import System.Posix.Types (EpochTime)
@@ -46,8 +46,12 @@ mkBridgeFuns valueAt latestValueAndTimeBefore valuesBetween =
 
         toInfernoValue :: IValue -> BridgeV RemoteM
         toInfernoValue =
+          -- Note that only double and text values can be directly queried;
+          -- if we get a value that's not `VEmpty`, we need to wrap it in a
+          -- `VOne`, since this is supposed to be a `Some` on the Inferno side
           fromIValue >>> \case
             d@VDouble{} -> VOne d
+            t@VText{} -> VOne t
             v -> v
 
     latestValueAndTimeBeforeFun :: BridgeV RemoteM

--- a/inferno-ml-server/src/Inferno/ML/Server/Module/Types.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Module/Types.hs
@@ -33,12 +33,12 @@ import Inferno.Types.Value
         VDouble,
         VEmpty,
         VEpochTime,
-        VText,
         VInt,
+        VText,
+        VTuple,
         VWord16,
         VWord32,
-        VWord64,
-        VTuple
+        VWord64
       ),
   )
 import Inferno.Types.VersionControl (VCObjectHash)

--- a/inferno-ml-server/src/Inferno/ML/Server/Module/Types.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Module/Types.hs
@@ -27,15 +27,25 @@ import Inferno.Module.Cast
   )
 import Inferno.Types.Value
   ( ImplEnvM,
-    Value (VArray, VCustom, VDouble, VEmpty, VEpochTime, VText, VTuple),
+    Value
+      ( VArray,
+        VCustom,
+        VDouble,
+        VEmpty,
+        VEpochTime,
+        VText,
+        VInt,
+        VWord16,
+        VWord32,
+        VWord64,
+        VTuple
+      ),
   )
 import Inferno.Types.VersionControl (VCObjectHash)
 import Prettyprinter (Pretty (pretty), cat, (<+>))
 import System.Posix.Types (EpochTime)
 import Web.HttpApiData (FromHttpApiData, ToHttpApiData)
 import "inferno-ml-server-types" Inferno.ML.Server.Types
-  ( IValue (IArray, IDouble, IEmpty, IText, ITime, ITuple),
-  )
 
 -- | Custom type for bridge prelude
 data BridgeValue
@@ -111,20 +121,28 @@ data BridgeFuns m = BridgeFuns
 
 fromIValue :: IValue -> Value v m
 fromIValue = \case
-  IDouble d -> VDouble d
   IText t -> VText t
+  IInt i -> VInt i
+  IWord16 w -> VWord16 w
+  IWord32 w -> VWord32 w
+  IWord64 w -> VWord64 w
+  IDouble d -> VDouble d
   ITime t -> VEpochTime t
-  ITuple (x, y) -> VTuple [fromIValue x, fromIValue y]
   IEmpty -> VEmpty
+  ITuple (x, y) -> VTuple [fromIValue x, fromIValue y]
   IArray v -> VArray $ Vector.toList $ fromIValue <$> v
 
 toIValue :: (MonadThrow f) => Value custom m -> f IValue
 toIValue = \case
   VText t -> pure $ IText t
+  VInt i -> pure $ IInt i
+  VWord16 w -> pure $ IWord16 w
+  VWord32 w -> pure $ IWord32 w
+  VWord64 w -> pure $ IWord64 w
   VDouble d -> pure $ IDouble d
   VEpochTime t -> pure $ ITime t
-  VTuple [x, y] -> curry ITuple <$> toIValue x <*> toIValue y
   VEmpty -> pure IEmpty
+  VTuple [x, y] -> curry ITuple <$> toIValue x <*> toIValue y
   VArray vs -> IArray . Vector.fromList <$> traverse toIValue vs
   _ -> throwM $ RuntimeError "toIValue: got an unsupported value type"
 

--- a/inferno-ml/CHANGELOG.md
+++ b/inferno-ml/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Revision History for inferno-ml
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.7.0.2 -- 2025-05-01
+* Add `unsqueeze`
+
 ## 0.7.0.1 -- 2025-04-08
 * Catch C++ exceptions in `forward` primitive
 

--- a/inferno-ml/inferno-ml.cabal
+++ b/inferno-ml/inferno-ml.cabal
@@ -1,6 +1,6 @@
 cabal-version:      >=1.10
 name:               inferno-ml
-version:            0.7.0.1
+version:            0.7.0.2
 synopsis:           Machine Learning primitives for Inferno
 description:        Machine Learning primitives for Inferno
 homepage:           https://github.com/plow-technologies/inferno.git#readme

--- a/inferno-ml/src/Inferno/ML/Module/Prelude.hs
+++ b/inferno-ml/src/Inferno/ML/Module/Prelude.hs
@@ -156,6 +156,9 @@ tanHTFun = Torch.Functional.tanh
 powTFun :: Int -> Tensor -> Tensor
 powTFun = pow
 
+unsqueezeFun :: Int -> Tensor -> Tensor
+unsqueezeFun = Torch.Functional.unsqueeze . Dim
+
 unsafeLoadScriptFun :: Text -> ScriptModule
 unsafeLoadScriptFun f = unsafePerformIO $ TS.loadScript TS.WithoutRequiredGrad $ unpack f
 
@@ -334,6 +337,8 @@ module ML
   matmul : tensor -> tensor -> tensor := ###matmul###;
 
   mseLoss : tensor -> tensor -> tensor := ###mseLoss###;
+
+  unsqueeze : int -> tensor -> tensor := ###unsqueezeFun###;
 
   @doc An impure (pseudo)random tensor generator;
   randnIO : dtype{#int, #float, #double} -> array of int -> tensor := ###!randnIOFun###;


### PR DESCRIPTION
- Makes `Writes` stream take any `IValue` (previously it was restricted to doubles only)
- Expands `IValue` to take more Inferno `Value` types (required for full range of possible writes)
- Changes Aeson instances accordingly (not as compact as before, but that's unavoidable)
- Adds `unsqueeze` primitive (tiny change so included it here)