### PR TITLE
[inferno-core] Add parsing+typechecking benchmark

### DIFF
--- a/inferno-core/CHANGELOG.md
+++ b/inferno-core/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Revision History for inferno-core
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.11.6.10 -- 2026-04-08
+* Add `criterion` benchmark suite for parse and type inference
+
 ## 0.11.6.9 -- 2026-04-06
 * Switch from `Set` to `Seq` for constraints in type inference
 * Refactor `infer`, use helper records and field access instead of anonymous tuple projections

--- a/inferno-core/bench/Main.hs
+++ b/inferno-core/bench/Main.hs
@@ -1,0 +1,96 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Main (main) where
+
+import Criterion.Main (bench, bgroup, defaultMain, whnf)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Inferno.Core
+  ( Interpreter (Interpreter, parseAndInferTypeReps),
+    mkInferno,
+  )
+import qualified Inferno.Module.Prelude as Prelude
+import NeatInterpolation (trimming)
+
+main :: IO ()
+main = do
+  Interpreter{parseAndInferTypeReps} <-
+    mkInferno (Prelude.builtinModules @IO @()) []
+  defaultMain
+    [ bgroup
+        "wide"
+        [ bench "100" . whnf parseAndInferTypeReps $ genWide 100
+        , bench "500" . whnf parseAndInferTypeReps $ genWide 500
+        , bench "1000" . whnf parseAndInferTypeReps $ genWide 1000
+        ]
+    , bgroup
+        "deep"
+        [ bench "25" . whnf parseAndInferTypeReps $ genDeep 25
+        , bench "50" . whnf parseAndInferTypeReps $ genDeep 50
+        , bench "100" . whnf parseAndInferTypeReps $ genDeep 100
+        ]
+    ]
+
+-- Generate a script with `n` `let`-bindings chaining simple arithmetic.
+-- Stresses environment growth, scope resolution, and substitution application.
+genWide :: Int -> Text
+genWide n = foldMap binding [0 .. n - 1] <> mconcat ["x", tshow $ n - 1]
+  where
+    binding :: Int -> Text
+    binding 0 = "let x0 = 1.0 in\n"
+    binding i
+      | even i =
+          withNewline [trimming|let x$xi = x$xp + x$xh in|]
+      | otherwise =
+          withNewline [trimming|let x$xi = x$xp + $xi.0 in|]
+      where
+        xi, xp, xh :: Text
+        xi = tshow i
+        xp = tshow $ i - 1
+        xh = tshow $ i `div` 2
+
+-- Generate a script with `n` blocks (~6 bindings each) exercising lambdas,
+-- comprehensions, `Array.reduce`, records, `if`/`then`/`else`, `Some`/`None`,
+-- and `match`. Variables chain across blocks so the type environment grows
+-- realistically.
+genDeep :: Int -> Text
+genDeep n = mconcat [foldMap block [0 .. n - 1], "acc", tshow (n - 1)]
+  where
+    prev :: Int -> Text
+    prev = \case
+      0 -> "1.0"
+      i -> "acc" <> tshow (i - 1)
+
+    block :: Int -> Text
+    block i =
+      withNewline
+        [trimming|
+          let f$si = fun x -> x * $c + $p in
+          let a$si = [f$si x | x <- [1.0, 2.0, 3.0, 4.0, 5.0]] in
+          let t$si = Array.reduce (+) 0.0 a$si in
+          let r$si = {a = t$si; b = f$si 10.0; c = Array.length a$si} in
+          let v$si =
+            match (if t$si > 0.0 then Some r$si.a else None) with {
+              | Some y -> y + 1.0
+              | None -> 0.0
+            }
+          in
+          let acc$si = v$si in
+        |]
+      where
+        si, c, p :: Text
+        si = tshow i
+        c = tshow (i + 1) <> ".1"
+        p = prev i
+
+tshow :: Int -> Text
+tshow = Text.pack . show
+
+-- The `trimming` QQ strips all leading/trailing whitespace chars, including
+-- newlines, so we need to add them back in to generate the script blocks
+withNewline :: Text -> Text
+withNewline = (<> "\n")

--- a/inferno-core/inferno-core.cabal
+++ b/inferno-core/inferno-core.cabal
@@ -156,3 +156,21 @@ executable inferno
     , text
 
   default-language: Haskell2010
