### PR TITLE
[inferno-ml] Run `inferno-ml-server` within systemd OOM policy

### DIFF
--- a/inferno-ml-server-types/CHANGELOG.md
+++ b/inferno-ml-server-types/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Revision History for inferno-ml-server-types
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.20.0
+* Add `OomKilled` warning trace
+
 ## 0.19.0
 * Breaking changes:
   - Rename `VCObjectHashRow` to `VCObjectHashField` and change its DB (de)serialization

--- a/inferno-ml-server-types/inferno-ml-server-types.cabal
+++ b/inferno-ml-server-types/inferno-ml-server-types.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          inferno-ml-server-types
-version:       0.19.0
+version:       0.20.0
 synopsis:      Types for Inferno ML server
 description:   Types for Inferno ML server
 homepage:      https://github.com/plow-technologies/inferno.git#readme

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
@@ -1132,6 +1132,9 @@ data TraceWarn p
     -- moving a tensor from \"cpu:0\" to \"cuda:0\". We don\'t throw any
     -- exceptions in that case, but the log is still helpful
     CouldntMoveTensor String
+  | -- @inferno-ml-server@ was last killed due to an OOM event; the time at
+    -- restart is recorded if possible
+    OomKilled (Maybe UTCTime)
   | OtherWarn Text
   deriving stock (Show, Eq, Generic)
   deriving anyclass (ToJSON, FromJSON)

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
@@ -1133,8 +1133,8 @@ data TraceWarn p
     -- exceptions in that case, but the log is still helpful
     CouldntMoveTensor String
   | -- @inferno-ml-server@ was last killed due to an OOM event; the time at
-    -- restart is recorded if possible
-    OomKilled (Maybe UTCTime)
+    -- restart is recorded
+    OomKilled UTCTime
   | OtherWarn Text
   deriving stock (Show, Eq, Generic)
   deriving anyclass (ToJSON, FromJSON)

--- a/inferno-ml-server/CHANGELOG.md
+++ b/inferno-ml-server/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Revision History for `inferno-ml-server`
 
+## 2025.9.16
+* Log information about most recent OOM event on startup
+
 ## 2025.6.10
 * Updates for introduction of `inferno-ml-compat`
 

--- a/inferno-ml-server/inferno-ml-server.cabal
+++ b/inferno-ml-server/inferno-ml-server.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               inferno-ml-server
-version:            2025.6.10
+version:            2025.9.16
 synopsis:           Server for Inferno ML
 description:        Server for Inferno ML
 homepage:           https://github.com/plow-technologies/inferno.git#readme

--- a/inferno-ml-server/src/Inferno/ML/Server.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server.hs
@@ -102,6 +102,9 @@ runInEnv cfg f =
         -- No `oom_kill` was triggered before this server start, so no warning
         False -> pure Nothing
         True -> do
+          -- The contents of `/var/lib/inferno-ml-server/last-oom` is just
+          -- the UTC time of when the system process was killed because of
+          -- an OOM event
           contents <- Text.unpack . Text.strip <$> Text.IO.readFile lastOomPath
           -- Fall back to current time if the file contents can't be parsed
           -- as a `UTCTime`. The time is only used for logging as a convenience

--- a/inferno-ml-server/src/Inferno/ML/Server.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server.hs
@@ -96,6 +96,11 @@ runInEnv cfg f =
           <*> newIORef mempty
           <*> newIORef Nothing
   where
+    -- See if we are restarting from a recent OOM event, i.e. the systemd service
+    -- manager stopped the service because it exceeded its `MemoryMax` and
+    -- the `OOMPolicy` was invoked. This leaves a breadcrumb file in the state
+    -- directory. If it exists, the time when OOM was invoked it returned and
+    -- the file is removed
     wasOomKilled :: IO (Maybe UTCTime)
     wasOomKilled =
       doesPathExist lastOomPath >>= \case

--- a/inferno-ml-server/src/Inferno/ML/Server/Log.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Log.hs
@@ -6,7 +6,6 @@ module Inferno.ML.Server.Log where
 
 import Control.Exception (displayException)
 import Control.Monad (when)
-import Data.Function ((&))
 import Control.Monad.Reader (runReaderT)
 import qualified Data.ByteString.Lazy as LBS
 import Data.Functor.Contravariant (contramap)
@@ -70,11 +69,12 @@ traceRemote = \case
           [ "Couldn't move tensor to device"
           , dev
           ]
-    OomKilled mutc ->
+    OomKilled time ->
       Text.pack $
         unwords
           [ "Server is restarting from out-of-memory event"
-          , mutc & maybe mempty (("triggered at "  <>) . show)
+          , "triggered at"
+          , show time
           ]
     OtherWarn t -> t
   ErrorTrace e -> err . Text.pack $ displayException e

