### PR TITLE
[inferno-ml] Add `inferno-ml-compat` to generate `ML` module

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -5,6 +5,7 @@ packages:
   ./inferno-types
   ./inferno-lsp
   ./inferno-vc
+  ./inferno-ml-compat
   ./inferno-ml
   ./inferno-ml-server-types
   ./inferno-ml-server

--- a/inferno-ml-compat/CHANGELOG.md
+++ b/inferno-ml-compat/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Revision History for inferno-ml-compat
+*Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
+
+## 0.0.1
+* Initial version

--- a/inferno-ml-compat/hie.yaml
+++ b/inferno-ml-compat/hie.yaml
@@ -1,0 +1,2 @@
+cradle:
+  cabal:

--- a/inferno-ml-compat/inferno-ml-compat.cabal
+++ b/inferno-ml-compat/inferno-ml-compat.cabal
@@ -22,19 +22,15 @@ library
     Inferno.ML.Types.Value.Compat
 
   hs-source-dirs:     src
-  -- TODO -Werror
   ghc-options:
-    -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
+    -Wall -Werror -Wincomplete-uni-patterns -Wincomplete-record-updates
     -Wunused-packages
 
   build-depends:
       base
-    , containers
     , exceptions
-    , extra
     , inferno-core
     , inferno-types
-    , inline-c-cpp
     , prettyprinter
     , template-haskell
     , text

--- a/inferno-ml-compat/inferno-ml-compat.cabal
+++ b/inferno-ml-compat/inferno-ml-compat.cabal
@@ -18,8 +18,8 @@ source-repository head
 
 library
   exposed-modules:
-    Inferno.ML.Compat.Module.Prelude
-    Inferno.ML.Compat.Types.Value
+    Inferno.ML.Module.Compat
+    Inferno.ML.Types.Value.Compat
 
   hs-source-dirs:     src
   -- TODO -Werror

--- a/inferno-ml-compat/inferno-ml-compat.cabal
+++ b/inferno-ml-compat/inferno-ml-compat.cabal
@@ -1,0 +1,51 @@
+cabal-version:      >=1.10
+name:               inferno-ml-compat
+version:            0.0.1
+synopsis:           Compat types for Inferno ML
+description:        Compat types for Inferno ML
+homepage:           https://github.com/plow-technologies/inferno.git#readme
+bug-reports:        https://github.com/plow-technologies/inferno.git/issues
+copyright:          Plow-Technologies LLC
+license:            MIT
+author:             Rory Tyler Hayford
+maintainer:         rory.hayford@plowtech.net
+build-type:         Simple
+extra-source-files: CHANGELOG.md
+
+source-repository head
+  type:     git
+  location: https://github.com/plow-technologies/inferno.git
+
+library
+  exposed-modules:
+    Inferno.ML.Compat.Module.Prelude
+    Inferno.ML.Compat.Types.Value
+
+  hs-source-dirs:     src
+  -- TODO -Werror
+  ghc-options:
+    -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
+    -Wunused-packages
+
+  build-depends:
+      base
+    , containers
+    , exceptions
+    , extra
+    , inferno-core
+    , inferno-types
+    , inline-c-cpp
+    , prettyprinter
+    , template-haskell
+    , text
+
+  default-language:   Haskell2010
+  default-extensions:
+    DerivingStrategies
+    FlexibleContexts
+    FlexibleInstances
+    LambdaCase
+    MultiParamTypeClasses
+    OverloadedStrings
+    TupleSections
+    TypeApplications