+
+benchmark inferno-bench
+  type:               exitcode-stdio-1.0
+  main-is:            Main.hs
+  hs-source-dirs:     bench
+  build-depends:
+    , base
+    , criterion
+    , inferno-core
+    , neat-interpolation
+    , text
+
+  default-language:   Haskell2010
+  default-extensions:
+    OverloadedStrings
+    TypeApplications
+
+  ghc-options:        -Wall -O2 -threaded -rtsopts "-with-rtsopts=-T -s"

--- a/inferno-core/inferno-core.cabal
+++ b/inferno-core/inferno-core.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               inferno-core
-version:            0.11.6.9
+version:            0.11.6.10
 synopsis:           A statically-typed functional scripting language
 description:
   Parser, type inference, and interpreter for a statically-typed functional scripting language


### PR DESCRIPTION
This adds a simple criterion benchmark with two main sets of benches:
- wide: for env growth, scope resolution, substitution
- deep: scripts with more realistic language use patterns (conditionals, pattern matching, etc...)

This was to have a benchmark to compare pre- and post-union-find implementation, but the current results are actually quite shocking.

Here are the results of `cabal bench inferno-bench --benchmark-options='-m prefix wide/100` (100 and 1,000 `let` bindings with simple arithmetic):

```
  Benchmark inferno-bench: RUNNING...
  benchmarking wide/100
  time                 780.5 ms   (750.3 ms .. 802.0 ms)
                       1.000 R²   (0.999 R² .. 1.000 R²)
  mean                 787.1 ms   (782.3 ms .. 790.0 ms)
  std dev              4.624 ms   (2.328 ms .. 5.924 ms)
  variance introduced by outliers: 19% (moderately inflated)

  benchmarking wide/1000
  time                 544.1 s    (537.0 s .. 555.8 s)
                       1.000 R²   (1.000 R² .. 1.000 R²)
  mean                 546.7 s    (543.1 s .. 552.7 s)
  std dev              5.743 s    (1.544 s .. 7.444 s)
  variance introduced by outliers: 19% (moderately inflated)

  9,701,472,088,504 bytes allocated in the heap
  6,225,591,173,928 bytes copied during GC
     9,423,733,736  bytes maximum residency (977 sample(s))
       252,873,560  bytes maximum slop
             27411 MiB total memory in use (0 MiB lost due to fragmentation)

                                       Tot time (elapsed)  Avg pause  Max pause
    Gen  0     2072172 colls,     0 par   1543.719s  1549.437s     0.0007s    0.0146s
    Gen  1       977 colls,     0 par   1368.232s  1372.017s     1.4043s    5.0042s

    TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)

    SPARKS: 4 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 4 fizzled)

    INIT    time    0.001s  (  0.000s elapsed)
    MUT     time  5969.814s  (5973.330s elapsed)
    GC      time  2911.951s  (2921.454s elapsed)
    EXIT    time    0.001s  (  0.001s elapsed)
    Total   time  8881.766s  (8894.785s elapsed)

    Alloc rate    1,625,087,849 bytes per MUT second

    Productivity  67.2% of total user, 67.2% of total elapsed
```

This single bench run took **~2.5 hours** to complete and raises several serious concerns about Inferno's current typechecking implementation. It confirms that the union-find refactor is essential:

### Scaling: 
`wide/100` takes 780ms, `wide/1000` takes **545s**, i.e. a 10x increase in input produces a **~700x increase in time**, which is **worse-than-quadratic** scaling (almost O(n^3))

### Allocation: 
**9.7 trillion bytes** are heap allocated for the whole run. The typechecker is generating and immediately discarding huge amounts of intermediate data. This is almost certainly from repeatedly walking and copying substitution maps.

### GC pressure: 
**6.2TB** copied during GC. Most of those allocations are short-lived but can't be collected quickly because they're referenced by the substitution env (which continues to grow as the typechecker walks the substitution map). Gen 1 GC alone took **23 minutes** in total with an average pause of 1.4s and a max pause of 5s!

### Residency: 
9.4GB peak live heap for _1000 trivial let-bindings_, which is ~9.4MB per-binding of live data, which is nuts!

### Productivity: 
A third of wall time is just GC. The remaining "computation" is mostly substitution walking, not actual useful work.