### PR TITLE
[inferno-ml] Catch exceptions in `toDevice` implementation

### DIFF
--- a/inferno-ml-server/CHANGELOG.md
+++ b/inferno-ml-server/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Revision History for `inferno-ml-server`
 
+## 2025.10.3
+* Catch/rethrow any synchronous exceptions from `toDeviceIO`
+
 ## 2025.9.16
 * Log information about most recent OOM event on startup
 

--- a/inferno-ml-server/inferno-ml-server.cabal
+++ b/inferno-ml-server/inferno-ml-server.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               inferno-ml-server
-version:            2025.9.16
+version:            2025.10.3
 synopsis:           Server for Inferno ML
 description:        Server for Inferno ML
 homepage:           https://github.com/plow-technologies/inferno.git#readme

--- a/inferno-ml-server/src/Inferno/ML/Server/Log.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Log.hs
@@ -146,7 +146,12 @@ withRemoteTracer instanceId pool f = withAsyncHandleIOTracers stdout stderr $
           -- Having `LevelWarn` traces show up helps with debugging; the
           -- server does not generate many of these, so it shouldn't overwhelm
           -- the DB with garbage messages (unlike `LevelInfo`)
-          WarnTrace _ -> True
+          WarnTrace warn -> case warn of
+            CouldntMoveTensor{} -> True
+            OomKilled{} -> True
+            OtherWarn{} -> True
+            -- This one is not really necessary for debugging
+            CancelingInference{} -> False
           ErrorTrace err -> case err of
             CacheSizeExceeded -> False
             NoSuchModel{} -> True

--- a/inferno-ml-server/src/Inferno/ML/Server/Module/Prelude.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Module/Prelude.hs
@@ -366,7 +366,10 @@ toDeviceIO device t0 =
       -- move a tensor to `cuda:0` when only `cpu` is available). So in this case
       -- a warning is logged (in the script evaluator) and the original tensor is
       -- returned
-      | isJust $ fromException @ErrorCall e -> pure $ Right t0
+      --
+      -- Note that `Left` here indicates that the tensor was NOT moved, and a
+      -- warning will be logged from script evaluator
+      | isJust $ fromException @ErrorCall e -> pure $ Left t0
       | otherwise ->
           throwM . RuntimeError $
             unwords


### PR DESCRIPTION
We might get a `CppException` in `toDevice`, which we should catch and rethrow as a `RuntimeError`. Just in case other exceptions are thrown, any synchronous exception is caught and rethrown now too. The previous behavior with `ErrorCall` (i.e. `error` from Hasktorch for the wrong device) is preserved