### PR TITLE
[inferno-ml] Add in-process memory monitor to preempt systemd OOM

### DIFF
--- a/inferno-ml-server-types/CHANGELOG.md
+++ b/inferno-ml-server-types/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Revision History for inferno-ml-server-types
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.21.0
+* Add `MemoryLimitExceeded` error ctor for OOM threshold breach
+
 ## 0.20.0
 * Add `OomKilled` warning trace
 

--- a/inferno-ml-server-types/inferno-ml-server-types.cabal
+++ b/inferno-ml-server-types/inferno-ml-server-types.cabal
@@ -44,6 +44,7 @@ library
     , base
     , base64-bytestring
     , bytestring
+    , byteunits
     , conduit
     , containers
     , cryptonite

--- a/inferno-ml-server-types/inferno-ml-server-types.cabal
+++ b/inferno-ml-server-types/inferno-ml-server-types.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          inferno-ml-server-types
-version:       0.20.0
+version:       0.21.0
 synopsis:      Types for Inferno ML server
 description:   Types for Inferno ML server
 homepage:      https://github.com/plow-technologies/inferno.git#readme

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
@@ -1025,8 +1025,8 @@ data RemoteError p m mv
   | -- | A script evaluation has used too much memory and has been killed
     -- (in-process), pre-empting systemd OOM
     MemoryLimitExceeded
-    -- | Actual memory usage at time of exception
-    Word64
+      -- | Actual memory usage at time of exception
+      Word64
   | DbError String
   | ClientError (Id p) String
   | OtherRemoteError Text

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
@@ -1155,8 +1155,8 @@ data TraceWarn p
     OomKilled UTCTime
   | -- | Memory monitoring will not work due to e.g. missing cgroup information
     CantMonitorMemory
-    -- | Details
-    Text
+      -- | Details
+      Text
   | OtherWarn Text
   deriving stock (Show, Eq, Generic)
   deriving anyclass (ToJSON, FromJSON)

--- a/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server-types/src/Inferno/ML/Server/Types.hs
@@ -1100,7 +1100,7 @@ instance (Typeable p, Typeable m, Typeable mv) => Exception (RemoteError p m mv)
         ]
     MemoryLimitExceeded limit usage ->
       unwords
