### PR TITLE
[inferno-core] Add `Time.parseTime`

### DIFF
--- a/inferno-core/CHANGELOG.md
+++ b/inferno-core/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Revision History for inferno-core
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.11.6.4 -- 2025-09-18
+* Add `Time.parseTime`
+
 ## 0.11.6.3 -- 2025-07-03
 * Add `mkPreludeDocs` functionality
 

--- a/inferno-core/inferno-core.cabal
+++ b/inferno-core/inferno-core.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               inferno-core
-version:            0.11.6.3
+version:            0.11.6.4
 synopsis:           A statically-typed functional scripting language
 description:
   Parser, type inference, and interpreter for a statically-typed functional scripting language

--- a/inferno-core/src/Inferno/Module/Prelude.hs
+++ b/inferno-core/src/Inferno/Module/Prelude.hs
@@ -81,6 +81,7 @@ import Inferno.Module.Prelude.Defs
     neqFun,
     normFun,
     orFun,
+    parseTimeFun,
     piFun,
     powFun,
     randomFun,
@@ -571,6 +572,13 @@ module Time
 
   @doc Format time to string;
   formatTime : time -> text -> text := ###formatTime###;
+
+  @doc `parseTime format str` parses the string input `str` into a `time` value
+  using the provided `format` string. If `str` cannot be parsed according to
+  `format`, then `None` is returned, otherwise `Some time`
+
+  Example: `parseTime "%Y-%m-%d %H:%M:%S" "2025-09-17 07:23:46" == Some (toTime (seconds 1758093826))`;
+  parseTime : time -> text -> option of time := ###!parseTimeFun###;
 
 module Word
 

--- a/inferno-core/src/Inferno/Module/Prelude.hs
+++ b/inferno-core/src/Inferno/Module/Prelude.hs
@@ -581,7 +581,7 @@ module Time
 
   For available format characters, please see the documentation for
   https://hackage-content.haskell.org/package/time-1.15/docs/Data-Time-Format.html#v:formatTime;
-  parseTime : time -> text -> option of time := ###!parseTimeFun###;
+  parseTime : text -> text -> option of time := ###!parseTimeFun###;
 
 module Word
 

--- a/inferno-core/src/Inferno/Module/Prelude.hs
+++ b/inferno-core/src/Inferno/Module/Prelude.hs
@@ -577,7 +577,10 @@ module Time
   using the provided `format` string. If `str` cannot be parsed according to
   `format`, then `None` is returned, otherwise `Some time`
 
-  Example: `parseTime "%Y-%m-%d %H:%M:%S" "2025-09-17 07:23:46" == Some (toTime (seconds 1758093826))`;
+  Example: `parseTime "%Y-%m-%d %H:%M:%S" "2025-09-17 07:23:46" == Some (toTime (seconds 1758093826))`
+
+  For available format characters, please see the documentation for
+  https://hackage-content.haskell.org/package/time-1.15/docs/Data-Time-Format.html#v:formatTime;
   parseTime : time -> text -> option of time := ###!parseTimeFun###;
 
 module Word

--- a/inferno-core/test/Eval/Spec.hs
+++ b/inferno-core/test/Eval/Spec.hs
@@ -355,6 +355,16 @@ evalTests = describe "evaluate" $
       vTrue
     shouldEvaluateTo "Time.formatTime (Time.toTime (Time.seconds 0)) \"%H:%M:%S\"" $ VText "00:00:00"
     shouldEvaluateTo "Time.formatTime (Time.toTime (Time.seconds 0)) \"%c\"" $ VText "Thu Jan  1 00:00:00 UTC 1970"
+    shouldEvaluateTo "Time.parseTime \"%Y-%m-%d %H:%M:%S\" \"2025-09-17 07:23:46\"" . VOne $
+      VEpochTime 1758093826
+    shouldEvaluateTo "Time.parseTime \"%a, %d %b %Y %H:%M:%S UTC\" \"Fri, 05 May 2000 23:59:59 UTC\"" . VOne $
+      VEpochTime 957571199
+    shouldEvaluateTo "Time.parseTime \"%d/%m/%Y %H:%M\" \"07/01/2014 09:55\"" . VOne $
+      VEpochTime 1389088500
+    shouldEvaluateTo "Time.parseTime \"%Y-%m-%dT%H:%M:%SZ\" \"2025-09-18T10:32:45Z\"" . VOne $
+      VEpochTime 1758191565
+    shouldEvaluateTo "Time.parseTime \"%Y%m%d%H%M%S\" \"19991231235959\"" . VOne $
+      VEpochTime 946684799
     -- Text
     shouldEvaluateTo "Text.append \"hello \" \"world\"" $ VText "hello world"
     shouldEvaluateTo "Text.length \"hello\"" $ VInt 5


### PR DESCRIPTION
Adds a wrapper around `Data.Time.Format.parseTimeM` so we can parse text inputs into `option of time`s with a user-provided format string.