### PR TITLE
[inferno-lsp] Increase parse and typecheck timeout to two minutes

### DIFF
--- a/inferno-lsp/CHANGELOG.md
+++ b/inferno-lsp/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Revision History for inferno-lsp
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.2.6.3 -- 2026-04-06
+* Increase parse and typecheck timeout from 10s to 120s
+
 ## 0.2.6.2 -- 2026-04-01
 * Replace `nub` with `nubOrd`
 

--- a/inferno-lsp/inferno-lsp.cabal
+++ b/inferno-lsp/inferno-lsp.cabal
@@ -1,6 +1,6 @@
 cabal-version:      >=1.10
 name:               inferno-lsp
-version:            0.2.6.2
+version:            0.2.6.3
 synopsis:           LSP for Inferno
 description:
   A language server protocol implementation for the Inferno language

--- a/inferno-lsp/src/Inferno/LSP/Server.hs
+++ b/inferno-lsp/src/Inferno/LSP/Server.hs
@@ -223,8 +223,13 @@ parseAndInferWithTimeout beforeParse afterParse interpreter idents doc_txt valid
 
   liftIO $ beforeParse (uuid, ts)
   result <- do
-    -- Timeout parsing and type checking after 10 seconds
-    let timeLimit = 10
+    -- Timeout parsing and type checking after 120 seconds
+    --
+    -- NOTE This limit was previously 10s but we had actual scripts in test/prod
+    -- time out because parsing and typechecking is so slow. This higher limit
+    -- will make the LSP session appear to "hang" (i.e. no immediate feedback)
+    -- but at least we can save scripts!
+    let timeLimit = 120
     mResult <- liftIO $ timeout (timeLimit * 1_000_000) $ parseAndInferDiagnostics @_ @c interpreter idents doc_txt validateInput
     case mResult of
       Nothing -> pure $ Left [errorDiagnostic 1 1 1 1 (Just "inferno.lsp") $ "Inferno timed out in " <> T.pack (show timeLimit) <> "s"]


### PR DESCRIPTION
This increases the timeout for parsing/typechecking from 10s to 120s. It's a bandaid while I'm working on efficiency/performance improvements in general for Inferno

This is a temporary, required increase. We have actual scripts failing to parse and typecheck within the current limit (!) 