### PR TITLE
Add function to generate prelude docs

### DIFF
--- a/inferno-core/CHANGELOG.md
+++ b/inferno-core/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Revision History for inferno-core
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.11.6.3 -- 2025-07-03
+* Add `mkPreludeDocs` functionality
+
 ## 0.11.6.2 -- 2025-07-03
 * Add `scalar` typeclass
 

--- a/inferno-core/inferno-core.cabal
+++ b/inferno-core/inferno-core.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               inferno-core
-version:            0.11.6.1
+version:            0.11.6.3
 synopsis:           A statically-typed functional scripting language
 description:
   Parser, type inference, and interpreter for a statically-typed functional scripting language

--- a/inferno-core/src/Inferno/Docs.hs
+++ b/inferno-core/src/Inferno/Docs.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# OPTIONS_GHC -Wno-unused-local-binds #-}
 
 module Inferno.Docs where
 
@@ -329,17 +328,19 @@ mkModuleDocs ::
   , Eq c
   ) =>
   ModuleMap m c -> Text
-mkModuleDocs modules =
-  flip Map.foldMapWithKey moduleToNameToTypeMeta $
-    \mModName nameToTypeMeta ->
-      mconcat
-        [ "### Module "
-        , maybe "Base (needs no prefix)" (.unModuleName) mModName
-        , Text.replicate 2 newline
-        , moduleDocs nameToTypeMeta
-        , Text.replicate 2 newline
-        ]
+mkModuleDocs modules = allModuleDocs <> allTypeClassDocs
   where
+    allModuleDocs :: Text
+    allModuleDocs =
+      flip Map.foldMapWithKey moduleToNameToTypeMeta $
+        \mModName nameToTypeMeta ->
+          mconcat
+            [ "### Module "
+            , maybe "Base (needs no prefix)" (.unModuleName) mModName
+            , Text.replicate 2 newline
+            , moduleDocs nameToTypeMeta
+            , Text.replicate 2 newline
+            ]
     moduleDocs :: Map Namespace (TypeMetadata TCScheme) -> Text
     moduleDocs =
       Map.foldMapWithKey $ \name typeMeta -> case name of


### PR DESCRIPTION
Adds `Inferno.Docs.mkPreludeDocs` to generate markdown docs for all primitives and typeclasses in the given prelude.

Example output (module docs from generating for `defaultMlPrelude`):

```md
### Module Tensor

#### `add : tensor → tensor → tensor`
`add t1 t2` adds each element of the tensor `t2` to each element of the
  tensor `t1` and returns a new resulting tensor

----

#### `addScalar : forall 'a. {requires scalar on 'a} ⇒ 'a → tensor → tensor`
`addScalar summand t` adds each element of `t` with the scalar `summand`
  and returns a new resulting tensor

----

#### `all : tensor → bool{#false,#true}`
Returns true if all elements in the tensor are true, false otherwise

----

#### `allDim : int → bool{#false,#true} → tensor → tensor`
`allDim dim keepdim t` returns true if all elements in each row of `t`
  in the given dimension `dim` are true, false otherwise. If `keepdim` is `#true`,
  the output tensor is of the same size as `t` except in the dimension `dim` where
  it is of size 1. Otherwise, `dim` is squeezed, resulting in the output tensor
  having 1 fewer dimension than `t`

----

#### `any : tensor → bool{#false,#true}`
Returns true if any element in the tensor is true, false otherwise

----

...
```

Example output (typeclass docs):

```md
## Type Classes
#### `abs`
- `int`
- `double`
- `timeDiff`

#### `addition`
- `int int int`
- `int double double`
- `double int double`
- `double double double`
- `word16 word16 word16`
- `word16 word32 word32`
- `word16 word64 word64`
- `word32 word16 word32`
- `word32 word32 word32`
- `word32 word64 word64`
- `word64 word16 word64`
- `word64 word32 word64`
- `word64 word64 word64`
- `time timeDiff time`
- `timeDiff time time`
- `timeDiff timeDiff timeDiff`

#### `bitlike`
- `word16`
- `word32`
- `word64`
- `bool{#false,#true}`

...
```