### PR TITLE
[inferno-core][parser] Module-level parsers

### DIFF
--- a/inferno-core/src/Inferno/Module.hs
+++ b/inferno-core/src/Inferno/Module.hs
@@ -30,8 +30,8 @@ import Inferno.Infer.Env (Namespace (..), TypeMetadata (..))
 import Inferno.Infer.Pinned (pinExpr)
 import qualified Inferno.Infer.Pinned as Pinned
 import Inferno.Module.Cast (ToValue (..))
-import qualified Inferno.Parse
 import Inferno.Parse (OpsTable, ParsedModule, TopLevelDefn (..))
+import qualified Inferno.Parse
 import Inferno.Types.Module
   ( BuiltinEnumHash (..),
     BuiltinFunHash (..),

--- a/inferno-core/src/Inferno/Module.hs
+++ b/inferno-core/src/Inferno/Module.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 
 module Inferno.Module
   ( Module (..),
@@ -29,7 +30,7 @@ import Inferno.Infer.Env (Namespace (..), TypeMetadata (..))
 import Inferno.Infer.Pinned (pinExpr)
 import qualified Inferno.Infer.Pinned as Pinned
 import Inferno.Module.Cast (ToValue (..))
-import Inferno.Parse (OpsTable, TopLevelDefn (..))
+import Inferno.Parse (OpsTable, ParsedModule, TopLevelDefn (..))
 import Inferno.Types.Module
   ( BuiltinEnumHash (..),
     BuiltinFunHash (..),
@@ -69,24 +70,22 @@ combineTermEnvs modules = foldM (\env m -> (env <>) <$> pinnedModuleTerms m) mem
 
 buildPinnedQQModules ::
   (MonadThrow m, Pretty c) =>
-  [(ModuleName, OpsTable, [TopLevelDefn (Either (TCScheme, Value c (ImplEnvM m c)) (Maybe TCScheme, Expr () SourcePos))])] ->
+  [ParsedModule (Either (TCScheme, Value c (ImplEnvM m c)) (Maybe TCScheme, Expr () SourcePos))] ->
   Map.Map ModuleName (PinnedModule (TermEnv VCObjectHash c (ImplEnvM m c) ()))
 buildPinnedQQModules modules =
   snd $
     foldl'
-      ( \(alreadyPinnedModulesMap, alreadyBuiltModules) (moduleNm, opsTable, sigs) ->
-          -- first build the new module
+      ( \(alreadyPinnedModulesMap, alreadyBuiltModules) pm ->
           let newMod =
-                buildModule alreadyPinnedModulesMap alreadyBuiltModules sigs $
+                buildModule alreadyPinnedModulesMap alreadyBuiltModules pm.defs $
                   Module
-                    { moduleName = moduleNm
-                    , moduleOpsTable = opsTable
+                    { moduleName = pm.name
+                    , moduleOpsTable = pm.opsTable
                     , moduleTypeClasses = mempty
-                    , moduleObjects = (Map.singleton (ModuleNamespace moduleNm) $ vcHash $ BuiltinModuleHash moduleNm, mempty, pure mempty)
+                    , moduleObjects = (Map.singleton (ModuleNamespace pm.name) $ vcHash $ BuiltinModuleHash pm.name, mempty, pure mempty)
                     }
-           in -- then insert it into the temporary module pin map as well as the final module map
-              ( Pinned.insertHardcodedModule moduleNm (Map.map Builtin $ pinnedModuleNameToHash newMod) alreadyPinnedModulesMap
-              , Map.insert moduleNm newMod alreadyBuiltModules
+           in ( Pinned.insertHardcodedModule pm.name (Map.map Builtin $ pinnedModuleNameToHash newMod) alreadyPinnedModulesMap
+              , Map.insert pm.name newMod alreadyBuiltModules
               )
       )
       mempty

--- a/inferno-core/src/Inferno/Module.hs
+++ b/inferno-core/src/Inferno/Module.hs
@@ -30,6 +30,7 @@ import Inferno.Infer.Env (Namespace (..), TypeMetadata (..))
 import Inferno.Infer.Pinned (pinExpr)
 import qualified Inferno.Infer.Pinned as Pinned
 import Inferno.Module.Cast (ToValue (..))
+import qualified Inferno.Parse
 import Inferno.Parse (OpsTable, ParsedModule, TopLevelDefn (..))
 import Inferno.Types.Module
   ( BuiltinEnumHash (..),
@@ -99,7 +100,7 @@ buildPinnedQQModules modules =
       PinnedModule (TermEnv VCObjectHash c (ImplEnvM m c) ()) ->
       PinnedModule (TermEnv VCObjectHash c (ImplEnvM m c) ())
     buildModule _ _ [] m = m
-    buildModule alreadyPinnedModulesMap alreadyBuiltModules (Signature{..} : xs) m@Module{moduleName, moduleObjects = (nsMap, tyMap, mTrmEnv)} =
+    buildModule alreadyPinnedModulesMap alreadyBuiltModules (Signature documentation name def : xs) m@Module{moduleName, moduleObjects = (nsMap, tyMap, mTrmEnv)} =
       let sigVarToNamespace = \case
             SigVar n -> FunNamespace $ Ident n
             SigOpVar n -> OpNamespace $ Ident n

--- a/inferno-core/src/Inferno/Module/Prelude.hs
+++ b/inferno-core/src/Inferno/Module/Prelude.hs
@@ -222,7 +222,6 @@ builtinModules = undefined -- FIXME Need to disable until parser is finished
 --   define addition on word64 word32 word64;
 --   define addition on word64 word64 word64;
 
-
 --   @doc Addition on `int`, `double`, `word16/32/64`, `time` and `timeDiff`;
 --   (+) : forall 'a 'b 'c. {requires addition on 'a 'b 'c} => 'a -> 'b -> 'c := ###sumFun###;
 
@@ -841,4 +840,4 @@ builtinModules = undefined -- FIXME Need to disable until parser is finished
 --   Example: `zipWith (+) [1, 2, 3] [4, 5, 6] == [5, 7, 9]`;
 --   zipWith : forall 'a 'b 'c. ('a -> 'b -> 'c) -> array of 'a -> array of 'b -> array of 'c := ###!zipWithFun###;
 
--- |]
+-- | ]

--- a/inferno-core/src/Inferno/Parse.hs
+++ b/inferno-core/src/Inferno/Parse.hs
@@ -149,12 +149,7 @@ type ParserOver r = ReaderT r (StateT [Comment SourcePos] BaseParsec)
 type Parser = ParserOver ParseEnv
 
 data TopLevelDefn def
-  = -- FIXME Don't use record fields in sum types, damn it!
-    Signature
-      { documentation :: Maybe Text
-      , name :: SigVar
-      , def :: def
-      }
+  = Signature (Maybe Text) SigVar def
   | EnumDef (Maybe Text) Text [Ident]
   | TypeClassInstance TypeClass
   | Export ModuleName
@@ -1087,16 +1082,21 @@ fixityLvl = try $ lexeme Lexer.decimal >>= check
         $ x >= 0 && x < 20
 
 sigsParser :: Parser (OpsTable, [TopLevelDefn (Maybe TCScheme, QQDefinition)])
-sigsParser = go mempty
+sigsParser = go id
   where
+    -- Avoids O(n) snoc (previously was `reverse acc`); now O(n) materialization,
+    -- O(1) snoc
     go ::
-      [TopLevelDefn (Maybe TCScheme, QQDefinition)] ->
+      (
+        [TopLevelDefn (Maybe TCScheme, QQDefinition)] ->
+        [TopLevelDefn (Maybe TCScheme, QQDefinition)]
+      ) ->
       Parser (OpsTable, [TopLevelDefn (Maybe TCScheme, QQDefinition)])
-    go acc =
+    go f =
       asum
-        [ flip withReaderT (go acc) . const =<< opDeclP
-        , go . (: acc) =<< sigParser
-        , asks $ (,reverse acc) . (.ops)
+        [ flip withReaderT (go f) . const =<< opDeclP
+        , go . (f .) . (:) =<< sigParser
+        , asks $ (, f mempty) . (.ops)
         ]
 
     opDeclP :: Parser ParseEnv

--- a/inferno-core/src/Inferno/Parse.hs
+++ b/inferno-core/src/Inferno/Parse.hs
@@ -50,6 +50,7 @@ import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
+import Data.Tuple.Extra (second3)
 import Inferno.Parse.Error (prettyError)
 import Inferno.Types.Syntax
   ( Comment (BlockComment, LineComment),
@@ -1115,7 +1116,25 @@ insertIntoOpsTable tbl f lvl op = IntMap.alter go lvl tbl
 
 modulesParser ::
   Parser [(ModuleName, OpsTable, [TopLevelDefn (Maybe TCScheme, QQDefinition)])]
-modulesParser = undefined
+modulesParser = do
+  void $ symbol "module"
+  nm <- ModuleName <$> lexeme variable
+  (ops, sigs) <- sigsParser
+
+  let qualOps :: OpsTable
+      qualOps = flip IntMap.map ops . fmap . second3 . const $ Scope nm
+
+  ((nm, ops, sigs) :) <$> asum
+    [ flip withReaderT modulesParser . const =<< asks (mergedEnv qualOps nm ops)
+    , pure mempty
+    ]
+  where
+    mergedEnv :: OpsTable -> ModuleName -> OpsTable -> ParseEnv -> ParseEnv
+    mergedEnv qualOps nm modTbl env =
+      mkParseEnv
+        (IntMap.unionWith (<>) env.ops qualOps)
+        (Map.insert nm modTbl env.modOps)
+        env.customTypes
 
 topLevel :: ParserOver r a -> ParserOver r a
 topLevel = undefined

--- a/inferno-core/src/Inferno/Parse.hs
+++ b/inferno-core/src/Inferno/Parse.hs
@@ -12,6 +12,7 @@ module Inferno.Parse
   ( Comment (..),
     OpsTable,
     TopLevelDefn (..),
+    ParsedModule (..),
     QQDefinition (..),
     InfernoParsingError (..),
     topLevel,
@@ -156,6 +157,13 @@ data TopLevelDefn def
   | EnumDef (Maybe Text) Text [Ident]
   | TypeClassInstance TypeClass
   | Export ModuleName
+  deriving (Eq, Show, Data)
+
+data ParsedModule a = ParsedModule
+  { name :: !ModuleName
+  , opsTable :: !OpsTable
+  , defs :: [TopLevelDefn a]
+  }
   deriving (Eq, Show, Data)
 
 type OpsTable = IntMap.IntMap [(Fixity, Scoped ModuleName, Text)]
@@ -1114,8 +1122,7 @@ insertIntoOpsTable tbl f lvl op = IntMap.alter go lvl tbl
       Nothing -> Just [(f, LocalScope, op)]
       (Just xs) -> Just $ (f, LocalScope, op) : xs
 
-modulesParser ::
-  Parser [(ModuleName, OpsTable, [TopLevelDefn (Maybe TCScheme, QQDefinition)])]
+modulesParser :: Parser [ParsedModule (Maybe TCScheme, QQDefinition)]
 modulesParser = do
   void $ symbol "module"
   nm <- ModuleName <$> lexeme variable
@@ -1124,10 +1131,11 @@ modulesParser = do
   let qualOps :: OpsTable
       qualOps = flip IntMap.map ops . fmap . second3 . const $ Scope nm
 
-  ((nm, ops, sigs) :) <$> asum
-    [ flip withReaderT modulesParser . const =<< asks (mergedEnv qualOps nm ops)
-    , pure mempty
-    ]
+  (ParsedModule nm ops sigs :)
+    <$> asum
+      [ flip withReaderT modulesParser . const =<< asks (mergedEnv qualOps nm ops)
+      , pure mempty
+      ]
   where
     mergedEnv :: OpsTable -> ModuleName -> OpsTable -> ParseEnv -> ParseEnv
     mergedEnv qualOps nm modTbl env =

--- a/inferno-core/src/Inferno/Parse.hs
+++ b/inferno-core/src/Inferno/Parse.hs
@@ -88,7 +88,7 @@ import Inferno.Types.Syntax
     Pat (PArray, PEmpty, PEnum, PLit, POne, PRecord, PTuple, PVar),
     RestOfRecord,
     Scoped (LocalScope, Scope),
-    SigVar,
+    SigVar (SigOpVar, SigVar),
     TList (TNil),
     fromScoped,
     rws,
@@ -680,13 +680,13 @@ letE = label ("a 'let' expression" <> example "x") $ do
         , Impl . ExtIdent . Right <$> implicitVariable
         ]
   tPos <- getSourcePos
-  maybeTy <- optional $ symbol ":" *> withReaderT toTyEnv schemeParser
+  mTy <- optional $ symbol ":" *> withReaderT toTyEnv schemeParser
   eqPos <- getSourcePos
   void . label "'='" $ symbol "="
   e1 <- expr <?> (bindMsg . Text.unpack . renderPretty) x
   inPos <- getSourcePos
   e2 <- inExpr
-  (x, maybeTy) & \case
+  (x, mTy) & \case
     (Expl y, Just t) ->
       pure $ LetAnnot startPos varPos y tPos t eqPos e1 inPos e2
     (Impl _, Just _) -> customFailure ImplicitVarTypeAnnot
@@ -1041,7 +1041,15 @@ enumConstructors :: Parser [Ident]
 enumConstructors = undefined
 
 sigVariable :: Parser SigVar
-sigVariable = undefined
+sigVariable =
+  lexeme . asum $
+    [ tryMany infixOp =<< asks (.infixOps)
+    , tryMany (fmap SigVar . string) =<< asks (.prefixOps)
+    , SigVar <$> variable
+    ]
+  where
+    infixOp :: Text -> Parser SigVar
+    infixOp op = char '(' *> fmap SigOpVar (string op) <* char ')'
 
 exprOrBuiltin :: Parser QQDefinition
 exprOrBuiltin = undefined
@@ -1050,13 +1058,50 @@ sigParser :: Parser (TopLevelDefn (Maybe TCScheme, QQDefinition))
 sigParser = undefined
 
 fixityP :: Parser Fixity
-fixityP = undefined
+fixityP =
+  lexeme . asum $
+    [ try $ rword "infixr" $> InfixOp RightFix
+    , try $ rword "infixl" $> InfixOp LeftFix
+    , try $ rword "infix" $> InfixOp NoFix
+    , rword "prefix" $> PrefixOp
+    ]
 
 fixityLvl :: Parser Int
-fixityLvl = undefined
+fixityLvl = try $ lexeme Lexer.decimal >>= check
+  where
+    check :: Int -> Parser Int
+    check x =
+      bool
+        (fail "Fixity level annotation must be between 0 and 19 (inclusive)")
+        (pure x)
+        $ x >= 0 && x < 20
 
 sigsParser :: Parser (OpsTable, [TopLevelDefn (Maybe TCScheme, QQDefinition)])
-sigsParser = undefined
+sigsParser = go mempty
+  where
+    go ::
+      [TopLevelDefn (Maybe TCScheme, QQDefinition)] ->
+      Parser (OpsTable, [TopLevelDefn (Maybe TCScheme, QQDefinition)])
+    go acc =
+      asum
+        [ flip withReaderT (go acc) . const =<< opDeclP
+        , go . (: acc) =<< sigParser
+        , asks $ (,reverse acc) . (.ops)
+        ]
+
+    opDeclP :: Parser ParseEnv
+    opDeclP = do
+      env <- ask
+      f <- fixityP
+      l <- fixityLvl
+      o <- operatorP <* symbol ";"
+      pure $ mkParseEnv (insertIntoOpsTable env.ops f l o) env.modOps env.customTypes
+
+    operatorP :: Parser Text
+    operatorP = lexeme $ takeWhile1P (Just "operator") isOpChar
+
+    isOpChar :: Char -> Bool
+    isOpChar = (&&) <$> (/= ';') <*> not . isSpace
 
 insertIntoOpsTable :: OpsTable -> Fixity -> Int -> Text -> OpsTable
 insertIntoOpsTable tbl f lvl op = IntMap.alter go lvl tbl

--- a/inferno-core/src/Inferno/Parse.hs
+++ b/inferno-core/src/Inferno/Parse.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedRecordDot #-}
@@ -129,7 +130,7 @@ data InfernoParsingError
   | InfixOpNotFound ModuleName Ident
   | UnboundTyVar Text
   | ImplicitVarTypeAnnot
-  deriving (Eq, Show, Ord)
+  deriving stock (Eq, Show, Ord)
 
 instance ShowErrorComponent InfernoParsingError where
   showErrorComponent (ModuleNotFound (ModuleName modNm)) =
@@ -157,14 +158,14 @@ data TopLevelDefn def
   | EnumDef (Maybe Text) Text [Ident]
   | TypeClassInstance TypeClass
   | Export ModuleName
-  deriving (Eq, Show, Data)
+  deriving stock (Eq, Show, Data)
 
 data ParsedModule a = ParsedModule
   { name :: !ModuleName
   , opsTable :: !OpsTable
   , defs :: [TopLevelDefn a]
   }
-  deriving (Eq, Show, Data)
+  deriving stock (Eq, Show, Data)
 
 type OpsTable = IntMap.IntMap [(Fixity, Scoped ModuleName, Text)]
 
@@ -172,7 +173,7 @@ data QQDefinition
   = QQRawDef String
   | QQToValueDef String
   | InlineDef (Expr () SourcePos)
-  deriving (Data)
+  deriving stock (Data)
 
 type TyParser = ParserOver TyParseEnv
 

--- a/inferno-core/src/Inferno/Parse.hs
+++ b/inferno-core/src/Inferno/Parse.hs
@@ -1087,8 +1087,7 @@ sigsParser = go id
     -- Avoids O(n) snoc (previously was `reverse acc`); now O(n) materialization,
     -- O(1) snoc
     go ::
-      (
-        [TopLevelDefn (Maybe TCScheme, QQDefinition)] ->
+      ( [TopLevelDefn (Maybe TCScheme, QQDefinition)] ->
         [TopLevelDefn (Maybe TCScheme, QQDefinition)]
       ) ->
       Parser (OpsTable, [TopLevelDefn (Maybe TCScheme, QQDefinition)])
@@ -1096,7 +1095,7 @@ sigsParser = go id
       asum
         [ flip withReaderT (go f) . const =<< opDeclP
         , go . (f .) . (:) =<< sigParser
-        , asks $ (, f mempty) . (.ops)
+        , asks $ (,f mempty) . (.ops)
         ]
 
     opDeclP :: Parser ParseEnv

--- a/inferno-core/src/Inferno/Utils/QQ/Module.hs
+++ b/inferno-core/src/Inferno/Utils/QQ/Module.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE TemplateHaskell #-}
-
-{-# OPTIONS_GHC -Wno-unused-imports #-} -- FIXME Parser rewrite
+-- FIXME Parser rewrite
+{-# OPTIONS_GHC -Wno-unused-imports #-}
 
 module Inferno.Utils.QQ.Module where
 
@@ -60,21 +60,21 @@ moduleQuoter :: [CustomType] -> QuasiQuoter
 moduleQuoter customTypes =
   QuasiQuoter
     { quoteExp = undefined -- FIXME parser rewrite
-      -- \str -> do
-      --   l <- location'
-      --   let (_, res) =
-      --         runParser' (runWriterT $ flip runReaderT (mempty, mempty, customTypes) $ topLevel modulesParser) $
-      --           State
-      --             (pack str)
-      --             0
-      --             (PosState (pack str) 0 l defaultTabWidth "")
-      --             []
-      --   case res of
-      --     Left (ParseErrorBundle errs pos) ->
-      --       let errs' = map mkParseErrorStr $ NEList.toList $ fst $ attachSourcePos errorOffset errs pos
-      --        in fail $ intercalate "\n\n" errs'
-      --     Right (modules, _comments) ->
-      --       [|buildPinnedQQModules $(dataToExpQ ((fmap liftText . cast) `extQ` metaToValue) modules)|]
+    -- \str -> do
+    --   l <- location'
+    --   let (_, res) =
+    --         runParser' (runWriterT $ flip runReaderT (mempty, mempty, customTypes) $ topLevel modulesParser) $
+    --           State
+    --             (pack str)
+    --             0
+    --             (PosState (pack str) 0 l defaultTabWidth "")
+    --             []
+    --   case res of
+    --     Left (ParseErrorBundle errs pos) ->
+    --       let errs' = map mkParseErrorStr $ NEList.toList $ fst $ attachSourcePos errorOffset errs pos
+    --        in fail $ intercalate "\n\n" errs'
+    --     Right (modules, _comments) ->
+    --       [|buildPinnedQQModules $(dataToExpQ ((fmap liftText . cast) `extQ` metaToValue) modules)|]
     , quotePat = error "moduleQuoter: Invalid use of this quasi-quoter in pattern context."
     , quoteType = error "moduleQuoter: Invalid use of this quasi-quoter in type context."
     , quoteDec = error "moduleQuoter: Invalid use of this quasi-quoter in top-level declaration context."

--- a/inferno-core/src/Inferno/Utils/QQ/Script.hs
+++ b/inferno-core/src/Inferno/Utils/QQ/Script.hs
@@ -2,8 +2,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
 {-# LANGUAGE TypeApplications #-}
-
-{-# OPTIONS_GHC -Wno-unused-imports #-} -- FIXME Parser rewrite
+-- FIXME Parser rewrite
+{-# OPTIONS_GHC -Wno-unused-imports #-}
 
 module Inferno.Utils.QQ.Script where
 
@@ -49,28 +49,28 @@ inferno :: forall m c. (MonadIO m, MonadThrow m, MonadCatch m, Pretty c, Eq c) =
 inferno =
   QuasiQuoter
     { quoteExp = undefined -- FIXME Parser rewrite
-      -- \str -> do
-      --   l <- location'
-      --   let (_, res) =
-      --         runParser' (runWriterT $ flip runReaderT (baseOpsTable @_ @c builtins, builtinModulesOpsTable @_ @c builtins, []) $ topLevel expr) $
-      --           State
-      --             (pack str)
-      --             0
-      --             (PosState (pack str) 0 l defaultTabWidth "")
-      --             []
-      --   case res of
-      --     Left (ParseErrorBundle errs pos) ->
-      --       let errs' = map mkParseErrorStr $ NEList.toList $ fst $ attachSourcePos errorOffset errs pos
-      --        in fail $ intercalate "\n\n" errs'
-      --     Right (ast, comments) ->
-      --       case pinExpr (builtinModulesPinMap @_ @c builtins) ast of
-      --         Left err -> fail $ "Pinning expression failed:\n" <> show err
-      --         Right pinnedAST ->
-      --           case inferExpr builtins pinnedAST of
-      --             Left err -> fail $ "Inference failed:\n" <> show err
-      --             Right (pinnedAST', t, _tyMap) -> do
-      --               let final = insertCommentsIntoExpr (appEndo comments []) pinnedAST'
-      --               dataToExpQ ((fmap liftText . cast) `extQ` vcObjectHashToValue) (final, t)
+    -- \str -> do
+    --   l <- location'
+    --   let (_, res) =
+    --         runParser' (runWriterT $ flip runReaderT (baseOpsTable @_ @c builtins, builtinModulesOpsTable @_ @c builtins, []) $ topLevel expr) $
+    --           State
+    --             (pack str)
+    --             0
+    --             (PosState (pack str) 0 l defaultTabWidth "")
+    --             []
+    --   case res of
+    --     Left (ParseErrorBundle errs pos) ->
+    --       let errs' = map mkParseErrorStr $ NEList.toList $ fst $ attachSourcePos errorOffset errs pos
+    --        in fail $ intercalate "\n\n" errs'
+    --     Right (ast, comments) ->
+    --       case pinExpr (builtinModulesPinMap @_ @c builtins) ast of
+    --         Left err -> fail $ "Pinning expression failed:\n" <> show err
+    --         Right pinnedAST ->
+    --           case inferExpr builtins pinnedAST of
+    --             Left err -> fail $ "Inference failed:\n" <> show err
+    --             Right (pinnedAST', t, _tyMap) -> do
+    --               let final = insertCommentsIntoExpr (appEndo comments []) pinnedAST'
+    --               dataToExpQ ((fmap liftText . cast) `extQ` vcObjectHashToValue) (final, t)
     , quotePat = error "inferno: Invalid use of this quasi-quoter in pattern context."
     , quoteType = error "inferno: Invalid use of this quasi-quoter in type context."
     , quoteDec = error "inferno: Invalid use of this quasi-quoter in top-level declaration context."


### PR DESCRIPTION
This adds module-level parsing

- `sigVariable` now reads precomputed `env.infixOps`/`env.prefixOps` instead of recomputing from the ops table on every call
- `sigsParser` uses difference list accumulator i.e. O(1) snoc, no more `reverse`ing 
- Decided to make `modulesParser` evaluate to a `[ParsedModule ...]` (new type def) instead of list-of-triples for better readability
- `TopLevelDefn.Signature` converted from partial record fields (which I consider bad) to positional pattern match
- `insertIntoOpsTable` prepends O(1) instead of appending O(n)
- Added missing deriving strategies