--- a/inferno-ml-server/src/Inferno/ML/Server/Log.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Log.hs
@@ -136,7 +136,10 @@ withRemoteTracer instanceId pool f = withAsyncHandleIOTracers stdout stderr $
         shallPersist :: RemoteTrace -> Bool
         shallPersist = \case
           InfoTrace _ -> False
-          WarnTrace _ -> False
+          -- Having `LevelWarn` traces show up helps with debugging; the
+          -- server does not generate many of these, so it shouldn't overwhelm
+          -- the DB with garbage messages (unlike `LevelInfo`)
+          WarnTrace _ -> True
           ErrorTrace err -> case err of
             CacheSizeExceeded -> False
             NoSuchModel{} -> True

--- a/inferno-ml-server/src/Inferno/ML/Server/Log.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Log.hs
@@ -6,6 +6,7 @@ module Inferno.ML.Server.Log where
 
 import Control.Exception (displayException)
 import Control.Monad (when)
+import Data.Function ((&))
 import Control.Monad.Reader (runReaderT)
 import qualified Data.ByteString.Lazy as LBS
 import Data.Functor.Contravariant (contramap)
@@ -68,6 +69,12 @@ traceRemote = \case
         unwords
           [ "Couldn't move tensor to device"
           , dev
+          ]
+    OomKilled mutc ->
+      Text.pack $
+        unwords
+          [ "Server is restarting from out-of-memory event"
+          , mutc & maybe mempty (("triggered at "  <>) . show)
           ]
     OtherWarn t -> t
   ErrorTrace e -> err . Text.pack $ displayException e

--- a/inferno-ml-server/src/Inferno/ML/Server/Utils.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Utils.hs
@@ -10,6 +10,7 @@ module Inferno.ML.Server.Utils
     queryStore,
     executeStore,
     withConns,
+    lastOomPath,
   )
 where
 
@@ -73,3 +74,9 @@ firstOrThrow e = maybe (throwM e) pure . (!? 0)
 withConns :: (HasPool r m) => (Connection -> m b) -> m b
 withConns f = view typed >>= \cs -> withRunInIO $ \r -> withResource cs $ r . f
 {-# INLINE withConns #-}
+
+-- | This path is written to as part of the @inferno-ml-server@ @ExecStopPost@
+-- if an OOM kill event is the @SERVICE_RESULT@. This is read at startup to
+-- log a warning if we just restarted the server due to an OOM kill
+lastOomPath :: FilePath
+lastOomPath = "/var/lib/inferno-ml-server/last-oom"

--- a/nix/inferno-ml/modules/inferno-ml-server.nix
+++ b/nix/inferno-ml/modules/inferno-ml-server.nix
@@ -171,6 +171,26 @@ in
             PrivateTmp = "yes";
             ProtectDevices = "yes";
             NoNewPrivileges = "yes";
+            # OOM settings. We don't want the system to slow to a crawl when
+            # it starts consuming too much memory.
+            #
+            # NOTE: This does not use `stop` as the `OOMPolicy` as it would not
+            # restart the server process. We unfortunately need to use `kill`,
+            # i.e. the server receives a `SIGKILL` from the kernel. But the
+            # server will restart afterwards
+            #
+            # Because `inferno-ml-server` and any child processes it may spawn
+            # are basically the only thing running on the system of any importance,
+            # we can reserver a fairly high amount of memory
+            MemoryHigh = "85%";
+            MemoryMax = "95%";
+            MemorySwapMax = "0";
+            OOMPolicy = "kill";
+            # This is to give the process access to the memory usage information
+            # under `/sys/fs/cgroup/...` (for currently unimplemented in-app
+            # memory monitoring)
+            ProtectControlGroups = false;
+            ReadOnlyPaths = [ "/sys/fs/cgroup" ];
           };
         };
 

--- a/nix/inferno-ml/modules/inferno-ml-server.nix
+++ b/nix/inferno-ml/modules/inferno-ml-server.nix
@@ -178,28 +178,30 @@ in
             PrivateTmp = "yes";
             ProtectDevices = "yes";
             NoNewPrivileges = "yes";
+            StateDirectory = "inferno-ml-server";
+            # Leave breadcrumb for OOM kills so we can check at startup if we
+            # just got killed by OOM; needs to be removed by `inferno-ml-server`
+            # afterwards
+            ExecStopPost =
+              "/bin/sh -c 'test $SERVICE_RESULT = oom-kill && echo $(date -Is) > /var/lib/inferno-ml-server/last-oom'";
             # OOM settings. We don't want the system to slow to a crawl when
             # it starts consuming too much memory. We also omit `MemoryHigh`,
             # as this would just cause the server to slow to a crawl as the
             # kernel starts to reclaim memory from the process (basically causing
             # what we want to avoid)
             #