--- a/inferno-ml-compat/src/Inferno/ML/Compat/Module/Prelude.hs
+++ b/inferno-ml-compat/src/Inferno/ML/Compat/Module/Prelude.hs
@@ -1,4 +1,142 @@
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# OPTIONS_GHC -Wwarn #-}
+{-# LANGUAGE NoFieldSelectors #-}
 
 module Inferno.ML.Compat.Module.Prelude where
+
+import Data.Text (Text)
+import Inferno.ML.Compat.Types.Value (MlValue)
+import Inferno.Types.Value (ImplEnvM, Value)
+import Prelude hiding (tanh)
+
+-- | Record-of-functions to generate the ML prelude, given implementations of
+-- each primitive within the sub-records. This is broken up into smaller internal
+-- records to avoid a huge single one
+data MkModule m tensor model mname x = MkModule
+  { models :: MkModelFuns m tensor model mname x
+  , devices :: MkDeviceFuns m tensor model mname x
+  , factories :: MkFactoryFuns m tensor model mname x
+  , conversions :: MkConversionFuns m tensor model mname x
+  , functional :: MkFunctionalFuns tensor
+  }
+
+-- | Primitives related to models (Torchscript modules)
+--
+-- NOTE: For documentation of each primitive, see the Inferno module
+data MkModelFuns m tensor model mname x = MkModelFuns
+  { loadModel :: Value (MlValue tensor model mname x) m
+  , unsafeLoadScript :: Text -> model
+  }
+
+{- HLINT ignore "Use newtype instead of data" -}
+
+-- | Device-related primitives, e.g. moving tensors
+--
+-- NOTE: For documentation of each primitive, see the Inferno module
+data MkDeviceFuns m tensor model mname x = MkDeviceFuns
+  { toDevice ::
+      Value
+        (MlValue tensor model mname x)
+        (ImplEnvM m (MlValue tensor model mname x))
+  -- ^ @toDevice@ is effectful, i.e. requires catching IO exceptions, so
+  -- needs to be lifted into @ImplEnvM@
+  }
+
+-- | Tensor factory primitives
+--
+-- NOTE: For documentation of each primitive, see the Inferno module
+data MkFactoryFuns m tensor model mname x = MkFactoryFuns
+  { zeros :: Value (MlValue tensor model mname x) m
+  , ones :: Value (MlValue tensor model mname x) m
+  , randnIO :: Value (MlValue tensor model mname x) m
+  }
+
+-- | Primitives to convert to and from tensors
+--
+-- NOTE: For documentation of each primitive, see the Inferno module
+data MkConversionFuns m tensor model mname x = MkConversionFuns
+  { asTensor0 :: Value (MlValue tensor model mname x) m
+  , asTensor1 :: Value (MlValue tensor model mname x) m
+  , asTensor2 :: Value (MlValue tensor model mname x) m
+  , asTensor3 :: Value (MlValue tensor model mname x) m
+  , asTensor4 :: Value (MlValue tensor model mname x) m
+  , asDouble :: tensor -> Double
+  , asArray1 :: tensor -> [Double]
+  , asArray2 :: tensor -> [[Double]]
+  , asArray3 :: tensor -> [[[Double]]]
+  , asArray4 :: tensor -> [[[[Double]]]]
+  }
+
+-- | Tensor operation primitives, corresponding to those in @Torch.Functional@
+--
+-- NOTE: For documentation of each primitive, see the Inferno module
+--
+-- TODO: Add a lot more, re-rexport most of @Torch.Functional@. Will probably
+-- need to split this into several sub-records though to avoid massive size
+data MkFunctionalFuns tensor = MkFunctionalFuns
+  { argmax :: Int -> Bool -> tensor -> tensor
+  , softmax :: Int -> tensor -> tensor
+  , stack :: Int -> [tensor] -> tensor
+  , tanh :: tensor -> tensor
+  , pow :: Int -> tensor -> tensor
+  , unsqueeze :: Int -> tensor -> tensor
+  , add :: tensor -> tensor -> tensor
+  , sumAll :: tensor -> tensor
+  , transpose2D :: tensor -> tensor
+  , matMul :: tensor -> tensor -> tensor
+  , mseLoss :: tensor -> tensor -> tensor
+  }
+
+-- | Given concrete types, this will create a 'MkPrelude' that is suitable for
+-- type-checking purposes, but which will throw an error if evaluated. This is
+-- useful when creating a prelude that does not depend directly on Hasktorch
+--
+-- See the @inferno-ml@ package\'s prelude for a true implementation
+mkUnboundPrelude :: MkModule m tensor model mname x
+mkUnboundPrelude =
+  MkModule
+    { models =
+        MkModelFuns
+          { loadModel = undefined
+          , unsafeLoadScript = undefined
+          }
+    , devices =
+        MkDeviceFuns
+          { toDevice = undefined
+          }
+    , factories =
+        MkFactoryFuns
+          { zeros = unbound
+          , ones = unbound
+          , randnIO = unbound
+          }
+    , conversions =
+        MkConversionFuns
+          { asTensor0 = unbound
+          , asTensor1 = unbound
+          , asTensor2 = unbound
+          , asTensor3 = unbound
+          , asTensor4 = unbound
+          , asDouble = unbound
+          , asArray1 = unbound
+          , asArray2 = unbound
+          , asArray3 = unbound
+          , asArray4 = unbound
+          }
+    , functional =
+        MkFunctionalFuns
+          { argmax = unbound
+          , softmax = unbound
+          , stack = unbound
+          , tanh = unbound
+          , pow = unbound
+          , unsqueeze = unbound
+          , add = unbound
+          , sumAll = unbound
+          , transpose2D = unbound
+          , matMul = unbound
+          , mseLoss = unbound
+          }
+    }
+  where
+    unbound :: a
+    unbound = error "Primitive is unbound"

--- a/inferno-ml-compat/src/Inferno/ML/Compat/Module/Prelude.hs
+++ b/inferno-ml-compat/src/Inferno/ML/Compat/Module/Prelude.hs
@@ -1,0 +1,4 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_GHC -Wwarn #-}
+
+module Inferno.ML.Compat.Module.Prelude where

--- a/inferno-ml-compat/src/Inferno/ML/Compat/Types/Value.hs
+++ b/inferno-ml-compat/src/Inferno/ML/Compat/Types/Value.hs
@@ -1,0 +1,124 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+
+module Inferno.ML.Compat.Types.Value where
+
+import Data.Data (Typeable)
+import qualified Data.Text as Text
+import Inferno.Module.Cast
+  ( FromValue (fromValue),
+    ToValue (toValue),
+    couldNotCast,
+  )
+import Inferno.Types.Syntax (CustomType)
+import Inferno.Types.Value (Value (VCustom))
+import Inferno.Utils.QQ.Module (moduleQuoter)
+import Language.Haskell.TH.Quote (QuasiQuoter)
+import Prettyprinter (Pretty (pretty), align)
+
+-- | Compatibility type for Inferno ML projects. This is intended to avoid
+-- forcing a dependency on the @hasktorch@ package. For example, dummy types
+-- can be provided (given correct class implementations) for tensors, models,
+-- etc... for type-checking purposes purely
+data MlValue tensor model mname x
+  = VTensor tensor
+  | VModel model
+  | VModelName mname
+  | VExtended x
+
+instance
+  ( Eq x
+  , Eq tensor
+  , Eq mname
+  ) =>
+  Eq (MlValue tensor model mname x)
+  where
+  VTensor t1 == VTensor t2 = t1 == t2
+  VModelName n1 == VModelName n2 = n1 == n2
+  VExtended x == VExtended y = x == y
+  _ == _ = False
+
+instance
+  ( Pretty x
+  , Show tensor
+  , Show model
+  , Pretty mname
+  ) =>
+  Pretty (MlValue tensor model mname x)
+  where
+  pretty = \case
+    VTensor t -> align . pretty . Text.pack $ show t
+    VModel m -> align . pretty . Text.pack $ show m
+    VModelName x -> align $ pretty x
+    VExtended x -> align $ pretty x
+
+instance ToValue (MlValue tensor model mname x) m tensor where
+  toValue = VCustom . VTensor
+
+instance
+  ( Show tensor
+  , Show model
+  , Show mname
+  , Pretty tensor
+  , Pretty model
+  , Pretty mname
+  , Pretty x
+  , Typeable tensor
+  ) =>
+  FromValue (MlValue tensor model mname x) m tensor
+  where
+  fromValue = \case
+    VCustom (VTensor t) -> pure t
+    v -> couldNotCast v
+
+instance ToValue (MlValue tensor model mname x) m model where
+  toValue = VCustom . VModel
+
+instance
+  ( Show tensor
+  , Show model
+  , Show mname
+  , Pretty tensor
+  , Pretty model
+  , Pretty mname
+  , Pretty x
+  , Typeable model
+  ) =>
+  FromValue (MlValue tensor model mname x) m model
+  where
+  fromValue = \case
+    VCustom (VModel m) -> pure m
+    v -> couldNotCast v
+
+instance ToValue (MlValue tensor model mname x) m mname where
+  toValue = VCustom . VModelName
+
+instance
+  ( Show tensor
+  , Show model
+  , Show mname
+  , Pretty tensor
+  , Pretty model
+  , Pretty mname
+  , Pretty x
+  , Typeable mname
+  ) =>
+  FromValue (MlValue tensor model mname x) m mname
+  where
+  fromValue = \case
+    VCustom (VModelName n) -> pure n
+    v -> couldNotCast v
+
+customTypes :: [CustomType]
+customTypes =
+  [ "tensor"
+  , -- NOTE It seems that `modelName` needs to come before `model`,
+    -- otherwise Inferno's parser fails??
+    "modelName"
+  , "model"
+  , "write"
+  ]
+
+mlQuoter :: QuasiQuoter
+mlQuoter = moduleQuoter customTypes

--- a/inferno-ml-compat/src/Inferno/ML/Module/Compat.hs
+++ b/inferno-ml-compat/src/Inferno/ML/Module/Compat.hs
@@ -1,6 +1,7 @@
-{-# LANGUAGE DisambiguateRecordFields #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE NoFieldSelectors #-}
 
@@ -8,59 +9,62 @@ module Inferno.ML.Module.Compat where
 
 import Control.Monad.Catch (MonadThrow)
 import Control.Monad.IO.Class (MonadIO)
+import Data.Data (Typeable)
 import Data.Text (Text)
+import GHC.Generics
 import Inferno.ML.Types.Value.Compat (MlValue, mlQuoter)
+import Inferno.Module.Cast (FromValue (..), ToValue (..))
 import Inferno.Module.Prelude (ModuleMap)
 import Inferno.Types.Value (ImplEnvM, Value)
 import Prettyprinter (Pretty)
+import Prelude hiding (tanh)
 
 -- | Record-of-functions to generate the ML prelude, given implementations of
 -- each primitive within the sub-records. This is broken up into smaller internal
 -- records to avoid a huge single one
-data MkModule m tensor model mname x = MkModule
+data MkMlModule m tensor model mname x = MkMlModule
   { models :: MkModelFuns m tensor model mname x
   , devices :: MkDeviceFuns m tensor model mname x
   , factories :: MkFactoryFuns m tensor model mname x
   , conversions :: MkConversionFuns m tensor model mname x
   , functional :: MkFunctionalFuns tensor
   }
+  deriving (Generic)
 
 -- | Primitives related to models (Torchscript modules)
 --
--- NOTE: For documentation of each primitive, see the Inferno module
+-- NOTE: For Inferno primitive documentation, see the Inferno module
 data MkModelFuns m tensor model mname x = MkModelFuns
   { loadModel :: Value (MlValue tensor model mname x) m
+  , forward :: Value (MlValue tensor model mname x) m
   , unsafeLoadScript :: Text -> model
   }
 
-{- HLINT ignore "Use newtype instead of data" -}
-
 -- | Device-related primitives, e.g. moving tensors
 --
--- NOTE: For documentation of each primitive, see the Inferno module
+-- NOTE: For Inferno primitive documentation, see the Inferno module
 data MkDeviceFuns m tensor model mname x = MkDeviceFuns
-  { toDevice ::
-      Value
-        (MlValue tensor model mname x)
-        (ImplEnvM m (MlValue tensor model mname x))
-  -- ^ @toDevice@ is effectful, i.e. requires catching IO exceptions, so
-  -- needs to be lifted into @ImplEnvM@
+  { toDevice :: Value (MlValue tensor model mname x) m
+  , toDeviceUnsafe :: Value (MlValue tensor model mname x) m
   }
+  deriving (Generic)
 
 -- | Tensor factory primitives
 --
--- NOTE: For documentation of each primitive, see the Inferno module
+-- NOTE: For Inferno primitive documentation, see the Inferno module
 data MkFactoryFuns m tensor model mname x = MkFactoryFuns
   { zeros :: Value (MlValue tensor model mname x) m
   , ones :: Value (MlValue tensor model mname x) m
   , randnIO :: Value (MlValue tensor model mname x) m
   }
+  deriving (Generic)
 
 -- | Primitives to convert to and from tensors
 --
--- NOTE: For documentation of each primitive, see the Inferno module
+-- NOTE: For Inferno primitive documentation, see the Inferno module
 data MkConversionFuns m tensor model mname x = MkConversionFuns
-  { asTensor0 :: Value (MlValue tensor model mname x) m
+  { toType :: Value (MlValue tensor model mname x) m
+  , asTensor0 :: Value (MlValue tensor model mname x) m
   , asTensor1 :: Value (MlValue tensor model mname x) m
   , asTensor2 :: Value (MlValue tensor model mname x) m
   , asTensor3 :: Value (MlValue tensor model mname x) m
@@ -71,10 +75,11 @@ data MkConversionFuns m tensor model mname x = MkConversionFuns
   , asArray3 :: tensor -> [[[Double]]]
   , asArray4 :: tensor -> [[[[Double]]]]
   }
+  deriving (Generic)
 
 -- | Tensor operation primitives, corresponding to those in @Torch.Functional@
 --
--- NOTE: For documentation of each primitive, see the Inferno module
+-- NOTE: For Inferno primitive documentation, see the Inferno module
 --
 -- TODO: Add a lot more, re-rexport most of @Torch.Functional@. Will probably
 -- need to split this into several sub-records though to avoid massive size
@@ -88,14 +93,16 @@ data MkFunctionalFuns tensor = MkFunctionalFuns
   , add :: tensor -> tensor -> tensor
   , sumAll :: tensor -> tensor
   , transpose2D :: tensor -> tensor
-  , matMul :: tensor -> tensor -> tensor
+  , matmul :: tensor -> tensor -> tensor
   , mseLoss :: tensor -> tensor -> tensor
   }
+  deriving (Generic)
 
 mkMlModule ::
   forall m tensor model mname x.
   ( MonadThrow m
   , MonadIO m
+  , Typeable tensor
   , Show tensor
   , Show model
   , Show mname
@@ -103,10 +110,35 @@ mkMlModule ::
   , Pretty model
   , Pretty mname
   , Pretty x
+  , Pretty (MlValue tensor model mname x)
+  , FromValue
+      (MlValue tensor model mname x)
+      (ImplEnvM m (MlValue tensor model mname x))
+      tensor
+  , FromValue
+      (MlValue tensor model mname x)
+      (ImplEnvM m (MlValue tensor model mname x))
+      model
+  , FromValue
+      (MlValue tensor model mname x)
+      (ImplEnvM m (MlValue tensor model mname x))
+      mname
+  , ToValue
+      (MlValue tensor model mname x)
+      (ImplEnvM m (MlValue tensor model mname x))
+      tensor
+  , ToValue
+      (MlValue tensor model mname x)
+      (ImplEnvM m (MlValue tensor model mname x))
+      model
+  , ToValue
+      (MlValue tensor model mname x)
+      (ImplEnvM m (MlValue tensor model mname x))
+      mname
   ) =>
-  MkModule m tensor model mname x ->
+  MkMlModule (ImplEnvM m (MlValue tensor model mname x)) tensor model mname x ->
   ModuleMap m (MlValue tensor model mname x)
-mkMlModule _mk =
+mkMlModule mk =
   [mlQuoter|
 
 module ML
@@ -115,24 +147,100 @@ module ML
 
   enum device := #cpu | #cuda;
 
+  zeros : dtype{#int, #float, #double} -> array of int -> tensor := ###!zeros###;
+
+  ones : dtype{#int, #float, #double} -> array of int -> tensor := ###!ones###;
+
+  add : tensor -> tensor -> tensor := ###add###;
+
+  toType : dtype{#int, #float, #double} -> tensor -> tensor := ###!toType###;
+
+  asTensor0 : dtype{#int, #float, #double} -> double -> tensor := ###!asTensor0###;
+
+  asTensor1 : dtype{#int, #float, #double} -> array of double -> tensor := ###!asTensor1###;
+
+  asTensor2 : dtype{#int, #float, #double} -> array of (array of double) -> tensor := ###!asTensor2###;
+
+  asTensor3 : dtype{#int, #float, #double} -> array of (array of (array of double)) -> tensor := ###!asTensor3###;
+
+  asTensor4 : dtype{#int, #float, #double} -> array of (array of (array of (array of double))) -> tensor := ###!asTensor4###;
+
+  asDouble : tensor -> double := ###asDouble###;
+
+  asArray1 : tensor -> array of double := ###asArray1###;
+
+  asArray2 : tensor -> array of (array of double) := ###asArray2###;
+
+  asArray3 : tensor -> array of (array of (array of double)) := ###asArray3###;
+
+  asArray4 : tensor -> array of (array of (array of (array of double))) := ###asArray4###;
+
+  sumAll : tensor -> tensor := ###sumAll###;
+
+  powT : int -> tensor -> tensor := ###pow###;
+
+  tanH : tensor -> tensor := ###tanh###;
+
+  @doc `argmax i k t` is the argmax of tensor `t` along dimension `i`. `k` denotes whether the output tensor has dim retained or not.;
+  argmax : int -> bool{#true, #false} -> tensor -> tensor := ###argmax###;
+
+  softmax : int -> tensor -> tensor := ###softmax###;
+
+  @doc `stack i [t]` takes an array of tensors `t` and appends them along the dimension i in a new tensor;
+  stack : int -> array of tensor -> tensor := ###stack###;
+
+  transpose2D : tensor -> tensor := ###transpose2D###;
+
+  matmul : tensor -> tensor -> tensor := ###matmul###;
+
+  mseLoss : tensor -> tensor -> tensor := ###mseLoss###;
+
+  unsqueeze : int -> tensor -> tensor := ###unsqueeze###;
+
+  @doc An impure (pseudo)random tensor generator;
+  randnIO : dtype{#int, #float, #double} -> array of int -> tensor := ###!randnIO###;
+
+  @doc Move a tensor to a different device;
+  toDevice : device{#cpu, #cuda} -> tensor -> tensor := ###!toDevice###;
+
+  @doc Move a tensor to a different device, e.g. "cpu" or "cuda:0" (without checking validity of device name);
+  toDeviceUnsafe : text -> tensor -> tensor := ###toDeviceUnsafe###;
+
+  @doc Load a named, serialized model;
+  loadModel : modelName -> model := ###!loadModel###;
+
+  unsafeLoadScript : text -> model := ###unsafeLoadScript###;
+
+  forward : model -> array of tensor -> array of tensor := ###!forward###;
+
 |]
+  where
+    -- Unfortunately the Inferno QQ parser can't handle overloaded record dots,
+    -- so the next best thing is to just use wildcards scoped to this function
+    MkModelFuns{..} = mk.models
+    MkDeviceFuns{..} = mk.devices
+    MkFactoryFuns{..} = mk.factories
+    MkConversionFuns{..} = mk.conversions
+    MkFunctionalFuns{..} = mk.functional
 
 -- | Given concrete types, this will create a 'MkPrelude' that is suitable for
 -- type-checking purposes, but which will throw an error if evaluated. This is
 -- useful when creating a prelude that does not depend directly on Hasktorch
 --
 -- See the @inferno-ml@ package\'s prelude for a true implementation
-mkUnboundPrelude :: MkModule m tensor model mname x
+mkUnboundPrelude :: MkMlModule m tensor model mname x
 mkUnboundPrelude =
-  MkModule
+  MkMlModule
     { models =
         MkModelFuns
           { loadModel = unbound
+          , forward = unbound
           , unsafeLoadScript = unbound
           }
     , devices =
         MkDeviceFuns
           { toDevice = unbound
+          , toDeviceUnsafe = unbound
           }
     , factories =
         MkFactoryFuns
@@ -142,7 +250,8 @@ mkUnboundPrelude =
           }
     , conversions =
         MkConversionFuns
-          { asTensor0 = unbound
+          { toType = unbound
+          , asTensor0 = unbound
           , asTensor1 = unbound
           , asTensor2 = unbound
           , asTensor3 = unbound
@@ -164,7 +273,7 @@ mkUnboundPrelude =
           , add = unbound
           , sumAll = unbound
           , transpose2D = unbound
-          , matMul = unbound
+          , matmul = unbound
           , mseLoss = unbound
           }
     }

--- a/inferno-ml-compat/src/Inferno/ML/Module/Compat.hs
+++ b/inferno-ml-compat/src/Inferno/ML/Module/Compat.hs
@@ -39,6 +39,7 @@ data MkModelFuns m tensor model mname x = MkModelFuns
   , forward :: Value (MlValue tensor model mname x) m
   , unsafeLoadScript :: Text -> model
   }
+  deriving (Generic)
 
 -- | Device-related primitives, e.g. moving tensors
 --

--- a/inferno-ml-compat/src/Inferno/ML/Module/Compat.hs
+++ b/inferno-ml-compat/src/Inferno/ML/Module/Compat.hs
@@ -226,8 +226,8 @@ module ML
 -- useful when creating a prelude that does not depend directly on Hasktorch
 --
 -- See the @inferno-ml@ package\'s prelude for a true implementation
-mkUnboundPrelude :: MkMlModule m tensor model mname x
-mkUnboundPrelude =
+mkUnboundModule :: MkMlModule m tensor model mname x
+mkUnboundModule =
   MkMlModule
     { models =
         MkModelFuns

--- a/inferno-ml-compat/src/Inferno/ML/Module/Compat.hs
+++ b/inferno-ml-compat/src/Inferno/ML/Module/Compat.hs
@@ -45,7 +45,7 @@ data MkModelFuns m tensor model mname x = MkModelFuns
 -- NOTE: For Inferno primitive documentation, see the Inferno module
 data MkDeviceFuns m tensor model mname x = MkDeviceFuns
   { toDevice :: Value (MlValue tensor model mname x) m
-  , toDeviceUnsafe :: Value (MlValue tensor model mname x) m
+  , toDeviceUnsafe :: Text -> tensor -> tensor
   }
   deriving (Generic)
 
@@ -106,9 +106,6 @@ mkMlModule ::
   , Show tensor
   , Show model
   , Show mname
-  , Pretty tensor
-  , Pretty model
-  , Pretty mname
   , Pretty x
   , Pretty (MlValue tensor model mname x)
   , FromValue

--- a/inferno-ml-compat/src/Inferno/ML/Types/Value/Compat.hs
+++ b/inferno-ml-compat/src/Inferno/ML/Types/Value/Compat.hs
@@ -4,18 +4,9 @@
 
 module Inferno.ML.Types.Value.Compat where
 
-import Data.Data (Typeable)
-import qualified Data.Text as Text
-import Inferno.Module.Cast
-  ( FromValue (fromValue),
-    ToValue (toValue),
-    couldNotCast,
-  )
 import Inferno.Types.Syntax (CustomType)
-import Inferno.Types.Value (Value (VCustom))
 import Inferno.Utils.QQ.Module (moduleQuoter)
 import Language.Haskell.TH.Quote (QuasiQuoter)
-import Prettyprinter (Pretty (pretty), align)
 
 -- | Compatibility type for Inferno ML projects. This is intended to avoid
 -- forcing a dependency on the @hasktorch@ package. For example, dummy types
@@ -26,89 +17,6 @@ data MlValue tensor model mname x
   | VModel model
   | VModelName mname
   | VExtended x
-
-instance
-  ( Eq x
-  , Eq tensor
-  , Eq mname
-  ) =>
-  Eq (MlValue tensor model mname x)
-  where
-  VTensor t1 == VTensor t2 = t1 == t2
-  VModelName n1 == VModelName n2 = n1 == n2
-  VExtended x == VExtended y = x == y
-  _ == _ = False
-
-instance
-  ( Pretty x
-  , Show tensor
-  , Show model
-  , Pretty mname
-  ) =>
-  Pretty (MlValue tensor model mname x)
-  where
-  pretty = \case
-    VTensor t -> align . pretty . Text.pack $ show t
-    VModel m -> align . pretty . Text.pack $ show m
-    VModelName x -> align $ pretty x
-    VExtended x -> align $ pretty x
-
-instance ToValue (MlValue tensor model mname x) m tensor where
-  toValue = VCustom . VTensor
-
-instance
-  ( Show tensor
-  , Show model
-  , Show mname
-  , Pretty tensor
-  , Pretty model
-  , Pretty mname
-  , Pretty x
-  , Typeable tensor
-  ) =>
-  FromValue (MlValue tensor model mname x) m tensor
-  where
-  fromValue = \case
-    VCustom (VTensor t) -> pure t
-    v -> couldNotCast v
-
-instance ToValue (MlValue tensor model mname x) m model where
-  toValue = VCustom . VModel
-
-instance
-  ( Show tensor
-  , Show model
-  , Show mname
-  , Pretty tensor
-  , Pretty model
-  , Pretty mname
-  , Pretty x
-  , Typeable model
-  ) =>
-  FromValue (MlValue tensor model mname x) m model
-  where
-  fromValue = \case
-    VCustom (VModel m) -> pure m
-    v -> couldNotCast v
-
-instance ToValue (MlValue tensor model mname x) m mname where
-  toValue = VCustom . VModelName
-
-instance
-  ( Show tensor
-  , Show model
-  , Show mname
-  , Pretty tensor
-  , Pretty model
-  , Pretty mname
-  , Pretty x
-  , Typeable mname
-  ) =>
-  FromValue (MlValue tensor model mname x) m mname
-  where
-  fromValue = \case
-    VCustom (VModelName n) -> pure n
-    v -> couldNotCast v
 
 customTypes :: [CustomType]
 customTypes =

--- a/inferno-ml-compat/src/Inferno/ML/Types/Value/Compat.hs
+++ b/inferno-ml-compat/src/Inferno/ML/Types/Value/Compat.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 
-module Inferno.ML.Compat.Types.Value where
+module Inferno.ML.Types.Value.Compat where
 
 import Data.Data (Typeable)
 import qualified Data.Text as Text

--- a/inferno-ml-server/CHANGELOG.md
+++ b/inferno-ml-server/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Revision History for `inferno-ml-server`
 
+## 2025.6.10
+* Updates for introduction of `inferno-ml-compat`
+
 ## 2025.5.21
 * Add script hash to server's `InfernoError`
 

--- a/inferno-ml-server/exe/ParseAndSave.hs
+++ b/inferno-ml-server/exe/ParseAndSave.hs
@@ -41,9 +41,9 @@ import Inferno.Core
   ( Interpreter (Interpreter, parseAndInfer),
     mkInferno,
   )
-import Inferno.ML.Module.Prelude (mlPrelude)
+import Inferno.ML.Module.Prelude (defaultMlPrelude)
 import Inferno.ML.Server.Module.Prelude (mkPrintModules, mkServerBridgePrelude)
-import Inferno.ML.Types.Value (customTypes)
+import Inferno.ML.Types.Value.Compat (customTypes)
 import Inferno.Module.Prelude (ModuleMap)
 import Inferno.Types.Syntax (Expr, TCScheme)
 import Inferno.Types.VersionControl
@@ -87,7 +87,7 @@ parseAndSave ipid p conns ios = do
   bracket (connectPostgreSQL conns) close (saveScriptAndParam ipid ast now ios)
   where
     prelude :: ModuleMap IO BridgeMlValue
-    prelude = Map.union printModules $ mkServerBridgePrelude funs mlPrelude
+    prelude = Map.union printModules $ mkServerBridgePrelude funs defaultMlPrelude
 
     printModules :: ModuleMap IO BridgeMlValue
     printModules = mkPrintModules notSupported notSupported

--- a/inferno-ml-server/inferno-ml-server.cabal
+++ b/inferno-ml-server/inferno-ml-server.cabal
@@ -67,6 +67,7 @@ library
     , http-types
     , inferno-core
     , inferno-ml
+    , inferno-ml-compat
     , inferno-ml-server-types
     , inferno-types
     , inferno-vc

--- a/inferno-ml-server/inferno-ml-server.cabal
+++ b/inferno-ml-server/inferno-ml-server.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               inferno-ml-server
-version:            2025.5.21
+version:            2025.6.10
 synopsis:           Server for Inferno ML
 description:        Server for Inferno ML
 homepage:           https://github.com/plow-technologies/inferno.git#readme
@@ -180,6 +180,7 @@ executable parse-and-save
     , containers
     , inferno-core
     , inferno-ml
+    , inferno-ml-compat
     , inferno-ml-server
     , inferno-ml-server-types
     , inferno-types

--- a/inferno-ml-server/src/Inferno/ML/Server/Bridge.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Bridge.hs
@@ -18,7 +18,7 @@ import Inferno.ML.Server.Module.Bridge (mkBridgeFuns)
 import Inferno.ML.Server.Module.Prelude (mkServerBridgePrelude, serverMlPrelude)
 import Inferno.ML.Server.Types
 import Inferno.ML.Server.Utils
-import Inferno.ML.Types.Value (customTypes)
+import Inferno.ML.Types.Value.Compat (customTypes)
 import Lens.Micro.Platform
 import Servant.Client.Streaming
   ( BaseUrl (BaseUrl),

--- a/inferno-ml-server/src/Inferno/ML/Server/Inference.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Inference.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE LexicalNegation #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE ViewPatterns #-}
@@ -53,7 +54,10 @@ import Inferno.ML.Server.Bridge (initializeInferno)
 import Inferno.ML.Server.Inference.Model
 import Inferno.ML.Server.Types
 import Inferno.ML.Server.Utils
-import Inferno.ML.Types.Value (MlValue (VExtended, VModelName))
+import Inferno.ML.Types.Value
+  ( pattern VExtended,
+    pattern VModelName,
+  )
 import Inferno.Types.Syntax
   ( Expr (App, Var),
     ExtIdent (ExtIdent),

--- a/inferno-ml-server/src/Inferno/ML/Server/Module/Prelude.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Module/Prelude.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
@@ -24,7 +25,12 @@ import Data.Text (Text)
 import Data.Tuple.Extra ((&&&))
 import Foreign.C (CTime (CTime))
 import Inferno.Eval.Error (EvalError (RuntimeError))
-import Inferno.ML.Module.Prelude (getDevice, mkMlPrelude)
+import Inferno.ML.Module.Prelude
+  ( MlModule,
+    defaultMlModule,
+    getDevice,
+    mkMlPrelude,
+  )
 import Inferno.ML.Server.Module.Types
 import Inferno.ML.Server.Types
   ( IValue,
@@ -32,7 +38,8 @@ import Inferno.ML.Server.Types
     TraceWarn (CouldntMoveTensor),
     logWarn,
   )
-import Inferno.ML.Types.Value (MlValue (VExtended), mlQuoter)
+import Inferno.ML.Types.Value (MlValue, pattern VExtended)
+import Inferno.ML.Types.Value.Compat (mlQuoter)
 import Inferno.Module.Cast
 import Inferno.Module.Prelude (ModuleMap)
 import qualified Inferno.Types.Module
@@ -270,8 +277,14 @@ serverMlPrelude :: ModuleMap RemoteM (MlValue BridgeValue)
 serverMlPrelude =
   -- NOTE There's no risk of overlap in module names here, so we can just
   -- use `union` instead of `unionWith`
-  Map.union printModules $ mkMlPrelude toDeviceFun
+  Map.union printModules $ mkMlPrelude mlModule
   where
+    mlModule :: MlModule (ImplEnvM RemoteM (MlValue BridgeValue)) BridgeValue
+    mlModule = module_ & #devices . #toDevice .~ toDeviceFun
+
+    module_ :: MlModule (ImplEnvM RemoteM (MlValue BridgeValue)) BridgeValue
+    module_ = defaultMlModule
+
     toDeviceFun :: BridgeV RemoteM
     toDeviceFun =
       VFun $ \case

--- a/inferno-ml-server/src/Inferno/ML/Server/Module/Prelude.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Module/Prelude.hs
@@ -280,10 +280,13 @@ serverMlPrelude =
   Map.union printModules $ mkMlPrelude mlModule
   where
     mlModule :: MlModule (ImplEnvM RemoteM (MlValue BridgeValue)) BridgeValue
-    mlModule = module_ & #devices . #toDevice .~ toDeviceFun
-
-    module_ :: MlModule (ImplEnvM RemoteM (MlValue BridgeValue)) BridgeValue
-    module_ = defaultMlModule
+    mlModule =
+      -- Note that the type app seems to be necessary for inference to work,
+      -- even though `mlModule` has a type signature above
+      defaultMlModule @(ImplEnvM RemoteM (MlValue BridgeValue)) @BridgeValue
+        -- Overrides the default, less-safe `toDevice` implementation with one
+        -- that checks if the tensor has been moved
+        & #devices . #toDevice .~ toDeviceFun
 
     toDeviceFun :: BridgeV RemoteM
     toDeviceFun =

--- a/inferno-ml-server/src/Inferno/ML/Server/Module/Types.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Module/Types.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PackageImports #-}
+{-# LANGUAGE PatternSynonyms #-}
 
 module Inferno.ML.Server.Module.Types where
 
@@ -21,7 +22,7 @@ import Database.PostgreSQL.Simple.ToField (ToField)
 import GHC.Generics (Generic)
 import Inferno.Eval (TermEnv)
 import Inferno.Eval.Error (EvalError (RuntimeError))
-import Inferno.ML.Types.Value (MlValue (VExtended))
+import Inferno.ML.Types.Value (MlValue, pattern VExtended)
 import Inferno.Module.Builtin (enumBoolHash)
 import Inferno.Module.Cast
   ( FromValue (fromValue),

--- a/inferno-ml/CHANGELOG.md
+++ b/inferno-ml/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Revision History for inferno-ml
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.8.0.0 -- 2025-06-10
+* Breaking change: make `ML` module an implementation of `inferno-ml-compat` modules and general refactor
+* Breaking change: make `MlValue` a type synonym and its constructors pattern synonyms (based on `inferno-ml-compat`'s `MlValue`)
+* Breaking change: `mlPrelude` -> `defaultMlPrelude`
+* Breaking change: Remove `mkMlPrelude`
+
 ## 0.7.0.2 -- 2025-05-01
 * Add `unsqueeze`
 

--- a/inferno-ml/app/Main.hs
+++ b/inferno-ml/app/Main.hs
@@ -7,7 +7,7 @@ module Main where
 import qualified Data.Map as Map
 import qualified Data.Text.IO as Text
 import Inferno.Core (Interpreter (..), mkInferno)
-import Inferno.ML.Module.Prelude (mlPrelude)
+import Inferno.ML.Module.Prelude (defaultMlPrelude)
 import Inferno.ML.Types.Value (MlValue, customTypes)
 import Inferno.Utils.Prettyprinter (showPretty)
 import System.Environment (getArgs)
@@ -18,7 +18,7 @@ main = do
     file : _ -> do
       src <- Text.readFile file
       Interpreter{evalExpr, defaultEnv, parseAndInferTypeReps} <-
-        mkInferno @_ @(MlValue ()) mlPrelude customTypes
+        mkInferno @_ @(MlValue ()) defaultMlPrelude customTypes
       case parseAndInferTypeReps src of
         Left err -> print err
         Right ast ->

--- a/inferno-ml/inferno-ml.cabal
+++ b/inferno-ml/inferno-ml.cabal
@@ -33,6 +33,7 @@ library
     , extra
     , hasktorch
     , inferno-core
+    , inferno-ml-compat
     , inferno-types
     , inline-c-cpp
     , prettyprinter

--- a/inferno-ml/inferno-ml.cabal
+++ b/inferno-ml/inferno-ml.cabal
@@ -37,7 +37,6 @@ library
     , inferno-types
     , inline-c-cpp
     , prettyprinter
-    , template-haskell
     , text
 
   default-language:   Haskell2010

--- a/inferno-ml/inferno-ml.cabal
+++ b/inferno-ml/inferno-ml.cabal
@@ -1,6 +1,6 @@
 cabal-version:      >=1.10
 name:               inferno-ml
-version:            0.7.0.2
+version:            0.8.0.0
 synopsis:           Machine Learning primitives for Inferno
 description:        Machine Learning primitives for Inferno
 homepage:           https://github.com/plow-technologies/inferno.git#readme

--- a/inferno-ml/lsp/Main.hs
+++ b/inferno-ml/lsp/Main.hs
@@ -4,12 +4,12 @@
 module Main where
 
 import Inferno.LSP.Server (runInfernoLspServer)
-import Inferno.ML.Module.Prelude (mlPrelude)
+import Inferno.ML.Module.Prelude (defaultMlPrelude)
 import Inferno.ML.Types.Value (MlValue, customTypes)
 import System.Exit (ExitCode (ExitFailure), exitSuccess, exitWith)
 
 main :: IO ()
 main = do
-  runInfernoLspServer @(MlValue ()) mlPrelude customTypes >>= \case
+  runInfernoLspServer @(MlValue ()) defaultMlPrelude customTypes >>= \case
     0 -> exitSuccess
     c -> exitWith . ExitFailure $ c

--- a/inferno-ml/src/Inferno/ML/Module/Prelude.hs
+++ b/inferno-ml/src/Inferno/ML/Module/Prelude.hs
@@ -204,7 +204,7 @@ getDType funName = \case
     throwM . RuntimeError $
       unwords
         [ funName <> ":"
-        , "unknown dtype "
+        , "unknown dtype"
         , show s
         ]
 

--- a/inferno-ml/src/Inferno/ML/Module/Prelude.hs
+++ b/inferno-ml/src/Inferno/ML/Module/Prelude.hs
@@ -1,14 +1,13 @@
 {-# LANGUAGE DisambiguateRecordFields #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-{-# OPTIONS_GHC -Wwarn #-}
 
 module Inferno.ML.Module.Prelude
-  ( defaultMlPrelude,
+  ( MlModule,
+    defaultMlPrelude,
     defaultMlModule,
     mkMlPrelude,
     getDevice,
-    MlModule,
   ) where
 
 import Control.Exception (evaluate)

--- a/inferno-ml/src/Inferno/ML/Module/Prelude.hs
+++ b/inferno-ml/src/Inferno/ML/Module/Prelude.hs
@@ -1,16 +1,17 @@
-{-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE DisambiguateRecordFields #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -Wwarn #-}
 
 module Inferno.ML.Module.Prelude
-  ( mlPrelude,
+  ( defaultMlPrelude,
+    defaultMlModule,
     mkMlPrelude,
     getDevice,
   ) where
 
 import Control.Exception (evaluate)
+import Control.Monad ((<=<))
 import Control.Monad.Catch
   ( Exception (displayException),
     MonadCatch,
@@ -21,30 +22,197 @@ import Control.Monad.Catch
   )
 import Control.Monad.Extra (concatMapM)
 import Control.Monad.IO.Class (MonadIO, liftIO)
+import Data.Bool (bool)
 import Data.Functor ((<&>))
 import qualified Data.Map as Map
 import Data.Proxy (Proxy (Proxy))
-import Data.Text (Text, unpack)
+import qualified Data.Text as Text
 import GHC.IO.Unsafe (unsafePerformIO)
-import Inferno.Eval.Error (EvalError (..))
+import Inferno.Eval.Error (EvalError (RuntimeError))
+import qualified Inferno.ML.Module.Compat as Compat
 import Inferno.ML.Types.Value
 import Inferno.Module.Cast (FromValue (fromValue), ToValue (toValue))
 import qualified Inferno.Module.Prelude as Prelude
 import Inferno.Types.Syntax (Ident)
-import Inferno.Types.Value (ImplEnvM, Value (..))
+import Inferno.Types.Value
+  ( ImplEnvM,
+    Value (VArray, VCustom, VEnum, VFun),
+  )
 import Language.C.Inline.Cpp.Exception (CppException)
 import Prettyprinter (Pretty)
 import Torch
-import qualified Torch.DType as TD
-import Torch.Functional
-import qualified Torch.Script as TS
+  ( DType,
+    Device (Device),
+    DeviceType (CPU, CUDA),
+    Dim (Dim),
+    IValue (IVTensor, IVTensorList, IVTuple),
+    KeepDim (KeepDim, RemoveDim),
+    LoadMode (WithoutRequiredGrad),
+    ScriptModule,
+    Tensor,
+    TensorLike,
+  )
+import qualified Torch
+import qualified Torch.DType as DType
+import qualified Torch.Functional
+import qualified Torch.Script
 
-getDtype :: (MonadThrow m) => String -> Ident -> m DType
-getDtype funName = \case
-  "int" -> return TD.Int64
-  "float" -> return TD.Float
-  "double" -> return TD.Double
-  s -> throwM $ RuntimeError $ funName ++ ": unknown dtype " ++ show s
+type MkModule m x = Compat.MkMlModule m Tensor ScriptModule ModelName x
+
+defaultMlModule ::
+  forall m x.
+  ( MonadIO m
+  , MonadCatch m
+  , Pretty x
+  , Eq x
+  ) =>
+  MkModule m x
+defaultMlModule =
+  Compat.MkMlModule
+    { models =
+        Compat.MkModelFuns
+          { loadModel =
+              VFun $ \case
+                VCustom (VModelName (ModelName mn)) ->
+                  either
+                    (throwM . RuntimeError . displayException)
+                    (pure . VCustom . VModel)
+                    =<< liftIO (try @_ @SomeException loadModel)
+                  where
+                    loadModel :: IO ScriptModule
+                    loadModel = Torch.Script.loadScript WithoutRequiredGrad mn
+                _ -> throwM $ RuntimeError "Expected a modelName"
+          , forward =
+              let
+                expectedTensors :: EvalError
+                expectedTensors = RuntimeError "expected an array of tensors"
+               in
+                VFun $ \case
+                  VCustom (VModel model) -> pure . VFun $ \case
+                    VArray mts ->
+                      getTensors mts >>= \tensors ->
+                        -- Note that we are using `forwardIO` here so any C++ exception can be
+                        -- caught, otherwise the operation will fail silently (besides printing
+                        -- to stderr)
+                        fmap (VArray . fmap (VCustom . VTensor)) . liftIO $
+                          forwardIO model tensors `catch` torchHandler
+                      where
+                        -- Unfortunately we need to unwrap all of the constructors to get the
+                        -- tensors inside
+                        getTensors :: [Value (MlValue x) m] -> m [Tensor]
+                        getTensors = traverse $ \case
+                          VCustom (VTensor t) -> pure t
+                          _ -> throwM expectedTensors
+
+                        -- Rethrow the C++ exception as a `RuntimeError` so we can at least
+                        -- see it in error messages more clearly
+                        torchHandler :: CppException -> IO [Tensor]
+                        torchHandler =
+                          throwM
+                            . RuntimeError
+                            . ("forward: exception from Torchscript interpreter " <>)
+                            . displayException
+                    _ -> throwM expectedTensors
+                  _ -> throwM $ RuntimeError "expected a model"
+          , unsafeLoadScript =
+              unsafePerformIO
+                . Torch.Script.loadScript WithoutRequiredGrad
+                . Text.unpack
+          }
+    , devices =
+        Compat.MkDeviceFuns
+          { -- NOTE This should be overridden -- we need `toDevice` to check
+            -- that the tensor is moved, but we need a concrete `m` to do that
+            -- in. Consumers can replace this implementation by updating the
+            -- record field. This is the default, less-ideal implementation
+            toDevice =
+              -- Implementation of `toDevice` that doesn't check the device that the
+              -- moved tensor is on (i.e. may fail silently)
+              VFun $ \case
+                VEnum _ e ->
+                  getDevice e <&> \dev ->
+                    VFun $
+                      fmap (toValue @_ @_ @Tensor . Torch.toDevice dev)
+                        . fromValue @_ @_ @Tensor
+                _ -> throwM $ RuntimeError "toDeviceFun: expecting a device enum"
+          , toDeviceUnsafe = \dev t ->
+              flip Torch.toDevice t $ case dev of
+                "cpu" -> Device CPU 0
+                "cuda:0" -> Device CUDA 0
+                d -> error $ unwords ["Unknown device setting:", Text.unpack d]
+          }
+    , factories =
+        Compat.MkFactoryFuns
+          { zeros =
+              withDType "zeros" $ \dt ->
+                VFun $
+                  fmap (toValue . (`Torch.zeros` Torch.withDType dt Torch.defaultOpts))
+                    . fromValue
+          , ones =
+              withDType "ones" $ \dt ->
+                VFun $
+                  fmap (toValue . (`Torch.ones` Torch.withDType dt Torch.defaultOpts))
+                    . fromValue
+          , randnIO =
+              withDType "randnIO" $ \dt ->
+                VFun $
+                  fmap (VCustom . VTensor)
+                    . liftIO
+                    . (`Torch.randnIO` Torch.withDType dt Torch.defaultOpts)
+                    <=< fromValue
+          }
+    , conversions =
+        Compat.MkConversionFuns
+          { toType =
+              withDType "toType" $ \dt ->
+                VFun $ fmap (VCustom . VTensor . Torch.toType dt) . fromValue
+          , asTensor0 = asTensorFun "asTensor0" $ Proxy @Double
+          , asTensor1 = asTensorFun "asTensor1" $ Proxy @[Double]
+          , asTensor2 = asTensorFun "asTensor2" $ Proxy @[[Double]]
+          , asTensor3 = asTensorFun "asTensor3" $ Proxy @[[[Double]]]
+          , asTensor4 = asTensorFun "asTensor4" $ Proxy @[[[[Double]]]]
+          , asDouble = Torch.asValue . Torch.toType DType.Double
+          , asArray1 = Torch.asValue . Torch.toType DType.Double
+          , asArray2 = Torch.asValue . Torch.toType DType.Double
+          , asArray3 = Torch.asValue . Torch.toType DType.Double
+          , asArray4 = Torch.asValue . Torch.toType DType.Double
+          }
+    , functional =
+        Compat.MkFunctionalFuns
+          { argmax =
+              \i -> Torch.Functional.argmax (Dim i) . bool RemoveDim KeepDim
+          , softmax = Torch.Functional.softmax . Dim
+          , stack = Torch.stack . Dim
+          , tanh = Torch.Functional.tanh
+          , pow = Torch.Functional.pow
+          , unsqueeze = Torch.Functional.unsqueeze . Dim
+          , add = Torch.Functional.add
+          , sumAll = Torch.Functional.sumAll
+          , transpose2D = Torch.Functional.transpose2D
+          , matmul = Torch.Functional.matmul
+          , mseLoss = Torch.Functional.mseLoss
+          }
+    }
+
+getDType :: (MonadThrow m) => String -> Ident -> m DType
+getDType funName = \case
+  "int" -> pure DType.Int64
+  "float" -> pure DType.Float
+  "double" -> pure DType.Double
+  s ->
+    throwM . RuntimeError $
+      unwords
+        [ funName <> ":"
+        , "unknown dtype "
+        , show s
+        ]
+
+withDType ::
+  (MonadThrow m) => String -> (DType -> Value (MlValue x) m) -> Value (MlValue x) m
+withDType funName f =
+  VFun $ \case
+    VEnum _ e -> f <$> getDType funName e
+    _ -> throwM . RuntimeError $ funName <> ": expecting a dtype enum"
 
 -- Get the Torch device from a `device{#cpu, #cuda}`. There will only ever
 -- be one CUDA device available for our purposes, i.e. `cuda:0`, so we only
@@ -62,149 +230,20 @@ getDevice = \case
         , "expected one of {#cpu,#cuda}"
         ]
 
-zerosFun :: (MonadThrow m, Pretty a) => Value (MlValue a) m
-zerosFun =
-  VFun $ \case
-    VEnum _ e -> do
-      dType <- getDtype "zeros" e
-      return $ VFun $ \vShape -> do
-        shp <- fromValue vShape
-        pure $ toValue $ zeros shp $ withDType dType defaultOpts
-    _ -> throwM $ RuntimeError "zerosFun: expecting a dtype enum"
-
-onesFun :: (MonadThrow m, Pretty x) => Value (MlValue x) m
-onesFun =
-  VFun $ \case
-    VEnum _ e -> do
-      dType <- getDtype "ones" e
-      return $ VFun $ \vShape -> do
-        shp <- fromValue vShape
-        pure $ toValue $ ones shp $ withDType dType defaultOpts
-    _ -> throwM $ RuntimeError "onesFun: expecting a dtype enum"
-
 asTensorFun ::
   forall a x m.
   ( TensorLike a
-  , FromValue
-      (MlValue x)
-      m
-      a
   , MonadThrow m
+  , FromValue (MlValue x) m a
   ) =>
   String ->
   Proxy a ->
   Value (MlValue x) m
 asTensorFun funName _proxy =
-  VFun $ \case
-    VEnum _ e -> do
-      dType <- getDtype funName e
-      pure $ VFun $ \v -> do
-        xs :: a <- fromValue v
-        pure $ VCustom $ VTensor $ toType dType $ asTensor xs
-    _ -> throwM $ RuntimeError $ funName ++ ": expecting a dtype enum"
-
-toTypeFun :: forall m x. (Pretty x, MonadThrow m) => Value (MlValue x) m
-toTypeFun =
-  VFun $ \case
-    VEnum _ e ->
-      getDtype "toType" e <&> \dt ->
-        VFun $ fmap (VCustom . VTensor . toType dt) . fromValue
-    _ -> throwM . RuntimeError $ "toType : expecting a dtype enum"
-
-asTensor0Fun :: forall m x. (MonadThrow m, Pretty x) => Value (MlValue x) m
-asTensor0Fun = asTensorFun "asTensor0" (Proxy :: Proxy Double)
-
-asTensor1Fun :: forall m x. (MonadThrow m, Pretty x) => Value (MlValue x) m
-asTensor1Fun = asTensorFun "asTensor1" (Proxy :: Proxy [Double])
-
-asTensor2Fun :: forall m x. (MonadThrow m, Pretty x) => Value (MlValue x) m
-asTensor2Fun = asTensorFun "asTensor2" (Proxy :: Proxy [[Double]])
-
-asTensor3Fun :: forall m x. (MonadThrow m, Pretty x) => Value (MlValue x) m
-asTensor3Fun = asTensorFun "asTensor3" (Proxy :: Proxy [[[Double]]])
-
-asTensor4Fun :: forall m x. (MonadThrow m, Pretty x) => Value (MlValue x) m
-asTensor4Fun = asTensorFun "asTensor4" (Proxy :: Proxy [[[[Double]]]])
-
-asDouble :: Tensor -> Double
-asDouble t = asValue $ toType TD.Double t
-
-asArray1Fun :: Tensor -> [Double]
-asArray1Fun t = asValue $ toType TD.Double t
-
-asArray2Fun :: Tensor -> [[Double]]
-asArray2Fun t = asValue $ toType TD.Double t
-
-asArray3Fun :: Tensor -> [[[Double]]]
-asArray3Fun t = asValue $ toType TD.Double t
-
-asArray4Fun :: Tensor -> [[[[Double]]]]
-asArray4Fun t = asValue $ toType TD.Double t
-
-argmaxFun :: Int -> Bool -> Tensor -> Tensor
-argmaxFun i keepDim = argmax (Dim i) (if keepDim then KeepDim else RemoveDim)
-
-softmaxFun :: Int -> Tensor -> Tensor
-softmaxFun i = softmax (Dim i)
-
-stackFun :: Int -> [Tensor] -> Tensor
-stackFun i = Torch.stack (Dim i)
-
-tanHTFun :: Tensor -> Tensor
-tanHTFun = Torch.Functional.tanh
-
-powTFun :: Int -> Tensor -> Tensor
-powTFun = pow
-
-unsqueezeFun :: Int -> Tensor -> Tensor
-unsqueezeFun = Torch.Functional.unsqueeze . Dim
-
-unsafeLoadScriptFun :: Text -> ScriptModule
-unsafeLoadScriptFun f = unsafePerformIO $ TS.loadScript TS.WithoutRequiredGrad $ unpack f
-
-loadModelFun ::
-  forall m x. (Pretty x, MonadIO m, MonadThrow m) => Value (MlValue x) m
-loadModelFun = VFun $ \case
-  VCustom (VModelName (ModelName mn)) ->
-    either (throwM . RuntimeError . displayException) (pure . VCustom . VModel)
-      =<< liftIO (try @_ @SomeException loadModel)
-    where
-      loadModel :: IO ScriptModule
-      loadModel = TS.loadScript TS.WithoutRequiredGrad mn
-  _ -> throwM $ RuntimeError "Expected a modelName"
-
-forwardFun ::
-  forall m x. (Pretty x, MonadIO m, MonadThrow m) => Value (MlValue x) m
-forwardFun = VFun $ \case
-  VCustom (VModel model) -> pure . VFun $ \case
-    VArray mts ->
-      getTensors mts >>= \tensors ->
-        -- Note that we are using `forwardIO` here so any C++ exception can be
-        -- caught, otherwise the operation will fail silently (besides printing
-        -- to stderr)
-        fmap (VArray . fmap (VCustom . VTensor)) . liftIO $
-          forwardIO model tensors `catch` torchHandler
-      where
-        -- Unfortunately we need to unwrap all of the constructors to get the
-        -- tensors inside
-        getTensors :: [Value (MlValue x) m] -> m [Tensor]
-        getTensors = traverse $ \case
-          VCustom (VTensor t) -> pure t
-          _ -> throwM expectedTensors
-
-        -- Rethrow the C++ exception as a `RuntimeError` so we can at least
-        -- see it in error messages more clearly
-        torchHandler :: CppException -> IO [Tensor]
-        torchHandler =
-          throwM
-            . RuntimeError
-            . ("forward: exception from Torchscript interpreter " <>)
-            . displayException
-    _ -> throwM expectedTensors
-  _ -> throwM $ RuntimeError "expected a model"
-  where
-    expectedTensors :: EvalError
-    expectedTensors = RuntimeError "expected an array of tensors"
+  withDType funName $ \dtype ->
+    VFun $
+      fmap (VCustom . VTensor . Torch.toType dtype . Torch.asTensor @a)
+        . fromValue
 
 -- Lifts Hasktorch's `forward` to `IO` (via `evaluate`) so we can catch
 -- any `CppStdException`s in case the Torchscript interpreter fails;
@@ -212,7 +251,7 @@ forwardFun = VFun $ \case
 -- so we need to `evaluate` it to be able to catch the exception in the Inferno
 -- primitive
 forwardIO :: ScriptModule -> [Tensor] -> IO [Tensor]
-forwardIO m ts = unIV =<< evaluate (forward m (fmap IVTensor ts))
+forwardIO m ts = unIV =<< evaluate (Torch.forward m (fmap IVTensor ts))
   where
     unIV :: IValue -> IO [Tensor]
     unIV = \case
@@ -221,144 +260,7 @@ forwardIO m ts = unIV =<< evaluate (forward m (fmap IVTensor ts))
       IVTuple ivs -> concatMapM unIV ivs
       res -> throwM . RuntimeError $ "expected tensor result, got " <> show res
 
-randnIOFun ::
-  forall m x.
-  ( MonadThrow m
-  , MonadIO m
-  , Pretty x
-  ) =>
-  Value (MlValue x) m
-randnIOFun =
-  VFun $ \case
-    VEnum _ e -> do
-      dType <- getDtype "randnIO" e
-      pure $ VFun $ \xs -> do
-        shp <- fromValue xs
-        t <- liftIO $ randnIO shp $ withDType dType defaultOpts
-        pure $ VCustom $ VTensor t
-    _ -> throwM $ RuntimeError "randnIOFun: expecting a dtype enum"
-
-toDeviceUnsafeFun :: Text -> Tensor -> Tensor
-toDeviceUnsafeFun d t =
-  let dev = case d of
-        "cpu" -> Device CPU 0
-        "cuda:0" -> Device CUDA 0
-        device' -> error $ "Unknown device setting: " ++ unpack device'
-   in toDevice dev t
-
--- Implementation of `toDevice` that doesn't check the device that the
--- moved tensor is on (i.e. may fail silently)
-defaultToDeviceFun ::
-  forall m x.
-  ( MonadThrow m
-  , MonadIO m
-  , Pretty x
-  ) =>
-  Value (MlValue x) m
-defaultToDeviceFun =
-  VFun $ \case
-    VEnum _ e ->
-      getDevice e <&> \dev ->
-        VFun $ \tensor ->
-          (toValue @_ @_ @Tensor) . toDevice dev
-            <$> (fromValue @_ @_ @Tensor) tensor
-    _ -> throwM $ RuntimeError "toDeviceFun: expecting a device enum"
-
-mlModules ::
-  forall m x.
-  ( MonadThrow m
-  , MonadIO m
-  , Pretty x
-  ) =>
-  Prelude.ModuleMap m (MlValue x)
-mlModules = mkMlModules defaultToDeviceFun
-
-mkMlModules ::
-  forall m x.
-  ( MonadThrow m
-  , MonadIO m
-  , Pretty x
-  ) =>
-  Value (MlValue x) (ImplEnvM m (MlValue x)) ->
-  Prelude.ModuleMap m (MlValue x)
-mkMlModules toDeviceFun =
-  [mlQuoter|
-
-module ML
-
-  enum dtype := #int | #float | #double;
-
-  enum device := #cpu | #cuda;
-
-  zeros : dtype{#int, #float, #double} -> array of int -> tensor := ###!zerosFun###;
-
-  ones : dtype{#int, #float, #double} -> array of int -> tensor := ###!onesFun###;
-
-  add : tensor -> tensor -> tensor := ###add###;
-
-  toType : dtype{#int, #float, #double} -> tensor -> tensor := ###!toTypeFun###;
-
-  asTensor0 : dtype{#int, #float, #double} -> double -> tensor := ###!asTensor0Fun###;
-
-  asTensor1 : dtype{#int, #float, #double} -> array of double -> tensor := ###!asTensor1Fun###;
-
-  asTensor2 : dtype{#int, #float, #double} -> array of (array of double) -> tensor := ###!asTensor2Fun###;
-
-  asTensor3 : dtype{#int, #float, #double} -> array of (array of (array of double)) -> tensor := ###!asTensor3Fun###;
-
-  asTensor4 : dtype{#int, #float, #double} -> array of (array of (array of (array of double))) -> tensor := ###!asTensor4Fun###;
-
-  asDouble : tensor -> double := ###asDouble###;
-
-  asArray1 : tensor -> array of double := ###asArray1Fun###;
-
-  asArray2 : tensor -> array of (array of double) := ###asArray2Fun###;
-
-  asArray3 : tensor -> array of (array of (array of double)) := ###asArray3Fun###;
-
-  asArray4 : tensor -> array of (array of (array of (array of double))) := ###asArray4Fun###;
-
-  sumAll : tensor -> tensor := ###sumAll###;
-
-  powT : int -> tensor -> tensor := ###powTFun###;
-
-  tanH : tensor -> tensor := ###tanHTFun###;
-
-  @doc `argmax i k t` is the argmax of tensor `t` along dimension `i`. `k` denotes whether the output tensor has dim retained or not.;
-  argmax : int -> bool{#true, #false} -> tensor -> tensor := ###argmaxFun###;
-
-  softmax : int -> tensor -> tensor := ###softmaxFun###;
-
-  @doc `stack i [t]` takes an array of tensors `t` and appends them along the dimension i in a new tensor;
-  stack : int -> array of tensor -> tensor := ###stackFun###;
-
-  transpose2D : tensor -> tensor := ###transpose2D###;
-
-  matmul : tensor -> tensor -> tensor := ###matmul###;
-
-  mseLoss : tensor -> tensor -> tensor := ###mseLoss###;
-
-  unsqueeze : int -> tensor -> tensor := ###unsqueezeFun###;
-
-  @doc An impure (pseudo)random tensor generator;
-  randnIO : dtype{#int, #float, #double} -> array of int -> tensor := ###!randnIOFun###;
-
-  @doc Move a tensor to a different device;
-  toDevice : device{#cpu, #cuda} -> tensor -> tensor := ###!toDeviceFun###;
-
-  @doc Move a tensor to a different device, e.g. "cpu" or "cuda:0" (without checking validity of device name);
-  toDeviceUnsafe : text -> tensor -> tensor := ###toDeviceUnsafeFun###;
-
-  @doc Load a named, serialized model;
-  loadModel : modelName -> model := ###!loadModelFun###;
-
-  unsafeLoadScript : text -> model := ###unsafeLoadScriptFun###;
-
-  forward : model -> array of tensor -> array of tensor := ###!forwardFun###;
-
-|]
-
-mlPrelude ::
+defaultMlPrelude ::
   forall m x.
   ( MonadIO m
   , MonadCatch m
@@ -366,11 +268,11 @@ mlPrelude ::
   , Eq x
   ) =>
   Prelude.ModuleMap m (MlValue x)
-mlPrelude =
+defaultMlPrelude =
   Map.unionWith
     (error "Duplicate module name in builtinModules")
     (Prelude.builtinModules @m @(MlValue x))
-    $ mlModules @m
+    $ Compat.mkMlModule defaultMlModule
 
 mkMlPrelude ::
   forall m x.
@@ -379,11 +281,11 @@ mkMlPrelude ::
   , Pretty x
   , Eq x
   ) =>
-  -- | @toDevice@ implementation
-  Value (MlValue x) (ImplEnvM m (MlValue x)) ->
+  -- | Implementation of Inferno ML primitives
+  MkModule (ImplEnvM m (MlValue x)) x ->
   Prelude.ModuleMap m (MlValue x)
 mkMlPrelude =
   Map.unionWith
     (error "Duplicate module name in builtinModules")
     (Prelude.builtinModules @m @(MlValue x))
-    . mkMlModules @m
+    . Compat.mkMlModule

--- a/inferno-ml/src/Inferno/ML/Module/Prelude.hs
+++ b/inferno-ml/src/Inferno/ML/Module/Prelude.hs
@@ -57,8 +57,12 @@ import qualified Torch.DType as DType
 import qualified Torch.Functional
 import qualified Torch.Script
 
+-- | A @MkMlModule@ implementation that depends on Hasktorch types
 type MlModule m x = Compat.MkMlModule m Tensor ScriptModule ModelName x
 
+-- | The default @ML@ Inferno module generator which depends on Hasktorch.
+-- Applying @mkMlModule@ will create the @ML@ module with these primitive
+-- implementations
 defaultMlModule ::
   forall m x.
   ( MonadIO m
@@ -260,6 +264,7 @@ forwardIO m ts = unIV =<< evaluate (Torch.forward m (fmap IVTensor ts))
       IVTuple ivs -> concatMapM unIV ivs
       res -> throwM . RuntimeError $ "expected tensor result, got " <> show res
 
+-- | Inferno prelude with a default @ML@ implementation (see 'defaultMlModule')
 defaultMlPrelude ::
   forall m x.
   ( MonadIO m
@@ -274,6 +279,8 @@ defaultMlPrelude =
     (Prelude.builtinModules @m @(MlValue x))
     $ Compat.mkMlModule defaultMlModule
 
+-- | Create an Inferno prelude with a custom @ML@ implementation. This can
+-- be used to override certain primitives inside the @MlModule@
 mkMlPrelude ::
   forall m x.
   ( MonadIO m

--- a/inferno-ml/src/Inferno/ML/Module/Prelude.hs
+++ b/inferno-ml/src/Inferno/ML/Module/Prelude.hs
@@ -8,6 +8,7 @@ module Inferno.ML.Module.Prelude
     defaultMlModule,
     mkMlPrelude,
     getDevice,
+    MlModule,
   ) where
 
 import Control.Exception (evaluate)
@@ -57,7 +58,7 @@ import qualified Torch.DType as DType
 import qualified Torch.Functional
 import qualified Torch.Script
 
-type MkModule m x = Compat.MkMlModule m Tensor ScriptModule ModelName x
+type MlModule m x = Compat.MkMlModule m Tensor ScriptModule ModelName x
 
 defaultMlModule ::
   forall m x.
@@ -66,7 +67,7 @@ defaultMlModule ::
   , Pretty x
   , Eq x
   ) =>
-  MkModule m x
+  MlModule m x
 defaultMlModule =
   Compat.MkMlModule
     { models =
@@ -282,7 +283,7 @@ mkMlPrelude ::
   , Eq x
   ) =>
   -- | Implementation of Inferno ML primitives
-  MkModule (ImplEnvM m (MlValue x)) x ->
+  MlModule (ImplEnvM m (MlValue x)) x ->
   Prelude.ModuleMap m (MlValue x)
 mkMlPrelude =
   Map.unionWith

--- a/inferno-ml/src/Inferno/ML/Types/Value.hs
+++ b/inferno-ml/src/Inferno/ML/Types/Value.hs
@@ -12,10 +12,13 @@ module Inferno.ML.Types.Value
     pattern VModelName,
     pattern VExtended,
     ModelName (ModelName),
+    -- Convenience re-export
+    customTypes,
   ) where
 
 import qualified Data.Text as Text
 import GHC.Generics (Generic)
+import Inferno.ML.Types.Value.Compat (customTypes)
 import qualified Inferno.ML.Types.Value.Compat as Compat
 import Inferno.Module.Cast
   ( FromValue (fromValue),

--- a/inferno-ml/src/Inferno/ML/Types/Value.hs
+++ b/inferno-ml/src/Inferno/ML/Types/Value.hs
@@ -3,55 +3,78 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PatternSynonyms #-}
 
-module Inferno.ML.Types.Value where
+module Inferno.ML.Types.Value
+  ( MlValue,
+    pattern VTensor,
+    pattern VModel,
+    pattern VModelName,
+    pattern VExtended,
+    ModelName (ModelName),
+  ) where
 
 import qualified Data.Text as Text
 import GHC.Generics (Generic)
-import Inferno.Module.Cast (FromValue (..), ToValue (..), couldNotCast)
-import Inferno.Types.Syntax (CustomType)
+import qualified Inferno.ML.Types.Value.Compat as Compat
+import Inferno.Module.Cast
+  ( FromValue (fromValue),
+    ToValue (toValue),
+    couldNotCast,
+  )
 import Inferno.Types.Value (Value (VCustom))
-import Inferno.Utils.QQ.Module (moduleQuoter)
-import Language.Haskell.TH.Quote (QuasiQuoter (..))
 import Prettyprinter (Pretty (pretty), align)
-import qualified Torch as T
+import Torch (ScriptModule, Tensor)
+
+type MlValue x = Compat.MlValue Tensor ScriptModule ModelName x
+
+{-# COMPLETE VTensor, VModel, VModelName, VExtended #-}
+
+pattern VTensor :: Tensor -> MlValue x
+pattern VTensor t = Compat.VTensor t
+
+pattern VModel :: ScriptModule -> MlValue x
+pattern VModel m = Compat.VModel m
+
+pattern VModelName :: ModelName -> MlValue x
+pattern VModelName mn = Compat.VModelName mn
+
+pattern VExtended :: x -> MlValue x
+pattern VExtended x = Compat.VExtended x
 
 -- | The name of a serialized model, e.g. @model.ts.pt@
 newtype ModelName = ModelName FilePath
   deriving stock (Show, Generic)
   deriving newtype (Eq, Pretty)
 
-data MlValue x
-  = VTensor T.Tensor
-  | VModel T.ScriptModule
-  | VModelName ModelName
-  | VExtended x
-
 instance (Eq x) => Eq (MlValue x) where
   VTensor t1 == VTensor t2 = t1 == t2
+  VModelName n1 == VModelName n2 = n1 == n2
   VExtended x == VExtended y = x == y
   _ == _ = False
 
 instance (Pretty x) => Pretty (MlValue x) where
   pretty = \case
-    VTensor t -> align (pretty $ Text.pack $ show t)
-    VModel m -> align (pretty $ Text.pack $ show m)
+    VTensor t -> align . pretty . Text.pack $ show t
+    VModel m -> align . pretty . Text.pack $ show m
     VModelName x -> align $ pretty x
     VExtended x -> align $ pretty x
 
-instance ToValue (MlValue x) m T.Tensor where
+instance ToValue (MlValue x) m Tensor where
   toValue = VCustom . VTensor
 
-instance (Pretty x) => FromValue (MlValue x) m T.Tensor where
-  fromValue (VCustom (VTensor t)) = pure t
-  fromValue v = couldNotCast v
+instance (Pretty x) => FromValue (MlValue x) m Tensor where
+  fromValue = \case
+    VCustom (VTensor t) -> pure t
+    v -> couldNotCast v
 
-instance ToValue (MlValue x) m T.ScriptModule where
+instance ToValue (MlValue x) m ScriptModule where
   toValue = VCustom . VModel
 
-instance (Pretty x) => FromValue (MlValue x) m T.ScriptModule where
-  fromValue (VCustom (VModel t)) = pure t
-  fromValue v = couldNotCast v
+instance (Pretty x) => FromValue (MlValue x) m ScriptModule where
+  fromValue = \case
+    VCustom (VModel t) -> pure t
+    v -> couldNotCast v
 
 instance ToValue (MlValue x) m ModelName where
   toValue = VCustom . VModelName
@@ -60,16 +83,3 @@ instance (Pretty x) => FromValue (MlValue x) m ModelName where
   fromValue = \case
     VCustom (VModelName t) -> pure t
     v -> couldNotCast v
-
-customTypes :: [CustomType]
-customTypes =
-  [ "tensor"
-  , -- NOTE It seems that `modelName` needs to come before `model`,
-    -- otherwise Inferno's parser fails??
-    "modelName"
-  , "model"
-  , "write"
-  ]
-
-mlQuoter :: QuasiQuoter
-mlQuoter = moduleQuoter customTypes

--- a/inferno-ml/test/Spec.hs
+++ b/inferno-ml/test/Spec.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE PatternSynonyms #-}
 
 module Main (main) where
 
@@ -12,7 +12,7 @@ import qualified Data.Map as Map
 import Data.Text (Text, unpack)
 import Inferno.Core (InfernoError (..), Interpreter (..), mkInferno)
 import Inferno.ML.Module.Prelude (defaultMlPrelude)
-import Inferno.ML.Types.Value (MlValue, pattern VTensor, customTypes)
+import Inferno.ML.Types.Value (MlValue, customTypes, pattern VTensor)
 import Inferno.Parse.Error (prettyError)
 import Inferno.Types.Value (Value (..))
 import Inferno.Utils.Prettyprinter (renderPretty)

--- a/inferno-ml/test/Spec.hs
+++ b/inferno-ml/test/Spec.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE PatternSynonyms #-}
 
 module Main (main) where
 
@@ -10,8 +11,8 @@ import qualified Data.List.NonEmpty as NEList
 import qualified Data.Map as Map
 import Data.Text (Text, unpack)
 import Inferno.Core (InfernoError (..), Interpreter (..), mkInferno)
-import Inferno.ML.Module.Prelude (mlPrelude)
-import Inferno.ML.Types.Value (MlValue (VTensor), customTypes)
+import Inferno.ML.Module.Prelude (defaultMlPrelude)
+import Inferno.ML.Types.Value (MlValue, pattern VTensor, customTypes)
 import Inferno.Parse.Error (prettyError)
 import Inferno.Types.Value (Value (..))
 import Inferno.Utils.Prettyprinter (renderPretty)
@@ -49,7 +50,7 @@ evalTests :: Spec
 evalTests = describe "evaluate" $
   do
     Interpreter{evalExpr, defaultEnv, parseAndInfer, parseAndInferTypeReps} <-
-      runIO $ mkInferno @_ @(MlValue ()) mlPrelude customTypes
+      runIO $ mkInferno @_ @(MlValue ()) defaultMlPrelude customTypes
     let shouldEvaluateInEnvTo implEnv str (v :: Value (MlValue ()) IO) =
           it ("\"" <> unpack str <> "\" should evaluate to " <> unpack (renderPretty v)) $ do
             case parseAndInferTypeReps str of


### PR DESCRIPTION
Currently we have two places (here in `inferno` and elsewhere) where we need to use the `ML` module primitive definitions. The current `inferno-ml` package has a hard dependency on `hasktorch`, however, which we can't use in the other place we need the `ML` module, so we've had to duplicate the module definition and keep the two in sync manually.

This fixes that by adding an `inferno-ml-compat` package that, given certain types (tensor, script module, etc...), will generate the `ML` module from the primitives contained in a group of record-of-functions.

The `inferno-ml` package instantiates this using `Tensor`, `ScriptModule`, etc... from Hasktorch, and provides primitive implementations that can be evaluated at runtime. Elsewhere we can use dummy types for type-checking and LSP purposes.

This keeps the `ML` module in sync but avoids a direct dependency on Hasktorch where we can't use it.