-        [ "Memory usage of evaluator has exceeded limit;"
+        [ "Memory usage of script evaluator has exceeded limit;"
         , "limit:"
         , show limit <> ","
         , "usage:"

--- a/inferno-ml-server/CHANGELOG.md
+++ b/inferno-ml-server/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Revision History for `inferno-ml-server`
 
+## 2025.10.7
+* Add in-process memory monitor for OOM threshold
+
 ## 2025.10.3
 * Catch/rethrow any synchronous exceptions from `toDeviceIO`
 

--- a/inferno-ml-server/inferno-ml-server.cabal
+++ b/inferno-ml-server/inferno-ml-server.cabal
@@ -86,6 +86,7 @@ library
     , template-haskell
     , text
     , time
+    , unix
     , unliftio
     , uuid
     , vector

--- a/inferno-ml-server/inferno-ml-server.cabal
+++ b/inferno-ml-server/inferno-ml-server.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               inferno-ml-server
-version:            2025.10.3
+version:            2025.10.7
 synopsis:           Server for Inferno ML
 description:        Server for Inferno ML
 homepage:           https://github.com/plow-technologies/inferno.git#readme

--- a/inferno-ml-server/src/Inferno/ML/Server.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server.hs
@@ -163,6 +163,7 @@ infernoMlRemote env = serve api $ hoistServer api (`toHandler` env) server
             e@InfernoError{} -> errWith err500 e
             e@NoBridgeSaved{} -> errWith err500 e
             e@ScriptTimeout{} -> errWith err500 e
+            e@MemoryLimitExceeded{} -> errWith err500 e
             e@DbError{} -> errWith err500 e
             e@ClientError{} -> errWith err500 e
 

--- a/inferno-ml-server/src/Inferno/ML/Server.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server.hs
@@ -93,6 +93,7 @@ runInEnv cfg f =
           <$> newMVar ()
           <*> newEmptyMVar
           <*> newManager defaultManagerSettings
+          <*> getMemoryMax
           <*> newIORef mempty
           <*> newIORef Nothing
   where

--- a/inferno-ml-server/src/Inferno/ML/Server/Inference.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Inference.hs
@@ -181,7 +181,10 @@ runInferenceParamWithEnv ::
   ScriptEnv ->
   RemoteM (WriteStream IO)
 runInferenceParamWithEnv ipid uuid senv =
-  withTimeoutMillis $ \t -> do
+  -- This enforces that the script will finish execution within its given
+  -- time limit (`withTimeoutMillis`) and that it will not consume up to or
+  -- beyond the `MemoryMax` defined in its systemd service configuration
+  withMemoryMonitor . withTimeoutMillis $ \t -> do
     logInfo $ RunningInference ipid t
     -- Clear the "console" before running the script, so any calls to
     -- `Print.print` will write to a fresh console

--- a/inferno-ml-server/src/Inferno/ML/Server/Log.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Log.hs
@@ -76,6 +76,12 @@ traceRemote = \case
           , "triggered at"
           , show time
           ]
+    CantMonitorMemory details ->
+      Text.unwords
+        [ details <> ","
+        , "cannot monitor memory usage;"
+        , "running action without memory monitoring"
+        ]
     OtherWarn t -> t
   ErrorTrace e -> err . Text.pack $ displayException e
   where
@@ -157,9 +163,10 @@ withRemoteTracer instanceId pool f = withAsyncHandleIOTracers stdout stderr $
             InfernoError{} -> True
             NoBridgeSaved{} -> True
             ScriptTimeout{} -> True
+            MemoryLimitExceeded{} -> True
             DbError{} -> True
             ClientError{} -> True
-            OtherRemoteError{} -> False
+            OtherRemoteError{} -> True
 
         printMessage :: Message -> Either Text Text
         printMessage (Message level stream) = case stream of

--- a/inferno-ml-server/src/Inferno/ML/Server/Log.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Log.hs
@@ -156,6 +156,7 @@ withRemoteTracer instanceId pool f = withAsyncHandleIOTracers stdout stderr $
             CouldntMoveTensor{} -> True
             OomKilled{} -> True
             OtherWarn{} -> True
+            CantMonitorMemory{} -> True
             -- This one is not really necessary for debugging
             CancelingInference{} -> False
           ErrorTrace err -> case err of

--- a/inferno-ml-server/src/Inferno/ML/Server/Types.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Types.hs
@@ -132,6 +132,11 @@ data Env = Env
           Async (Maybe (Types.WriteStream IO))
         )
   , manager :: Manager
+  , -- Maximum memory in bytes that the server process is allowed to use; if
+    -- this is `Nothing`, the cgroup information does not exist or is not
+    -- readable as bytes. In this case, no in-process memory monitoring will
+    -- be used
+    memoryMax :: Maybe Word64
   , -- Prints to the console. This is cleared before every script evaluation
     console :: IORef (Seq Text)
   , -- The interpreter needs to be updated if the bridge info changes,

--- a/inferno-ml-server/src/Inferno/ML/Server/Utils.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Utils.hs
@@ -43,15 +43,17 @@ import Database.PostgreSQL.Simple.Vector (query)
 import Inferno.ML.Server.Types
 import Inferno.VersionControl.Types (VCObjectHash)
 import Lens.Micro.Platform (view)
+import System.Exit (ExitCode (ExitFailure))
 import System.FilePath ((</>))
 import System.IO.Error
   ( isEOFError,
     isIllegalOperation,
     isResourceVanishedError,
   )
