### PR TITLE
[inferno-ml] Some SQL and error cleanup

### DIFF
--- a/inferno-ml-server-types/CHANGELOG.md
+++ b/inferno-ml-server-types/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Revision History for inferno-ml-server-types
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.19.0
+* Breaking changes:
+  - Rename `VCObjectHashRow` to `VCObjectHashField` and change its DB (de)serialization
+  - Add script hash to server's `InfernoError`
+
 ## 0.18.0
 * Breaking changes:
   - Make `Writes` polymorphic

--- a/inferno-ml-server-types/inferno-ml-server-types.cabal
+++ b/inferno-ml-server-types/inferno-ml-server-types.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          inferno-ml-server-types
-version:       0.18.0
+version:       0.19.0
 synopsis:      Types for Inferno ML server
 description:   Types for Inferno ML server
 homepage:      https://github.com/plow-technologies/inferno.git#readme

--- a/inferno-ml-server-types/inferno-ml-server-types.cabal
+++ b/inferno-ml-server-types/inferno-ml-server-types.cabal
@@ -42,9 +42,11 @@ library
     , aeson
     , attoparsec
     , base
+    , base64-bytestring
     , bytestring
     , conduit
     , containers
+    , cryptonite
     , deepseq
     , generic-lens
     , hashable

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
@@ -1018,7 +1018,7 @@ data RemoteError p m mv
   | InvalidScript (Id p) Text
   | InvalidOutput (Id p) Text
   | -- | Any error condition returned by Inferno script evaluation
-    InfernoError (Id p) SomeInfernoError
+    InfernoError (Id p) VCObjectHash SomeInfernoError
   | NoBridgeSaved (Id p)
   | ScriptTimeout (Id p) Int
   | DbError String
@@ -1068,10 +1068,12 @@ instance (Typeable p, Typeable m, Typeable mv) => Exception (RemoteError p m mv)
         , "script output should be an array of `write` but was"
         , Text.unpack t
         ]
-    InfernoError ipid (SomeInfernoError x) ->
+    InfernoError ipid vch (SomeInfernoError x) ->
       unwords
-        [ "Inferno evaluation failed when evaluating"
+        [ "Parameter"
         , show ipid
+        , "failed to evaluate script"
+        , show vch
         , "with:"
         , x
         ]

--- a/inferno-ml-server/CHANGELOG.md
+++ b/inferno-ml-server/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Revision History for `inferno-ml-server`
 
+## 2025.5.21
+* Add script hash to server's `InfernoError`
+
 ## 2025.5.15
 * Add `Print` module with new logging primitives
 

--- a/inferno-ml-server/inferno-ml-server.cabal
+++ b/inferno-ml-server/inferno-ml-server.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               inferno-ml-server
-version:            2025.4.23
+version:            2025.5.21
 synopsis:           Server for Inferno ML
 description:        Server for Inferno ML
 homepage:           https://github.com/plow-technologies/inferno.git#readme

--- a/inferno-ml-server/src/Inferno/ML/Server/Inference.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Inference.hs
@@ -308,7 +308,7 @@ runInferenceParamWithEnv ipid uuid senv =
                     dummy :: ImplExpl
                     dummy = Expl . ExtIdent $ Right "dummy"
 
-              either (throwInfernoError ipid) yieldPairs
+              either (throwInfernoError ipid senv.script) yieldPairs
                 =<< flip (`evalExpr` implEnv) expr
                 =<< runImplEnvM mempty (mkEnvFromClosure localEnv closure)
               where

--- a/inferno-ml-server/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Types.hs
@@ -418,10 +418,10 @@ type EvaluationEnv = Types.EvaluationEnv (EntityId GId) PID
 -- Orphans
 
 instance FromField VCObjectHash where
-  fromField f mb = wrappedTo <$> fromField @VCObjectHashRow f mb
+  fromField f mb = wrappedTo <$> fromField @VCObjectHashField f mb
 
 instance ToField VCObjectHash where
-  toField = toField . VCObjectHashRow
+  toField = toField . VCObjectHashField
 
 deriving newtype instance ToHttpApiData EpochTime
 

--- a/inferno-ml-server/src/Inferno/ML/Server/Utils.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Utils.hs
@@ -32,6 +32,7 @@ import Database.PostgreSQL.Simple
   )
 import Database.PostgreSQL.Simple.Vector (query)
 import Inferno.ML.Server.Types