-            # NOTE: This does not use `stop` as the `OOMPolicy` as it would not
-            # restart the server process. We unfortunately need to use `kill`,
-            # i.e. the server receives a `SIGKILL` from the kernel. But the
-            # server will restart afterwards
-            #
             # Because `inferno-ml-server` and any child processes it may spawn
             # are basically the only thing running on the system of any importance,
             # we can reserver a fairly high amount of memory
             MemoryMax = "90%";
             MemorySwapMax = "0";
-            OOMPolicy = "kill";
+            OOMPolicy = "stop";
             # This is to give the process access to the memory usage information
             # under `/sys/fs/cgroup/...` (for currently unimplemented in-app
             # memory monitoring)
             ProtectControlGroups = false;
             ReadOnlyPaths = [ "/sys/fs/cgroup" ];
+            SupplementaryGroups= "systemd-journal";
           };
         };
 

--- a/nix/inferno-ml/modules/inferno-ml-server.nix
+++ b/nix/inferno-ml/modules/inferno-ml-server.nix
@@ -183,7 +183,8 @@ in
             # just got killed by OOM; needs to be removed by `inferno-ml-server`
             # afterwards
             ExecStopPost =
-              "/bin/sh -c 'test $SERVICE_RESULT = oom-kill && echo $(date -Is) > /var/lib/inferno-ml-server/last-oom'";
+              "/bin/sh -c 'test $SERVICE_RESULT = oom-kill && echo $(date -u --rfc-3339=seconds)"
+              + " > /var/lib/inferno-ml-server/last-oom'";
             # OOM settings. We don't want the system to slow to a crawl when
             # it starts consuming too much memory. We also omit `MemoryHigh`,
             # as this would just cause the server to slow to a crawl as the
@@ -201,7 +202,7 @@ in
             # memory monitoring)
             ProtectControlGroups = false;
             ReadOnlyPaths = [ "/sys/fs/cgroup" ];
-            SupplementaryGroups= "systemd-journal";
+            SupplementaryGroups = "systemd-journal";
           };
         };
 

--- a/nix/inferno-ml/modules/inferno-ml-server.nix
+++ b/nix/inferno-ml/modules/inferno-ml-server.nix
@@ -192,7 +192,7 @@ in
             #
             # Because `inferno-ml-server` and any child processes it may spawn
             # are basically the only thing running on the system of any importance,
-            # we can reserver a fairly high amount of memory
+            # we can reserve a fairly high amount of memory
             MemoryMax = "90%";
             MemorySwapMax = "0";
             OOMPolicy = "stop";

--- a/nix/inferno-ml/modules/inferno-ml-server.nix
+++ b/nix/inferno-ml/modules/inferno-ml-server.nix
@@ -63,6 +63,18 @@ in
                   "Number of seconds for script eval timeout";
               };
 
+              memoryMax = lib.mkOption {
+                type = lib.types.ints.between 1 100;
+                default = 95;
+                description =
+                  lib.mdDoc
+                    ''
+                      Percentage of total system memory the server process is allowed
+                      to consume; after reaching this threshold, the server process is
+                      OOM-killed and restarted
+                    '';
+              };
+
               instanceId = lib.mkOption {
                 type = lib.types.nullOr lib.types.str;
                 default = null;
@@ -194,7 +206,7 @@ in
             # Because `inferno-ml-server` and any child processes it may spawn
             # are basically the only thing running on the system of any importance,
             # we can reserve a fairly high amount of memory
-            MemoryMax = "90%";
+            MemoryMax = "${builtins.toString configuration.memoryMax}%";
             MemorySwapMax = "0";
             OOMPolicy = "stop";
             # This is to give the process access to the memory usage information


### PR DESCRIPTION
- Adds an `OOMPolicy` for the `inferno-ml-server` process with `MemoryMax` as a percentage of system memory
- Adds warning logs if the server is restarting from an OOM event (helpful for debugging)
- Adds `configuration.memoryMax` to the NixOS config for the server with corresponding adjustments on the Haskell type

This is needed because scripts can sometimes consume all system memory until kernel memory reclamation begins and the entire system slows to a crawl and freezes from a user's point of view. It's better to just kill the process and restart it in this case, otherwise we can't even e.g. poll the process status. A subsequent PR will add in-process memory monitoring to preempt the OOM and just kill the thread that's evaluating the script, but that's a different task (and requires the cgroup information that's created by introducing the `OOMPolicy` to the systemd service).

Example log after triggering OOM:

```
inferno-ml-server[1143]: 2025-09-12 08:41:30.863259853 UTC: [WARN] Server is restarting from out-of-memory event triggered at 2025-09-12 08:41:25 UTC
```