+import System.Posix.Process (exitImmediately)
 import UnliftIO (MonadUnliftIO (withRunInIO))
 import UnliftIO.Async (cancel, waitEitherCatch, withAsync)
-import UnliftIO.Concurrent (threadDelay)
+import UnliftIO.Concurrent (forkIO, threadDelay)
 import UnliftIO.Directory (doesPathExist)
 import UnliftIO.Exception
   ( SomeException,
@@ -59,6 +61,8 @@ import UnliftIO.Exception
     catchJust,
     displayException,
     fromException,
+    mask_,
+    throwIO,
   )
 import UnliftIO.IO
   ( Handle,
@@ -108,7 +112,8 @@ withConns f = view typed >>= \cs -> withRunInIO $ \r -> withResource cs $ r . f
 -- | Try to run a @RemoteM@ process while monitoring its memory usage. If
 -- the value of the process @memory.current@ comes within a close threshold of
 -- the server\'s @MemoryMax@ acccording to its systemd service configuration,
--- the action is cancelled and an exception is raised
+-- the action is cancelled and an exception is raised. The server process is
+-- restarted to reclaim memory
 --
 -- NOTE: If the cgroup @memory.max@ information is missing or unreadable at the
 -- time of server start, the provided @RemoteM@ action is run /without/ memory
@@ -116,10 +121,8 @@ withConns f = view typed >>= \cs -> withRunInIO $ \r -> withResource cs $ r . f
 --
 -- Even without the active monitor below, if the entire server process exceeds
 -- @MemoryMax@ it will be stopped and restarted. However, it\'s preferable to
--- stop a single action within the server and keep the server running rather
--- than stopping and re-starting the entire process. First, we can still service
--- other endpoints, e.g. @/status@. Second, we can return a more meaningful
--- error message
+-- first return the response with the exception as the response body for a more
+-- meaningful error message
 --
 -- NOTE: This is really only meant to be used with the script evaluator, which
 -- is the only server endpoint that can consume a significant amount of memory.
@@ -149,6 +152,19 @@ withMemoryMonitor f =
                   -- cancel `f` and re-throw the exception
                   Left (Left e) -> do
                     cancel inner
+                    -- Schedule a restart for 500ms from now, giving enough time
+                    -- for warp handler to send the response with the correct body
+                    -- (i.e. the synchronously rethrown exception below). Exit
+                    -- code of 1 for generic non-success
+                    --
+                    -- NOTE: We do a restart here because even try to force
+                    -- memory reclamation both Torch FFI and Haskell GC does
+                    -- not seem to free enough memory. Then we are stuck in
+                    -- a position where the memory monitor will fail, but we
+                    -- don't get restarted by systemd. However, here we can send
+                    -- the response with a clear body describing the problem and
+                    -- release the memory by killing the process
+                    scheduleSelfRestart 500000 1
                     throwRemoteError $ toRemoteError e
                   -- Should never happen; monitor runs in infinite loop until it
                   -- throws an exception
@@ -192,7 +208,8 @@ withMemoryMonitor f =
               -- which propagates to the calling thread, which also includes the
               -- `RemoteM` effect in its child scope, i.e. also killing it
               when (current >= limit) $
-                throwRemoteError $ MemoryLimitExceeded memMax current
+                throwRemoteError $
+                  MemoryLimitExceeded memMax current
           -- Wait 200ms
           threadDelay 200000
           where
@@ -238,13 +255,14 @@ withMemoryMonitor f =
 -- | Get the maximum memory in bytes that the server process can use according
 -- to its systemd policy. Note:
 --   * if the cgroup @memory.max@ does not exist, @Nothing@ is returned
---   * unparseable contents such as @infinity@, etc... will result in @Nothing@
+--   * unparseable contents such as @infinity@, @max@ etc... also return @Nothing@
 --
 -- This is a constant value and depends on the value of the @MemoryMax@ defined
 -- for the server\'s systemd service
 getMemoryMax :: (MonadIO m) => m (Maybe Word64)
 getMemoryMax = getCgroupMemInfo "memory.max"
 
+-- | Try to parse memory in bytes from a file under the server cgroup directory
 getCgroupMemInfo ::
   (MonadIO m) =>
   -- | Path to relevant file in cgroup directory, e.g. @memory.max@, @memory.current@
@@ -271,3 +289,20 @@ cgroupPath = "/sys/fs/cgroup/system.slice/inferno-ml-server.service"
 -- log a warning if we just restarted the server due to an OOM kill
 lastOomPath :: FilePath
 lastOomPath = "/var/lib/inferno-ml-server/last-oom"
+
+-- | Force a restart of the entire server process internally. This forks a
+-- thread that waits for the given amount of microseconds before exiting
+-- immediately.
+--
+-- NOTE: Exit code MUST be non-zero for systemd to restart service
+scheduleSelfRestart :: (MonadUnliftIO m) => Int -> Int -> m ()
+scheduleSelfRestart micros code
+  | code <= 0 = throwIO $ userError "`scheduleRestart`: exit code must be non-zero"
+  | otherwise =
+      -- NOTE: `mask_` here because we DON'T want to be killed by any async
+      -- exceptions. This is meant to kill the process without any interruption
+      mask_ . void . forkIO $ do
+        -- Delaying gives Warp the necessary amount of time for the response to
+        -- be sent
+        threadDelay micros
+        liftIO . exitImmediately $ ExitFailure code

--- a/inferno-ml-server/src/Inferno/ML/Server/Utils.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Utils.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Inferno.ML.Server.Utils
@@ -164,7 +165,7 @@ withMemoryMonitor f =
                     -- don't get restarted by systemd. However, here we can send
                     -- the response with a clear body describing the problem and
                     -- release the memory by killing the process
-                    scheduleSelfRestart 500000 1
+                    scheduleSelfRestart 500_000 1
                     throwRemoteError $ toRemoteError e
                   -- Should never happen; monitor runs in infinite loop until it
                   -- throws an exception
@@ -207,11 +208,10 @@ withMemoryMonitor f =
               -- the OOM killer is likely to be invoked. This throws an exception,
               -- which propagates to the calling thread, which also includes the
               -- `RemoteM` effect in its child scope, i.e. also killing it
-              when (current >= limit) $
-                throwRemoteError $
-                  MemoryLimitExceeded memMax current
+              when (current >= limit) . throwRemoteError $
+                MemoryLimitExceeded current
           -- Wait 200ms
-          threadDelay 200000
+          threadDelay 200_000
           where
             -- Try to read the `Word64` (memory in bytes) from the open file handle
             readMemoryCurrent :: RemoteM (Maybe Word64)

--- a/inferno-ml-server/src/Inferno/ML/Server/Utils.hs
+++ b/inferno-ml-server/src/Inferno/ML/Server/Utils.hs
@@ -10,18 +10,22 @@ module Inferno.ML.Server.Utils
     queryStore,
     executeStore,
     withConns,
+    getMemoryMax,
+    getMemoryCurrent,
     lastOomPath,
   )
 where
 
 import Control.Monad (void)
 import Control.Monad.Catch (Exception, MonadCatch, MonadThrow (throwM))