+import Inferno.VersionControl.Types (VCObjectHash)
 import Lens.Micro.Platform (view)
 import UnliftIO (MonadUnliftIO (withRunInIO))
 import UnliftIO.Exception (catch, displayException)
@@ -39,8 +40,9 @@ import UnliftIO.Exception (catch, displayException)
 throwRemoteError :: RemoteError -> RemoteM a
 throwRemoteError = throwM
 
-throwInfernoError :: (Exception e) => Id InferenceParam -> e -> RemoteM a
-throwInfernoError ipid = throwRemoteError . InfernoError ipid . SomeInfernoError . show
+throwInfernoError :: (Exception e) => Id InferenceParam -> VCObjectHash -> e -> RemoteM a
+throwInfernoError ipid vch =
+  throwRemoteError . InfernoError ipid vch . SomeInfernoError . show
 
 catchDb :: (MonadThrow m, MonadCatch m, MonadUnliftIO m) => m a -> m a
 catchDb f = catch @_ @SqlError f $ (throwM @_ @RemoteError) . DbError . displayException

--- a/nix/inferno-ml/migrations/v1-create-tables.sql
+++ b/nix/inferno-ml/migrations/v1-create-tables.sql
@@ -20,8 +20,8 @@ create table if not exists models
   ( id uuid primary key default gen_random_uuid()
   , name text not null
   , gid numeric not null
-  , visibility jsonb
-  , created timestamptz default now()
+  , visibility jsonb not null
+  , created timestamptz not null default now()
     -- May be missing, if there is no model version yet
   , updated timestamptz
     -- See note above
@@ -47,7 +47,7 @@ create table if not exists mversions
     -- this once and store it here
   , size bigint not null
   , version text not null
-  , created timestamptz default now()
+  , created timestamptz not null default now()
     -- See note above
   , terminated timestamptz
   , unique (version, model)

--- a/nix/inferno-ml/migrations/v1-create-tables.sql
+++ b/nix/inferno-ml/migrations/v1-create-tables.sql
@@ -64,11 +64,13 @@ create table if not exists scripts
 -- Model versions linked to specific Inferno scripts (i.e. junction table
 -- between `scripts` and `mversions`)
 create table if not exists mselections
-  ( script bytea primary key references scripts (id)
+  ( script bytea not null references scripts (id)
   , model uuid not null references mversions (id)
     -- Inferno identifier linked to this specific model version
   , ident text not null
-  , unique (script, model)
+    -- The script and model combination must be unique, so can be used as
+    -- a composite primary key
+  , primary key (script, model)
   );
 
 create table if not exists params

--- a/nix/inferno-ml/migrations/v1-create-tables.sql
+++ b/nix/inferno-ml/migrations/v1-create-tables.sql
@@ -64,7 +64,7 @@ create table if not exists scripts
 -- Model versions linked to specific Inferno scripts (i.e. junction table
 -- between `scripts` and `mversions`)
 create table if not exists mselections
-  ( script bytea not null references scripts (id)
+  ( script bytea primary key references scripts (id)
   , model uuid not null references mversions (id)
     -- Inferno identifier linked to this specific model version
   , ident text not null
@@ -89,7 +89,9 @@ create table if not exists params
 
 -- Execution info for inference evaluation
 create table if not exists evalinfo
-  ( id uuid primary key
+  ( -- Note that it is required to provide the ID when creating a new row,
+    -- hence no default
+    id uuid primary key
   , param uuid not null references params (id)
     -- When inference evaluation began
   , started timestamptz not null
@@ -104,7 +106,7 @@ create table if not exists evalinfo
 create table if not exists consoles
   ( -- Each "console" belongs to the same evaluation job as the `evalinfo`
     -- table, so it can use the same ID
-    id uuid not null references evalinfo (id)
+    id uuid primary key references evalinfo (id)
     -- Each line of "console" output
   , prints text[] not null
   );
@@ -112,7 +114,7 @@ create table if not exists consoles
 -- Stores information required to call the data bridge
 create table if not exists bridges
   ( -- Same ID as the referenced param
-    id uuid not null references params (id)
+    id uuid primary key references params (id)
     -- Host of the bridge server
   , ip inet not null
   , port integer check (port > 0)


### PR DESCRIPTION
Just a bit of cleanup, mostly SQL things. Some tables had foreign keys that could also serve as primary keys, and I made the primary key of `scripts` more reasonable/idiomatic (along with necessary changes on the Haskell side).

Also adds the script hash to the server's `InfernoError`.