-import Control.Monad.IO.Class (liftIO)
+import Control.Monad.IO.Class (MonadIO (liftIO))
 import Control.Monad.Reader (MonadReader)
+import qualified Data.ByteString.Char8 as ByteString.Char8
 import Data.Generics.Labels ()
 import Data.Generics.Product (HasType (typed))
 import Data.Pool (Pool, withResource)
 import Data.Vector (Vector, (!?))
+import Data.Word (Word64)
 import Database.PostgreSQL.Simple
   ( Connection,
     FromRow,
@@ -35,7 +39,9 @@ import Database.PostgreSQL.Simple.Vector (query)
 import Inferno.ML.Server.Types
 import Inferno.VersionControl.Types (VCObjectHash)
 import Lens.Micro.Platform (view)
+import System.FilePath ((</>))
 import UnliftIO (MonadUnliftIO (withRunInIO))
+import UnliftIO.Directory (doesPathExist)
 import UnliftIO.Exception (catch, displayException)
 
 throwRemoteError :: RemoteError -> RemoteM a
@@ -74,6 +80,43 @@ firstOrThrow e = maybe (throwM e) pure . (!? 0)
 withConns :: (HasPool r m) => (Connection -> m b) -> m b
 withConns f = view typed >>= \cs -> withRunInIO $ \r -> withResource cs $ r . f
 {-# INLINE withConns #-}
+
+-- | Get the maximum memory in bytes that the server process can use according
+-- to its systemd policy. Note:
+--   * if the cgroup @memory.max@ does not exist, @Nothing@ is returned
+--   * unparseable contents such as @infinity@, etc... will result in @Nothing@
+--
+-- This is a constant value
+getMemoryMax :: (MonadIO m) => m (Maybe Word64)
+getMemoryMax = getCgroupMemInfo "memory.max"
+
+-- | Get the server\'s current memory usage in bytes using its cgroup information.
+-- Note:
+--   * if the cgroup @memory.current@ does not exist, @Nothing@ is returned
+--   * unparseable contents will result in @Nothing@
+getMemoryCurrent :: (MonadIO m) => m (Maybe Word64)
+getMemoryCurrent = getCgroupMemInfo "memory.current"
+
+getCgroupMemInfo ::
+  (MonadIO m) =>
+  -- | Path to relevant file in cgroup directory, e.g. @memory.max@, @memory.current@
+  FilePath ->
+  m (Maybe Word64)
+getCgroupMemInfo fp =
+  doesPathExist path >>= \case
+    False -> pure Nothing
+    True ->
+      fmap fst . ByteString.Char8.readWord64
+        <$> liftIO (ByteString.Char8.readFile path)
+  where
+    path :: FilePath
+    path = cgroupPath </> fp
+
+-- | Path to the cgroup information for the @inferno-ml-server@ systemd service.
+-- This is needed for e.g. getting information on current memory usage. Note
+-- that this path is readable for the @inferno@ user, including its contents
+cgroupPath :: FilePath
+cgroupPath = "/sys/fs/cgroup/system.slice/inferno-ml-server.service"
 
 -- | This path is written to as part of the @inferno-ml-server@ @ExecStopPost@
 -- if an OOM kill event is the @SERVICE_RESULT@. This is read at startup to


### PR DESCRIPTION
Adds an in-process monitor for memory usage during script evaluation by reading the cgroup memory information for the `inferno-ml-server` systemd service. If we get close to the OOM threshold, the server will respond with an error message and then restart itself. This avoids having script evaluation interrupted **without** an error message, which is the case currently. Since we have `Restart=always` defined for the systemd service, the process memory is freed and the service restarts.

At first I wanted to avoid having the restart, but despite my best efforts I could not get GHC or libc arenas (from Torch FFI) to free enough memory. That would leave us in a state where memory was still allocated but not freed, and any subsequent script evaluations would fail. We would still get the error message, but the server would need to be manually restarted to free all of the memory. So instead a self-restart is scheduled after Warp has enough time to serve the request with the error details.

Another alternative would be to run script evaluation within a separate process within systemd constraints, but that would involve rewriting a significant portion of `inferno-ml-server` and we don't have the time for that.

Now if we are close enough to the OOM threshold we'll see error messages like this:

```
"Memory usage of script evaluator has exceeded limit, script evaluation memory usage: 0.07 GB"
``` 

(note that I had to intentionally lower the OOM threshold to 7% of system memory to get the error message, a bit contrived but illustrates the principle)