### PR TITLE
[inferno-core][parser] Parser fixes

### DIFF
--- a/inferno-core/src/Inferno/Core.hs
+++ b/inferno-core/src/Inferno/Core.hs
@@ -8,6 +8,7 @@ import Control.Monad (foldM)
 import Control.Monad.Catch (MonadCatch, MonadThrow)
 import Control.Monad.Fix (MonadFix)
 import Data.Bifunctor (bimap, first)
+import Data.Foldable (foldl') -- NOTE: Do NOT remove, needed for GHC version compat
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.Map as Map
 import qualified Data.Set as Set
@@ -113,7 +114,7 @@ mkInferno prelude customTypes = do
                   Left $ InferenceError err
                 Right runtimeReps ->
                   let finalAst =
-                        foldl
+                        foldl'
                           App
                           (bimap pinnedToMaybe (const ()) pinnedAST')
                           [TypeRep () ty | ty <- runtimeReps]

--- a/inferno-core/src/Inferno/Module.hs
+++ b/inferno-core/src/Inferno/Module.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 
 module Inferno.Module
   ( Module (..),
@@ -29,7 +30,8 @@ import Inferno.Infer.Env (Namespace (..), TypeMetadata (..))
 import Inferno.Infer.Pinned (pinExpr)
 import qualified Inferno.Infer.Pinned as Pinned
 import Inferno.Module.Cast (ToValue (..))
-import Inferno.Parse (OpsTable, TopLevelDefn (..))
+import Inferno.Parse (OpsTable, ParsedModule, TopLevelDefn (..))
+import qualified Inferno.Parse
 import Inferno.Types.Module
   ( BuiltinEnumHash (..),
     BuiltinFunHash (..),
@@ -69,24 +71,22 @@ combineTermEnvs modules = foldM (\env m -> (env <>) <$> pinnedModuleTerms m) mem
 
 buildPinnedQQModules ::
   (MonadThrow m, Pretty c) =>
-  [(ModuleName, OpsTable, [TopLevelDefn (Either (TCScheme, Value c (ImplEnvM m c)) (Maybe TCScheme, Expr () SourcePos))])] ->
+  [ParsedModule (Either (TCScheme, Value c (ImplEnvM m c)) (Maybe TCScheme, Expr () SourcePos))] ->
   Map.Map ModuleName (PinnedModule (TermEnv VCObjectHash c (ImplEnvM m c) ()))
 buildPinnedQQModules modules =
   snd $
     foldl'
-      ( \(alreadyPinnedModulesMap, alreadyBuiltModules) (moduleNm, opsTable, sigs) ->
-          -- first build the new module
+      ( \(alreadyPinnedModulesMap, alreadyBuiltModules) pm ->
           let newMod =
-                buildModule alreadyPinnedModulesMap alreadyBuiltModules sigs $
+                buildModule alreadyPinnedModulesMap alreadyBuiltModules pm.defs $
                   Module
-                    { moduleName = moduleNm
-                    , moduleOpsTable = opsTable
+                    { moduleName = pm.name
+                    , moduleOpsTable = pm.opsTable
                     , moduleTypeClasses = mempty
-                    , moduleObjects = (Map.singleton (ModuleNamespace moduleNm) $ vcHash $ BuiltinModuleHash moduleNm, mempty, pure mempty)
+                    , moduleObjects = (Map.singleton (ModuleNamespace pm.name) $ vcHash $ BuiltinModuleHash pm.name, mempty, pure mempty)
                     }
-           in -- then insert it into the temporary module pin map as well as the final module map
-              ( Pinned.insertHardcodedModule moduleNm (Map.map Builtin $ pinnedModuleNameToHash newMod) alreadyPinnedModulesMap
-              , Map.insert moduleNm newMod alreadyBuiltModules
+           in ( Pinned.insertHardcodedModule pm.name (Map.map Builtin $ pinnedModuleNameToHash newMod) alreadyPinnedModulesMap
+              , Map.insert pm.name newMod alreadyBuiltModules
               )
       )
       mempty
@@ -100,7 +100,7 @@ buildPinnedQQModules modules =
       PinnedModule (TermEnv VCObjectHash c (ImplEnvM m c) ()) ->
       PinnedModule (TermEnv VCObjectHash c (ImplEnvM m c) ())
     buildModule _ _ [] m = m
-    buildModule alreadyPinnedModulesMap alreadyBuiltModules (Signature{..} : xs) m@Module{moduleName, moduleObjects = (nsMap, tyMap, mTrmEnv)} =
+    buildModule alreadyPinnedModulesMap alreadyBuiltModules (Signature documentation name def : xs) m@Module{moduleName, moduleObjects = (nsMap, tyMap, mTrmEnv)} =
       let sigVarToNamespace = \case
             SigVar n -> FunNamespace $ Ident n
             SigOpVar n -> OpNamespace $ Ident n

--- a/inferno-core/src/Inferno/Module/Prelude.hs
+++ b/inferno-core/src/Inferno/Module/Prelude.hs
@@ -183,662 +183,662 @@ preludeNameToTypeMap moduleMap =
 -- `define typeclass_name on t1 ... tn;`.
 
 builtinModules :: (MonadIO m, MonadThrow m, MonadCatch m, Pretty c, Eq c) => ModuleMap m c
-builtinModules =
-  [infernoModules|
+builtinModules = undefined -- FIXME Need to disable until parser is finished
+--   [infernoModules|
 
-module Number
+-- module Number
 
-  @doc The identity function;
-  id : forall 'a. 'a -> 'a := ###!idFun###;
+--   @doc The identity function;
+--   id : forall 'a. 'a -> 'a := ###!idFun###;
 
-  infixl 12 !!;
-  infixl 12 !?;
+--   infixl 12 !!;
+--   infixl 12 !?;
 
-  infixr 11 **;
+--   infixr 11 **;
 
-  infixl 10 *;
-  infixl 10 /;
-  infixl 10 %;
+--   infixl 10 *;
+--   infixl 10 /;
+--   infixl 10 %;
 
-  infixl 9 +;
-  infixl 9 -;
+--   infixl 9 +;
+--   infixl 9 -;
 
-  prefix 19 -;
+--   prefix 19 -;
 
-  define addition on int int int;
-  define addition on int double double;
-  define addition on double int double;
-  define addition on double double double;
-  define addition on time timeDiff time;
-  define addition on timeDiff time time;
-  define addition on timeDiff timeDiff timeDiff;
-  define addition on word16 word16 word16;
-  define addition on word16 word32 word32;
-  define addition on word32 word16 word32;
-  define addition on word32 word32 word32;
-  define addition on word16 word64 word64;
-  define addition on word64 word16 word64;
-  define addition on word32 word64 word64;
-  define addition on word64 word32 word64;
-  define addition on word64 word64 word64;
+--   define addition on int int int;
+--   define addition on int double double;
+--   define addition on double int double;
+--   define addition on double double double;
+--   define addition on time timeDiff time;
+--   define addition on timeDiff time time;
+--   define addition on timeDiff timeDiff timeDiff;
+--   define addition on word16 word16 word16;
+--   define addition on word16 word32 word32;
+--   define addition on word32 word16 word32;
+--   define addition on word32 word32 word32;
+--   define addition on word16 word64 word64;
+--   define addition on word64 word16 word64;
+--   define addition on word32 word64 word64;
+--   define addition on word64 word32 word64;
+--   define addition on word64 word64 word64;
 
 
-  @doc Addition on `int`, `double`, `word16/32/64`, `time` and `timeDiff`;
-  (+) : forall 'a 'b 'c. {requires addition on 'a 'b 'c} => 'a -> 'b -> 'c := ###sumFun###;
+--   @doc Addition on `int`, `double`, `word16/32/64`, `time` and `timeDiff`;
+--   (+) : forall 'a 'b 'c. {requires addition on 'a 'b 'c} => 'a -> 'b -> 'c := ###sumFun###;
 
-  define subtraction on int int int;
-  define subtraction on int double double;
-  define subtraction on double int double;
-  define subtraction on double double double;
-  define subtraction on time timeDiff time;
-  define subtraction on timeDiff timeDiff timeDiff;
-  define subtraction on word16 word16 word16;
-  define subtraction on word32 word32 word32;
-  define subtraction on word64 word64 word64;
+--   define subtraction on int int int;
+--   define subtraction on int double double;
+--   define subtraction on double int double;
+--   define subtraction on double double double;
+--   define subtraction on time timeDiff time;
+--   define subtraction on timeDiff timeDiff timeDiff;
+--   define subtraction on word16 word16 word16;
+--   define subtraction on word32 word32 word32;
+--   define subtraction on word64 word64 word64;
 
-  @doc Subtraction on `int`, `double`, `word16/32/64`, `time` and `timeDiff`;
-  (-) : forall 'a 'b 'c. {requires subtraction on 'a 'b 'c} => 'a -> 'b -> 'c := ###subFun###;
+--   @doc Subtraction on `int`, `double`, `word16/32/64`, `time` and `timeDiff`;
+--   (-) : forall 'a 'b 'c. {requires subtraction on 'a 'b 'c} => 'a -> 'b -> 'c := ###subFun###;
 
-  define division on int int int;
-  define division on int double double;
-  define division on double int double;
-  define division on double double double;
+--   define division on int int int;
+--   define division on int double double;
+--   define division on double int double;
+--   define division on double double double;
 
-  @doc Division on `int`, `double`;
-  (/) : forall 'a 'b 'c. {requires division on 'a 'b 'c} => 'a -> 'b -> 'c := ###divFun###;
+--   @doc Division on `int`, `double`;
+--   (/) : forall 'a 'b 'c. {requires division on 'a 'b 'c} => 'a -> 'b -> 'c := ###divFun###;
 
-  define multiplication on int int int;
-  define multiplication on int double double;
-  define multiplication on double int double;
-  define multiplication on double double double;
-  define multiplication on int timeDiff timeDiff;
-  define multiplication on timeDiff int timeDiff;
+--   define multiplication on int int int;
+--   define multiplication on int double double;
+--   define multiplication on double int double;
+--   define multiplication on double double double;
+--   define multiplication on int timeDiff timeDiff;
+--   define multiplication on timeDiff int timeDiff;
 
-  @doc Multiplication on `int`, `double`;
-  (*) : forall 'a 'b 'c. {requires multiplication on 'a 'b 'c} => 'a -> 'b -> 'c := ###mulFun###;
+--   @doc Multiplication on `int`, `double`;
+--   (*) : forall 'a 'b 'c. {requires multiplication on 'a 'b 'c} => 'a -> 'b -> 'c := ###mulFun###;
 
-  @doc Reciprocal fraction;
-  recip : double -> double := ###recipFun###;
+--   @doc Reciprocal fraction;
+--   recip : double -> double := ###recipFun###;
 
-  define power on int;
-  define power on double;
+--   define power on int;
+--   define power on double;
 
-  @doc `x ** y` raises `x` to the power of `y`, where the arguments are `int` or `double`;
-  (**) : forall 'a. {requires power on 'a} => 'a -> 'a -> 'a := ###powFun###;
+--   @doc `x ** y` raises `x` to the power of `y`, where the arguments are `int` or `double`;
+--   (**) : forall 'a. {requires power on 'a} => 'a -> 'a -> 'a := ###powFun###;
 
-  @doc Square root;
-  sqrt : double -> double := ###sqrtFun###;
+--   @doc Square root;
+--   sqrt : double -> double := ###sqrtFun###;
 
-  @doc Exponential function;
-  exp : double -> double := ###expFun###;
+--   @doc Exponential function;
+--   exp : double -> double := ###expFun###;
 
-  @doc Natural logarithm;
-  ln : double -> double := ###lnFun###;
+--   @doc Natural logarithm;
+--   ln : double -> double := ###lnFun###;
 
-  @doc Logarithm with base `10`;
-  log : double -> double := ###logFun###;
+--   @doc Logarithm with base `10`;
+--   log : double -> double := ###logFun###;
 
-  @doc Logarithm with base `b`;
-  logBase : double -> double -> double := ###logBaseFun###;
+--   @doc Logarithm with base `b`;
+--   logBase : double -> double -> double := ###logBaseFun###;
 
-  define negate on int;
-  define negate on double;
-  define negate on timeDiff;
+--   define negate on int;
+--   define negate on double;
+--   define negate on timeDiff;
 
-  @doc Negation (unary) on `int`, `double`, or `timeDiff`;
-  - : forall 'a. {requires negate on 'a} => 'a -> 'a := ###negateFun###;
+--   @doc Negation (unary) on `int`, `double`, or `timeDiff`;
+--   - : forall 'a. {requires negate on 'a} => 'a -> 'a := ###negateFun###;
 
-  define abs on int;
-  define abs on double;
-  define abs on timeDiff;
+--   define abs on int;
+--   define abs on double;
+--   define abs on timeDiff;
 
-  @doc Absolute value (sometimes written |x|) on `int`, `double`, or `timeDiff`;
-  abs : forall 'a. {requires abs on 'a} => 'a -> 'a := ###absFun###;
+--   @doc Absolute value (sometimes written |x|) on `int`, `double`, or `timeDiff`;
+--   abs : forall 'a. {requires abs on 'a} => 'a -> 'a := ###absFun###;
 
-  @doc Modulus operator. `n % m` is the remainder obtained when `n` is divided by `m`. E.g. `5 % 3 == 2`;
-  (%) : int -> int -> int := ###modFun###;
+--   @doc Modulus operator. `n % m` is the remainder obtained when `n` is divided by `m`. E.g. `5 % 3 == 2`;
+--   (%) : int -> int -> int := ###modFun###;
 
-  define roundable on double;
-  define roundable on int;
+--   define roundable on double;
+--   define roundable on int;
 
-  @doc Floor function (rounds down to nearest integer);
-  floor : forall 'a. {requires roundable on 'a} => 'a -> int := ###floorFun###;
+--   @doc Floor function (rounds down to nearest integer);
+--   floor : forall 'a. {requires roundable on 'a} => 'a -> int := ###floorFun###;
 
-  @doc Ceiling function (rounds up to nearest integer);
-  ceiling : forall 'a. {requires roundable on 'a} => 'a -> int := ###ceilingFun###;
+--   @doc Ceiling function (rounds up to nearest integer);
+--   ceiling : forall 'a. {requires roundable on 'a} => 'a -> int := ###ceilingFun###;
 
-  @doc `round x` returns the nearest integer to `x`
-  (the even integer if `x` is equidistant between two integers);
-  round : forall 'a. {requires roundable on 'a} => 'a -> int := ###roundFun###;
+--   @doc `round x` returns the nearest integer to `x`
+--   (the even integer if `x` is equidistant between two integers);
+--   round : forall 'a. {requires roundable on 'a} => 'a -> int := ###roundFun###;
 
-  @doc `roundTo d x` rounds `x` to `d` decimal places;
-  roundTo : int -> double -> double := ###roundToFun###;
+--   @doc `roundTo d x` rounds `x` to `d` decimal places;
+--   roundTo : int -> double -> double := ###roundToFun###;
 
-  @doc `truncate x` returns the integer nearest `x` between zero and `x`;
-  truncate : forall 'a. {requires roundable on 'a} => 'a -> int := ###truncateFun###;
+--   @doc `truncate x` returns the integer nearest `x` between zero and `x`;
+--   truncate : forall 'a. {requires roundable on 'a} => 'a -> int := ###truncateFun###;
 
-  @doc `truncateTo d x` truncates `x` to `d` decimal places;
-  truncateTo : int -> double -> double := ###truncateToFun###;
+--   @doc `truncateTo d x` truncates `x` to `d` decimal places;
+--   truncateTo : int -> double -> double := ###truncateToFun###;
 
-  @doc `limit l u x = min l (max x u)` limits `x` to be between `l` and `u`;
-  limit : double -> double -> double -> double := ###limitFun###;
+--   @doc `limit l u x = min l (max x u)` limits `x` to be between `l` and `u`;
+--   limit : double -> double -> double -> double := ###limitFun###;
 
-  @doc Pi (`3.14159... :: double`), the constant;
-  pi : double := ###piFun###;
+--   @doc Pi (`3.14159... :: double`), the constant;
+--   pi : double := ###piFun###;
 
-  @doc Sine (trigonometric function) of a `double`;
-  sin : double -> double := ###sinFun###;
+--   @doc Sine (trigonometric function) of a `double`;
+--   sin : double -> double := ###sinFun###;
 
-  @doc Hyperbolic sine (trigonometric function) of a `double`;
-  sinh : double -> double := ###sinhFun###;
+--   @doc Hyperbolic sine (trigonometric function) of a `double`;
+--   sinh : double -> double := ###sinhFun###;
 
-  @doc Inverse sine (trigonometric function) of a `double`;
-  arcSin : double -> double := ###arcSinFun###;
+--   @doc Inverse sine (trigonometric function) of a `double`;
+--   arcSin : double -> double := ###arcSinFun###;
 
-  @doc Cosine (trigonometric function), on `double`;
-  cos : double -> double := ###cosFun###;
+--   @doc Cosine (trigonometric function), on `double`;
+--   cos : double -> double := ###cosFun###;
 
-  @doc Hyperbolic cosine (trigonometric function) of a `double`;
-  cosh : double -> double := ###coshFun###;
+--   @doc Hyperbolic cosine (trigonometric function) of a `double`;
+--   cosh : double -> double := ###coshFun###;
 
-  @doc Inverse cosine (trigonometric function) of a `double`;
-  arcCos : double -> double := ###arcCosFun###;
+--   @doc Inverse cosine (trigonometric function) of a `double`;
+--   arcCos : double -> double := ###arcCosFun###;
 
-  @doc Tan (trigonometric function), on `double`;
-  tan : double -> double := ###tanFun###;
+--   @doc Tan (trigonometric function), on `double`;
+--   tan : double -> double := ###tanFun###;
 
-  @doc Hyperbolic tangent (trigonometric function) of a `double`;
-  tanh : double -> double := ###tanhFun###;
+--   @doc Hyperbolic tangent (trigonometric function) of a `double`;
+--   tanh : double -> double := ###tanhFun###;
 
-  @doc Inverse tan (trigonometric function) of a `double`;
-  arcTan : double -> double := ###arcTanFun###;
+--   @doc Inverse tan (trigonometric function) of a `double`;
+--   arcTan : double -> double := ###arcTanFun###;
 
-  @doc Convert int to double;
-  intToDouble : int -> double := ###intToDouble###;
+--   @doc Convert int to double;
+--   intToDouble : int -> double := ###intToDouble###;
 
-  @doc Convert double to int;
-  doubleToInt : double -> int := ###doubleToInt###;
+--   @doc Convert double to int;
+--   doubleToInt : double -> int := ###doubleToInt###;
 
-  @doc A (pseudo)random `double` number in the `[0, 1)` interval. To obtain a random number between 20 and 30, use `(10 * random ()) + 20`. The `()` argument is needed so that each time `random` is called a new random value is generated.;
-  random : () -> double := ###!randomFun###;
+--   @doc A (pseudo)random `double` number in the `[0, 1)` interval. To obtain a random number between 20 and 30, use `(10 * random ()) + 20`. The `()` argument is needed so that each time `random` is called a new random value is generated.;
+--   random : () -> double := ###!randomFun###;
 
-  define scalar on int;
-  define scalar on double;
-  define scalar on bool{#true, #false};
+--   define scalar on int;
+--   define scalar on double;
+--   define scalar on bool{#true, #false};
 
-module Option
-  @doc `Option.reduce f o d` unwraps an optional value `o` and applies `f` to it, if o contains a `Some` value. Otherwise it returns the default value `d`.
-  ~~~inferno
-  Option.reduce (fun str -> `${str} there!`) "hi" (Some "hello") == "hello there!"
-  Option.reduce (fun str -> `${str} there!`) "hi" None == "hi"
-  ~~~;
-  reduce : forall 'a 'b. ('a -> 'b) -> 'b -> option of 'a -> 'b :=
-    fun f b ma -> match ma with {
-      | Some a -> f a
-      | None -> b
-    };
+-- module Option
+--   @doc `Option.reduce f o d` unwraps an optional value `o` and applies `f` to it, if o contains a `Some` value. Otherwise it returns the default value `d`.
+--   ~~~inferno
+--   Option.reduce (fun str -> `${str} there!`) "hi" (Some "hello") == "hello there!"
+--   Option.reduce (fun str -> `${str} there!`) "hi" None == "hi"
+--   ~~~;
+--   reduce : forall 'a 'b. ('a -> 'b) -> 'b -> option of 'a -> 'b :=
+--     fun f b ma -> match ma with {
+--       | Some a -> f a
+--       | None -> b
+--     };
 
-  @doc `Option.map f ma` applies `f` to the value inside `ma`, namely if `ma` is `Some a`, it will return `Some (f a)`.;
-  map : forall 'a 'b. ('a -> 'b) -> option of 'a -> option of 'b :=
-    fun f ma -> match ma with {
-      | Some a -> Some (f a)
-      | None -> None
-    };
+--   @doc `Option.map f ma` applies `f` to the value inside `ma`, namely if `ma` is `Some a`, it will return `Some (f a)`.;
+--   map : forall 'a 'b. ('a -> 'b) -> option of 'a -> option of 'b :=
+--     fun f ma -> match ma with {
+--       | Some a -> Some (f a)
+--       | None -> None
+--     };
 
-  @doc `Option.flatMap f ma` applies `f` to the value inside `ma` and flattens the result,
-  i.e. if `ma` is `Some a`, it returns the `option` result of `f a`, otherwise `None`.;
-  flatMap : forall 'a 'b. ('a -> option of 'b) -> option of 'a -> option of 'b :=
-    fun f ma -> match ma with {
-      | Some a -> f a
-      | None -> None
-    };
+--   @doc `Option.flatMap f ma` applies `f` to the value inside `ma` and flattens the result,
+--   i.e. if `ma` is `Some a`, it returns the `option` result of `f a`, otherwise `None`.;
+--   flatMap : forall 'a 'b. ('a -> option of 'b) -> option of 'a -> option of 'b :=
+--     fun f ma -> match ma with {
+--       | Some a -> f a
+--       | None -> None
+--     };
 
-  @doc `Option.traverse f xs` applies `f` to each element of `xs`, returning `Some` of
-  the resulting array if all applications return `Some`, or `None` if any returns `None`.;
-  traverse : forall 'a 'b. ('a -> option of 'b) -> array of 'a -> option of (array of 'b) :=
-    ###!traverseOptionFun###;
+--   @doc `Option.traverse f xs` applies `f` to each element of `xs`, returning `Some` of
+--   the resulting array if all applications return `Some`, or `None` if any returns `None`.;
+--   traverse : forall 'a 'b. ('a -> option of 'b) -> array of 'a -> option of (array of 'b) :=
+--     ###!traverseOptionFun###;
 
-  singleton : forall 'a. 'a -> option of 'a := fun a -> Some a;
+--   singleton : forall 'a. 'a -> option of 'a := fun a -> Some a;
 
-  @doc Given a tuple `(Some x , Some y)`, `Option.mergeTuple` returns `Some (x , y)`. If any of the components are `None` it returns `None`.;
-  mergeTuple : forall 'a 'b. (option of 'a, option of 'b) -> option of ('a, 'b) :=
-    fun ab -> match ab with {
-      | (Some a , Some b) -> Some (a , b)
-      | _ -> None
-    };
+--   @doc Given a tuple `(Some x , Some y)`, `Option.mergeTuple` returns `Some (x , y)`. If any of the components are `None` it returns `None`.;
+--   mergeTuple : forall 'a 'b. (option of 'a, option of 'b) -> option of ('a, 'b) :=
+--     fun ab -> match ab with {
+--       | (Some a , Some b) -> Some (a , b)
+--       | _ -> None
+--     };
 
-  @doc `Option.join` removes the outer "layer" of a nested option. (By definition, `Option.join == Option.reduce id None`).
-  ~~~inferno
-  Option.join None == None
-  Option.join (Some None) == None
-  Option.join (Some (Some a)) == Some a
-  ~~~;
-  join : forall 'a. option of (option of 'a) -> option of 'a := reduce Number.id None;
+--   @doc `Option.join` removes the outer "layer" of a nested option. (By definition, `Option.join == Option.reduce id None`).
+--   ~~~inferno
+--   Option.join None == None
+--   Option.join (Some None) == None
+--   Option.join (Some (Some a)) == Some a
+--   ~~~;
+--   join : forall 'a. option of (option of 'a) -> option of 'a := reduce Number.id None;
 
-module Array
-
-  @doc Array construction. `cons x xs` is the array that has `x` as its first element and array `xs` as the rest of the array. For example, `cons 3 [1, 2] == [3, 1, 2]`;
-  cons : forall 'a. 'a -> array of 'a -> array of 'a := ###!consFun###;
-
-  @doc Array destruction into head and tail. `uncons xs` is `Some (x, xs1)` if array has at least one element and `xs == cons x xs1`, and is `None` if `xs == []`. For example, `uncons [1, 2, 3] == Some (1, [2, 3])`;
-  uncons : forall 'a. array of 'a -> option of ('a, array of 'a) := ###!unconsFun###;
-
-  @doc Array indexing: gets the ith element of an array. Throws a RuntimeError if i is out of bounds.;
-  get : forall 'a. array of 'a -> int -> 'a := ###!arrayIndexFun###;
-
-  @doc Safe array indexing: gets the ith element of an array. Returns None if i is out of bounds.;
-  getOpt : forall 'a. array of 'a -> int -> option of 'a := ###!arrayIndexOptFun###;
-
-  @doc This function can be used to create an array with a single element:
-  ~~~inferno
-  singleton 2
-  ~~~;
-  singleton : forall 'a. 'a -> array of 'a := ###!singletonFun###;
-
-  length : forall 'a. array of 'a -> int := ###!lengthFun###;
-
-  @doc The minimum value in an array, or `None` if empty;
-  minimum: forall 'a. {requires order on 'a} => array of 'a -> option of 'a := ###!minimumFun###;
-
-  @doc The maximum value in an array, or `None` if empty;
-  maximum: forall 'a. {requires order on 'a} => array of 'a -> option of 'a := ###!maximumFun###;
-
-  @doc The average of the values in an array, or `None` if empty;
-  average: forall 'a. {requires numeric on 'a} => array of 'a -> option of double := ###!averageFun###;
-
-  @doc Return the median of the values in an array, or `None` if empty;
-  median: forall 'a. {requires numeric on 'a} => array of 'a -> option of double := ###!medianFun###;
-
-  @doc The index of the minimum value in an array, or `None` if empty;
-  argmin: forall 'a. {requires order on 'a} => array of 'a -> option of int := ###!argminFun###;
-
-  @doc The index of the maximum value in an array, or `None` if empty;
-  argmax: forall 'a. {requires order on 'a} => array of 'a -> option of int := ###!argmaxFun###;
-
-  @doc Returns the indices that would sort an array;
-  argsort: forall 'a. {requires order on 'a} => array of 'a -> array of int := ###!argsortFun###;
+-- module Array
+
+--   @doc Array construction. `cons x xs` is the array that has `x` as its first element and array `xs` as the rest of the array. For example, `cons 3 [1, 2] == [3, 1, 2]`;
+--   cons : forall 'a. 'a -> array of 'a -> array of 'a := ###!consFun###;
+
+--   @doc Array destruction into head and tail. `uncons xs` is `Some (x, xs1)` if array has at least one element and `xs == cons x xs1`, and is `None` if `xs == []`. For example, `uncons [1, 2, 3] == Some (1, [2, 3])`;
+--   uncons : forall 'a. array of 'a -> option of ('a, array of 'a) := ###!unconsFun###;
+
+--   @doc Array indexing: gets the ith element of an array. Throws a RuntimeError if i is out of bounds.;
+--   get : forall 'a. array of 'a -> int -> 'a := ###!arrayIndexFun###;
+
+--   @doc Safe array indexing: gets the ith element of an array. Returns None if i is out of bounds.;
+--   getOpt : forall 'a. array of 'a -> int -> option of 'a := ###!arrayIndexOptFun###;
+
+--   @doc This function can be used to create an array with a single element:
+--   ~~~inferno
+--   singleton 2
+--   ~~~;
+--   singleton : forall 'a. 'a -> array of 'a := ###!singletonFun###;
+
+--   length : forall 'a. array of 'a -> int := ###!lengthFun###;
+
+--   @doc The minimum value in an array, or `None` if empty;
+--   minimum: forall 'a. {requires order on 'a} => array of 'a -> option of 'a := ###!minimumFun###;
+
+--   @doc The maximum value in an array, or `None` if empty;
+--   maximum: forall 'a. {requires order on 'a} => array of 'a -> option of 'a := ###!maximumFun###;
+
+--   @doc The average of the values in an array, or `None` if empty;
+--   average: forall 'a. {requires numeric on 'a} => array of 'a -> option of double := ###!averageFun###;
+
+--   @doc Return the median of the values in an array, or `None` if empty;
+--   median: forall 'a. {requires numeric on 'a} => array of 'a -> option of double := ###!medianFun###;
+
+--   @doc The index of the minimum value in an array, or `None` if empty;
+--   argmin: forall 'a. {requires order on 'a} => array of 'a -> option of int := ###!argminFun###;
+
+--   @doc The index of the maximum value in an array, or `None` if empty;
+--   argmax: forall 'a. {requires order on 'a} => array of 'a -> option of int := ###!argmaxFun###;
+
+--   @doc Returns the indices that would sort an array;
+--   argsort: forall 'a. {requires order on 'a} => array of 'a -> array of int := ###!argsortFun###;
 
-  @doc Returns the Euclidean norm of an array, or `None` if empty;
-  magnitude: forall 'a. {requires numeric on 'a} => array of 'a -> option of double := ###!magnitudeFun###;
+--   @doc Returns the Euclidean norm of an array, or `None` if empty;
+--   magnitude: forall 'a. {requires numeric on 'a} => array of 'a -> option of double := ###!magnitudeFun###;
 
-  @doc Returns the Euclidean norm of an array, or `None` if empty;
-  norm: forall 'a. {requires numeric on 'a} => array of 'a -> option of double := ###!normFun###;
+--   @doc Returns the Euclidean norm of an array, or `None` if empty;
+--   norm: forall 'a. {requires numeric on 'a} => array of 'a -> option of double := ###!normFun###;
 
-  @doc The `Array.range` function takes two `int` arguments `n` and `m` and produces an array `[n,...,m]`.
-  If `m` > `n`, the empty array is returned.;
-  range := ###enumFromToInt64###;
+--   @doc The `Array.range` function takes two `int` arguments `n` and `m` and produces an array `[n,...,m]`.
+--   If `m` > `n`, the empty array is returned.;
+--   range := ###enumFromToInt64###;
 
-  @doc The `Array.map` function takes a function `f` and an array of elements and applies `f` to each one;
-  map := fun f xs -> [f x | x <- xs];
+--   @doc The `Array.map` function takes a function `f` and an array of elements and applies `f` to each one;
+--   map := fun f xs -> [f x | x <- xs];
 
-  @doc `Array.keepSomes` discards any `None` values in an array and unwaps all `Some`s.
-  ~~~inferno
-  Array.keepSomes [None, Some "hello", None, Some "world"] = ["hello", "world"]
-  ~~~;
-  keepSomes : forall 'a. array of (option of 'a) -> array of 'a := ###!keepSomesFun###;
+--   @doc `Array.keepSomes` discards any `None` values in an array and unwaps all `Some`s.
+--   ~~~inferno
+--   Array.keepSomes [None, Some "hello", None, Some "world"] = ["hello", "world"]
+--   ~~~;
+--   keepSomes : forall 'a. array of (option of 'a) -> array of 'a := ###!keepSomesFun###;
 
-  @doc `reduce` applied to a binary operator, a starting value (typically an identity of the operator, e.g. `0`), and an array, reduces the array using the binary operator, from left to right:
-  ~~~inferno
-  reduce f z [x1, x2, ..., xn] == (...((z `f` x1) `f` x2) `f`...) `f` xn
-  ~~~
-  Example: `reduce (+) 42 [1, 2, 3, 4] == 52`;
-  reduce : forall 'a 'b. ('b -> 'a -> 'b) -> 'b -> array of 'a -> 'b := ###!foldlFun###;
+--   @doc `reduce` applied to a binary operator, a starting value (typically an identity of the operator, e.g. `0`), and an array, reduces the array using the binary operator, from left to right:
+--   ~~~inferno
+--   reduce f z [x1, x2, ..., xn] == (...((z `f` x1) `f` x2) `f`...) `f` xn
+--   ~~~
+--   Example: `reduce (+) 42 [1, 2, 3, 4] == 52`;
+--   reduce : forall 'a 'b. ('b -> 'a -> 'b) -> 'b -> array of 'a -> 'b := ###!foldlFun###;
 
-  @doc `reduceRight`, applied to a binary operator, a starting value (typically an identity of the operator), and a array, reduces the array using the binary operator, from right to left:
-  ~~~inferno
-  reduceRight f z [x1, x2, ..., xn] == x1 `f` (x2 `f` ... (xn `f` z)...)
-  ~~~
-  Example: `reduceRight (+) 42 [1, 2, 3, 4] == 52`, but `reduceRight (-) 0 [5, 3] == 2` while `reduceRight (-) 0 [3, 5] == -2`;
-  reduceRight : forall 'a 'b. ('a -> 'b -> 'b) -> 'b -> array of 'a -> 'b := ###!foldrFun###;
+--   @doc `reduceRight`, applied to a binary operator, a starting value (typically an identity of the operator), and a array, reduces the array using the binary operator, from right to left:
+--   ~~~inferno
+--   reduceRight f z [x1, x2, ..., xn] == x1 `f` (x2 `f` ... (xn `f` z)...)
+--   ~~~
+--   Example: `reduceRight (+) 42 [1, 2, 3, 4] == 52`, but `reduceRight (-) 0 [5, 3] == 2` while `reduceRight (-) 0 [3, 5] == -2`;
+--   reduceRight : forall 'a 'b. ('a -> 'b -> 'b) -> 'b -> array of 'a -> 'b := ###!foldrFun###;
 
-  define zero on int;
-  define zero on double;
-  define zero on word16;
-  define zero on word32;
-  define zero on word64;
-  define zero on timeDiff;
+--   define zero on int;
+--   define zero on double;
+--   define zero on word16;
+--   define zero on word32;
+--   define zero on word64;
+--   define zero on timeDiff;
 
-  zero : forall 'a. {requires rep on 'a, requires zero on 'a} => 'a := ###!zeroFun###;
+--   zero : forall 'a. {requires rep on 'a, requires zero on 'a} => 'a := ###!zeroFun###;
 
-  @doc `Array.sum` computes the sum of elements in an array. The elements can be of type `int`/`double`/`word`.;
-  sum := reduce Number.(+) zero;
+--   @doc `Array.sum` computes the sum of elements in an array. The elements can be of type `int`/`double`/`word`.;
+--   sum := reduce Number.(+) zero;
 
-  findFirstSome : forall 'a. array of (option of 'a) -> option of 'a :=
-    reduceRight
-      (fun a rest -> match a with {
-        | Some _ -> a
-        | None -> rest
-      })
-      None;
-  findLastSome : forall 'a. array of (option of 'a) -> option of 'a :=
-    reduce
-      (fun rest a -> match a with {
-        | Some _ -> a
-        | None -> rest
-      })
-      None;
-  findFirstAndLastSome : forall 'a. array of (option of 'a) -> option of ('a, 'a) :=
-    let firstLast =
-      reduce
-        (fun acc a -> match (a , acc) with {
-          | (Some _ , (None , _)) -> (a , a)
-          | (Some _ , (Some v , _)) -> (Some v , a)
-          | (None , _) -> acc
-        })
-        (None, None)
-    in fun arr -> Option.mergeTuple (firstLast arr);
+--   findFirstSome : forall 'a. array of (option of 'a) -> option of 'a :=
+--     reduceRight
+--       (fun a rest -> match a with {
+--         | Some _ -> a
+--         | None -> rest
+--       })
+--       None;
+--   findLastSome : forall 'a. array of (option of 'a) -> option of 'a :=
+--     reduce
+--       (fun rest a -> match a with {
+--         | Some _ -> a
+--         | None -> rest
+--       })
+--       None;
+--   findFirstAndLastSome : forall 'a. array of (option of 'a) -> option of ('a, 'a) :=
+--     let firstLast =
+--       reduce
+--         (fun acc a -> match (a , acc) with {
+--           | (Some _ , (None , _)) -> (a , a)
+--           | (Some _ , (Some v , _)) -> (Some v , a)
+--           | (None , _) -> acc
+--         })
+--         (None, None)
+--     in fun arr -> Option.mergeTuple (firstLast arr);
 
-  @doc `Array.reverse xs` returns the elements of `xs` in reverse order;
-  reverse : forall 'a. array of 'a -> array of 'a := ###!reverseFun###;
+--   @doc `Array.reverse xs` returns the elements of `xs` in reverse order;
+--   reverse : forall 'a. array of 'a -> array of 'a := ###!reverseFun###;
 
-  @doc `Array.take n xs` returns the first `n` elements of `xs`.
-  If `n` is greater than the length of `xs`, returns `xs`.;
-  take : forall 'a. int -> array of 'a -> array of 'a := ###!takeFun###;
+--   @doc `Array.take n xs` returns the first `n` elements of `xs`.
+--   If `n` is greater than the length of `xs`, returns `xs`.;
+--   take : forall 'a. int -> array of 'a -> array of 'a := ###!takeFun###;
 
-  @doc `Array.drop n xs` returns `xs` with the first `n` elements removed.
-  If `n` is greater than the length of `xs`, returns the empty array.;
-  drop : forall 'a. int -> array of 'a -> array of 'a := ###!dropFun###;
+--   @doc `Array.drop n xs` returns `xs` with the first `n` elements removed.
+--   If `n` is greater than the length of `xs`, returns the empty array.;
+--   drop : forall 'a. int -> array of 'a -> array of 'a := ###!dropFun###;
 
-  @doc `Array.filter p xs` returns an array containing only the elements of `xs`
-  that satisfy the predicate `p`;
-  filter : forall 'a. ('a -> bool{#true, #false}) -> array of 'a -> array of 'a := ###!filterFun###;
+--   @doc `Array.filter p xs` returns an array containing only the elements of `xs`
+--   that satisfy the predicate `p`;
+--   filter : forall 'a. ('a -> bool{#true, #false}) -> array of 'a -> array of 'a := ###!filterFun###;
 
-  @doc `Array.takeWhile`, applied to a predicate `p` and a list `xs`, returns the longest prefix (possibly empty) of `xs` of elements that satisfy `p`;
-  takeWhile : forall 'a. ('a -> bool{#true, #false}) -> array of 'a -> array of 'a := ###!takeWhileFun###;
+--   @doc `Array.takeWhile`, applied to a predicate `p` and a list `xs`, returns the longest prefix (possibly empty) of `xs` of elements that satisfy `p`;
+--   takeWhile : forall 'a. ('a -> bool{#true, #false}) -> array of 'a -> array of 'a := ###!takeWhileFun###;
 
-  @doc `Array.dropWhile p xs` drops the longest (possibly empty) prefix of elements of `xs` satisfying the predicate `p` and returns the remainder;
-  dropWhile : forall 'a. ('a -> bool{#true, #false}) -> array of 'a -> array of 'a := ###!dropWhileFun###;
+--   @doc `Array.dropWhile p xs` drops the longest (possibly empty) prefix of elements of `xs` satisfying the predicate `p` and returns the remainder;
+--   dropWhile : forall 'a. ('a -> bool{#true, #false}) -> array of 'a -> array of 'a := ###!dropWhileFun###;
 
-module Text
+-- module Text
 
-  append : text -> text -> text := ###appendText###;
+--   append : text -> text -> text := ###appendText###;
 
-  length : text -> int := ###textLength###;
+--   length : text -> int := ###textLength###;
 
-  strip : text -> text := ###stripText###;
+--   strip : text -> text := ###stripText###;
 
-  @doc Converts text to uppercase;
-  toUpper : text -> text := ###toUpperText###;
+--   @doc Converts text to uppercase;
+--   toUpper : text -> text := ###toUpperText###;
 
-  @doc Converts text to lowercase;
-  toLower : text -> text := ###toLowerText###;
+--   @doc Converts text to lowercase;
+--   toLower : text -> text := ###toLowerText###;
 
-  @doc Joins an array of text values into a single text, separating each element
-  with a space. Useful for splitting large amounts of text across lines;
-  unwords : array of text -> text := ###unwordsText###;
+--   @doc Joins an array of text values into a single text, separating each element
+--   with a space. Useful for splitting large amounts of text across lines;
+--   unwords : array of text -> text := ###unwordsText###;
 
-  splitAt : int -> text -> (text, text) := ###!textSplitAt###;
+--   splitAt : int -> text -> (text, text) := ###!textSplitAt###;
 
-  @doc Encode text as UTF-8 bytes. Returns an array of `word16` values representing
-  the UTF-8 byte sequence. Each `word16` represents one byte (0-255). Note: We use
-  `word16` instead of `word8` because Inferno does not currently support `word8`.;
-  encodeUtf8 : text -> array of word16 := ###encodeUtf8Text###;
+--   @doc Encode text as UTF-8 bytes. Returns an array of `word16` values representing
+--   the UTF-8 byte sequence. Each `word16` represents one byte (0-255). Note: We use
+--   `word16` instead of `word8` because Inferno does not currently support `word8`.;
+--   encodeUtf8 : text -> array of word16 := ###encodeUtf8Text###;
 
-  @doc Decode UTF-8 bytes to text. Takes an array of `word16` values
-  (each representing a byte, 0-255) and converts them to text. Uses lenient
-  decoding to handle invalid UTF-8 sequences gracefully. Note: We use `word16`
-  instead of `word8` because Inferno does not currently support `word8`.;
-  decodeUtf8 : array of word16 -> text := ###decodeUtf8Text###;
+--   @doc Decode UTF-8 bytes to text. Takes an array of `word16` values
+--   (each representing a byte, 0-255) and converts them to text. Uses lenient
+--   decoding to handle invalid UTF-8 sequences gracefully. Note: We use `word16`
+--   instead of `word8` because Inferno does not currently support `word8`.;
+--   decodeUtf8 : array of word16 -> text := ###decodeUtf8Text###;
 
-module Time
+-- module Time
 
-  toTime : timeDiff -> time := ###!idFun###;
+--   toTime : timeDiff -> time := ###!idFun###;
 
-  seconds : int -> timeDiff := ###secondsFun###;
+--   seconds : int -> timeDiff := ###secondsFun###;
 
-  minutes : int -> timeDiff := ###minutesFun###;
+--   minutes : int -> timeDiff := ###minutesFun###;
 
-  hours : int -> timeDiff := ###hoursFun###;
+--   hours : int -> timeDiff := ###hoursFun###;
 
-  days : int -> timeDiff := ###daysFun###;
+--   days : int -> timeDiff := ###daysFun###;
 
-  weeks : int -> timeDiff := ###weeksFun###;
+--   weeks : int -> timeDiff := ###weeksFun###;
 
-  secondsBefore : time -> int -> time := ###secondsBeforeFun###;
+--   secondsBefore : time -> int -> time := ###secondsBeforeFun###;
 
-  minutesBefore : time -> int -> time := ###minutesBeforeFun###;
+--   minutesBefore : time -> int -> time := ###minutesBeforeFun###;
 
-  hoursBefore : time -> int -> time := ###hoursBeforeFun###;
+--   hoursBefore : time -> int -> time := ###hoursBeforeFun###;
 
-  daysBefore : time -> int -> time := ###daysBeforeFun###;
+--   daysBefore : time -> int -> time := ###daysBeforeFun###;
 
-  weeksBefore : time -> int -> time := ###weeksBeforeFun###;
+--   weeksBefore : time -> int -> time := ###weeksBeforeFun###;
 
-  @doc Subtracts the given number of months, with days past the last day of the month clipped to the last day. For instance, 1 month before 2005-03-30 is 2005-02-28.;
-  monthsBefore : time -> int -> time := ###monthsBeforeFun###;
+--   @doc Subtracts the given number of months, with days past the last day of the month clipped to the last day. For instance, 1 month before 2005-03-30 is 2005-02-28.;
+--   monthsBefore : time -> int -> time := ###monthsBeforeFun###;
 
-  @doc Subtracts the given number of years, with days past the last day of the month clipped to the last day. For instance, 2 years before 2006-02-29 is 2004-02-28.;
-  yearsBefore : time -> int -> time := ###yearsBeforeFun###;
+--   @doc Subtracts the given number of years, with days past the last day of the month clipped to the last day. For instance, 2 years before 2006-02-29 is 2004-02-28.;
+--   yearsBefore : time -> int -> time := ###yearsBeforeFun###;
 
-  @doc Rounds down to the start of the nearest hour;
-  hour : time -> time := ###hourFun###;
+--   @doc Rounds down to the start of the nearest hour;
+--   hour : time -> time := ###hourFun###;
 
-  @doc Rounds down to the start of the nearest day;
-  day : time -> time := ###dayFun###;
+--   @doc Rounds down to the start of the nearest day;
+--   day : time -> time := ###dayFun###;
 
-  @doc Rounds down to the start of the nearest month;
-  month : time -> time := ###monthFun###;
+--   @doc Rounds down to the start of the nearest month;
+--   month : time -> time := ###monthFun###;
 
-  @doc Rounds down to the start of the nearest year;
-  year : time -> time := ###yearFun###;
+--   @doc Rounds down to the start of the nearest year;
+--   year : time -> time := ###yearFun###;
 
-  intervalEvery : timeDiff -> time -> time -> array of time := ###timeIntervalFun###;
+--   intervalEvery : timeDiff -> time -> time -> array of time := ###timeIntervalFun###;
 
-  @doc Convert time to int (returned as number of seconds since January 1, 1970, 00:00, not counting leap seconds);
-  timeToInt : time -> int := ###timeToInt###;
+--   @doc Convert time to int (returned as number of seconds since January 1, 1970, 00:00, not counting leap seconds);
+--   timeToInt : time -> int := ###timeToInt###;
 
-  @doc Format time to string;
-  formatTime : time -> text -> text := ###formatTime###;
+--   @doc Format time to string;
+--   formatTime : time -> text -> text := ###formatTime###;
 
-  @doc `parseTime format str` parses the string input `str` into a `time` value
-  using the provided `format` string. If `str` cannot be parsed according to
-  `format`, then `None` is returned, otherwise `Some time`
+--   @doc `parseTime format str` parses the string input `str` into a `time` value
+--   using the provided `format` string. If `str` cannot be parsed according to
+--   `format`, then `None` is returned, otherwise `Some time`
 
-  Example: `parseTime "%Y-%m-%d %H:%M:%S" "2025-09-17 07:23:46" == Some (toTime (seconds 1758093826))`
+--   Example: `parseTime "%Y-%m-%d %H:%M:%S" "2025-09-17 07:23:46" == Some (toTime (seconds 1758093826))`
 
-  For available format characters, please see the documentation for
-  https://hackage-content.haskell.org/package/time-1.15/docs/Data-Time-Format.html#v:formatTime;
-  parseTime : text -> text -> option of time := ###!parseTimeFun###;
+--   For available format characters, please see the documentation for
+--   https://hackage-content.haskell.org/package/time-1.15/docs/Data-Time-Format.html#v:formatTime;
+--   parseTime : text -> text -> option of time := ###!parseTimeFun###;
 
-module Word
+-- module Word
 
-  infixr 5 &&;
-  infixr 4 XOR;
-  infixr 3 ||;
+--   infixr 5 &&;
+--   infixr 4 XOR;
+--   infixr 3 ||;
 
-  prefix 19 !;
+--   prefix 19 !;
 
-  define bitlike on bool{#true, #false};
-  define bitlike on word16;
-  define bitlike on word32;
-  define bitlike on word64;
+--   define bitlike on bool{#true, #false};
+--   define bitlike on word16;
+--   define bitlike on word32;
+--   define bitlike on word64;
 
-  @doc Checks if the bit at the provided offset is set;
-  testBit : forall 'a. {requires bitlike on 'a} => 'a -> int -> bool{#true, #false} := ###testBitFun###;
+--   @doc Checks if the bit at the provided offset is set;
+--   testBit : forall 'a. {requires bitlike on 'a} => 'a -> int -> bool{#true, #false} := ###testBitFun###;
 
-  @doc Sets the bit at the provided offset to `1`;
-  setBit : forall 'a. {requires bitlike on 'a} => 'a -> int -> 'a := ###setBitFun###;
+--   @doc Sets the bit at the provided offset to `1`;
+--   setBit : forall 'a. {requires bitlike on 'a} => 'a -> int -> 'a := ###setBitFun###;
 
-  @doc Clears the bit at the provided offset (i.e., sets it to `0`);
-  clearBit : forall 'a. {requires bitlike on 'a} => 'a -> int -> 'a := ###clearBitFun###;
+--   @doc Clears the bit at the provided offset (i.e., sets it to `0`);
+--   clearBit : forall 'a. {requires bitlike on 'a} => 'a -> int -> 'a := ###clearBitFun###;
 
-  @doc Switches the bit at the provided offset (`0` to `1` or vice versa);
-  complementBit : forall 'a. {requires bitlike on 'a} => 'a -> int -> 'a := ###complementBitFun###;
+--   @doc Switches the bit at the provided offset (`0` to `1` or vice versa);
+--   complementBit : forall 'a. {requires bitlike on 'a} => 'a -> int -> 'a := ###complementBitFun###;
 
-  @doc `shift x i` shifts `x` left by `i` bits if `i` is positive, or right by `-i` bits otherwise.  Right shifts perform sign extension on signed number types (i.e. they fill the top bits with `1` if `x` is negative and with `0` otherwise).
-  Examples:
-  ~~~inferno
-  shift 0x0F0 4 == 0xF00
-  shift 0x0F0 (-4) == 0x00F
-  shift 0x0F0 (-8) == 0x000
-  ~~~;
-  shift : forall 'a. {requires bitlike on 'a} => 'a -> int -> 'a := ###shiftFun###;
+--   @doc `shift x i` shifts `x` left by `i` bits if `i` is positive, or right by `-i` bits otherwise.  Right shifts perform sign extension on signed number types (i.e. they fill the top bits with `1` if `x` is negative and with `0` otherwise).
+--   Examples:
+--   ~~~inferno
+--   shift 0x0F0 4 == 0xF00
+--   shift 0x0F0 (-4) == 0x00F
+--   shift 0x0F0 (-8) == 0x000
+--   ~~~;
+--   shift : forall 'a. {requires bitlike on 'a} => 'a -> int -> 'a := ###shiftFun###;
 
-  @doc Bitwise AND;
-  (&&) : forall 'a. {requires bitlike on 'a} => 'a -> 'a -> 'a := ###andFun###;
+--   @doc Bitwise AND;
+--   (&&) : forall 'a. {requires bitlike on 'a} => 'a -> 'a -> 'a := ###andFun###;
 
-  @doc Bitwise OR;
-  (||) : forall 'a. {requires bitlike on 'a} => 'a -> 'a -> 'a := ###orFun###;
+--   @doc Bitwise OR;
+--   (||) : forall 'a. {requires bitlike on 'a} => 'a -> 'a -> 'a := ###orFun###;
 
-  @doc Bitwise XOR;
-  (XOR) : forall 'a. {requires bitlike on 'a} => 'a -> 'a -> 'a := ###xorFun###;
+--   @doc Bitwise XOR;
+--   (XOR) : forall 'a. {requires bitlike on 'a} => 'a -> 'a -> 'a := ###xorFun###;
 
-  @doc Complements (switches 0s and 1s) all bits in the argument;
-  ! : forall 'a. {requires bitlike on 'a} => 'a -> 'a := ###complementFun###;
+--   @doc Complements (switches 0s and 1s) all bits in the argument;
+--   ! : forall 'a. {requires bitlike on 'a} => 'a -> 'a := ###complementFun###;
 
-  define toWord64 on bool{#true, #false};
-  define toWord64 on int;
-  define toWord64 on word16;
-  define toWord64 on word32;
-  define toWord64 on word64;
+--   define toWord64 on bool{#true, #false};
+--   define toWord64 on int;
+--   define toWord64 on word16;
+--   define toWord64 on word32;
+--   define toWord64 on word64;
 
-  @doc Convert an `int` or another word to a `word64`;
-  toWord64 : forall 'a. {requires toWord64 on 'a} => 'a -> word64 := ###toWord64Fun###;
+--   @doc Convert an `int` or another word to a `word64`;
+--   toWord64 : forall 'a. {requires toWord64 on 'a} => 'a -> word64 := ###toWord64Fun###;
 
-  define toWord32 on bool{#true, #false};
-  define toWord32 on int;
-  define toWord32 on word16;
-  define toWord32 on word32;
-  define toWord32 on word64;
+--   define toWord32 on bool{#true, #false};
+--   define toWord32 on int;
+--   define toWord32 on word16;
+--   define toWord32 on word32;
+--   define toWord32 on word64;
 
-  @doc Convert an `int` or another word to a `word32`, dropping bits if necessary;
-  toWord32 : forall 'a. {requires toWord32 on 'a} => 'a -> word32 := ###toWord32Fun###;
+--   @doc Convert an `int` or another word to a `word32`, dropping bits if necessary;
+--   toWord32 : forall 'a. {requires toWord32 on 'a} => 'a -> word32 := ###toWord32Fun###;
 
-  define toWord16 on bool{#true, #false};
-  define toWord16 on int;
-  define toWord16 on word16;
-  define toWord16 on word32;
-  define toWord16 on word64;
+--   define toWord16 on bool{#true, #false};
+--   define toWord16 on int;
+--   define toWord16 on word16;
+--   define toWord16 on word32;
+--   define toWord16 on word64;
 
-  @doc Convert an `int` or another word to a `word16`, dropping bits if necessary;
-  toWord16 : forall 'a. {requires toWord16 on 'a} => 'a -> word16 := ###toWord16Fun###;
+--   @doc Convert an `int` or another word to a `word16`, dropping bits if necessary;
+--   toWord16 : forall 'a. {requires toWord16 on 'a} => 'a -> word16 := ###toWord16Fun###;
 
-  define fromWord on bool{#true, #false};
-  define fromWord on word16;
-  define fromWord on word32;
-  define fromWord on word64;
+--   define fromWord on bool{#true, #false};
+--   define fromWord on word16;
+--   define fromWord on word32;
+--   define fromWord on word64;
 
-  @doc Convert a word to an `int`;
-  fromWord : forall 'a. {requires fromWord on 'a} => 'a -> int := ###fromWordFun###;
+--   @doc Convert a word to an `int`;
+--   fromWord : forall 'a. {requires fromWord on 'a} => 'a -> int := ###fromWordFun###;
 
-  @doc Decode a BCD-encoded word64;
-  fromBCD : word64 -> option of word64 := ###fromBCDFun###;
+--   @doc Decode a BCD-encoded word64;
+--   fromBCD : word64 -> option of word64 := ###fromBCDFun###;
 
-  @doc Encode a BCD-encoded word64;
-  toBCD : word64 -> word64 := ###toBCDFun###;
+--   @doc Encode a BCD-encoded word64;
+--   toBCD : word64 -> word64 := ###toBCDFun###;
 
-module Base
+-- module Base
 
-  infix 7 >=;
-  infix 7 >;
-  infix 7 <=;
-  infix 7 <;
-  infix 6 ==;
-  infix 6 !=;
-  infix 19 ..;
+--   infix 7 >=;
+--   infix 7 >;
+--   infix 7 <=;
+--   infix 7 <;
+--   infix 6 ==;
+--   infix 6 !=;
+--   infix 19 ..;
 
-  infixr 5 ?;
-  // infixl 5 <|>;
+--   infixr 5 ?;
+--   // infixl 5 <|>;
 
-  infixl 12 <<;
-  infixl 12 |>;
+--   infixl 12 <<;
+--   infixl 12 |>;
 
-  @doc Function composition. `(f << g) x == f (g x)`;
-  (<<) : forall 'a 'b 'c. ('b -> 'c) -> ('a -> 'b) -> 'a -> 'c := fun f g x -> f (g x);
+--   @doc Function composition. `(f << g) x == f (g x)`;
+--   (<<) : forall 'a 'b 'c. ('b -> 'c) -> ('a -> 'b) -> 'a -> 'c := fun f g x -> f (g x);
 
-  @doc The pipe operator. `x |> f |> g == g (f x)`;
-  (|>) : forall 'a 'b 'c. 'a -> ('a -> 'b) -> 'b := fun x f -> f x;
+--   @doc The pipe operator. `x |> f |> g == g (f x)`;
+--   (|>) : forall 'a 'b 'c. 'a -> ('a -> 'b) -> 'b := fun x f -> f x;
 
-  (..) := ###enumFromToInt64###;
+--   (..) := ###enumFromToInt64###;
 
-  define order on int;
-  define order on double;
-  define order on time;
-  define order on timeDiff;
+--   define order on int;
+--   define order on double;
+--   define order on time;
+--   define order on timeDiff;
 
-  @doc Ordering on `int`, `double`, `word16/32/64`, `time` and `timeDiff`;
-  (>) : forall 'a. {requires order on 'a} => 'a -> 'a -> bool{#true, #false} := ###gtFun###;
+--   @doc Ordering on `int`, `double`, `word16/32/64`, `time` and `timeDiff`;
+--   (>) : forall 'a. {requires order on 'a} => 'a -> 'a -> bool{#true, #false} := ###gtFun###;
 
-  @doc Ordering on `int`, `double`, `word16/32/64`, `time` and `timeDiff`;
-  (>=) : forall 'a. {requires order on 'a} => 'a -> 'a -> bool{#true, #false} := ###geqFun###;
+--   @doc Ordering on `int`, `double`, `word16/32/64`, `time` and `timeDiff`;
+--   (>=) : forall 'a. {requires order on 'a} => 'a -> 'a -> bool{#true, #false} := ###geqFun###;
 
-  @doc Ordering on `int`, `double`, `word16/32/64`, `time` and `timeDiff`;
-  (<) : forall 'a. {requires order on 'a} => 'a -> 'a -> bool{#true, #false} := ###ltFun###;
+--   @doc Ordering on `int`, `double`, `word16/32/64`, `time` and `timeDiff`;
+--   (<) : forall 'a. {requires order on 'a} => 'a -> 'a -> bool{#true, #false} := ###ltFun###;
 
-  @doc Ordering on `int`, `double`, `word16/32/64`, `time` and `timeDiff`;
-  (<=) : forall 'a. {requires order on 'a} => 'a -> 'a -> bool{#true, #false} := ###leqFun###;
+--   @doc Ordering on `int`, `double`, `word16/32/64`, `time` and `timeDiff`;
+--   (<=) : forall 'a. {requires order on 'a} => 'a -> 'a -> bool{#true, #false} := ###leqFun###;
 
-  @doc The equality function works on any value of the same type. Always returns `#false` for functions;
-  (==) : forall 'a. 'a -> 'a -> bool{#true, #false} := ###!eqFun###;
+--   @doc The equality function works on any value of the same type. Always returns `#false` for functions;
+--   (==) : forall 'a. 'a -> 'a -> bool{#true, #false} := ###!eqFun###;
 
-  @doc The (not) equals function works on any value of the same type. Always returns `#true` for functions;
-  (!=) : forall 'a. 'a -> 'a -> bool{#true, #false} := ###!neqFun###;
+--   @doc The (not) equals function works on any value of the same type. Always returns `#true` for functions;
+--   (!=) : forall 'a. 'a -> 'a -> bool{#true, #false} := ###!neqFun###;
 
-  @doc Minimum function on `int`, `double`, `word16/32/64`, `time` and `timeDiff`;
-  min : forall 'a. {requires order on 'a} => 'a -> 'a -> 'a := ###minFun###;
+--   @doc Minimum function on `int`, `double`, `word16/32/64`, `time` and `timeDiff`;
+--   min : forall 'a. {requires order on 'a} => 'a -> 'a -> 'a := ###minFun###;
 
-  @doc Maximum function on `int`, `double`, `word16/32/64`, `time` and `timeDiff`;
-  max : forall 'a. {requires order on 'a} => 'a -> 'a -> 'a := ###maxFun###;
+--   @doc Maximum function on `int`, `double`, `word16/32/64`, `time` and `timeDiff`;
+--   max : forall 'a. {requires order on 'a} => 'a -> 'a -> 'a := ###maxFun###;
 
-  export Number;
-  export Word;
+--   export Number;
+--   export Word;
 
-  @doc Array indexing: an infix operator to get the ith element of an array. Throws a RuntimeError if i is out of bounds.;
-  (!!) : forall 'a. array of 'a -> int -> 'a := Array.get;
+--   @doc Array indexing: an infix operator to get the ith element of an array. Throws a RuntimeError if i is out of bounds.;
+--   (!!) : forall 'a. array of 'a -> int -> 'a := Array.get;
 
-  @doc Safe array indexing: an infix operator to get the ith element of an array. Returns None if i is out of bounds.;
-  (!?) : forall 'a. array of 'a -> int -> option of 'a := Array.getOpt;
+--   @doc Safe array indexing: an infix operator to get the ith element of an array. Returns None if i is out of bounds.;
+--   (!?) : forall 'a. array of 'a -> int -> option of 'a := Array.getOpt;
 
-  // TODO why doesn't this work?
-  // (:) : forall 'a. 'a -> array of 'a -> array of 'a := cons;
+--   // TODO why doesn't this work?
+--   // (:) : forall 'a. 'a -> array of 'a -> array of 'a := cons;
 
-  @doc The `fromOption` function unwraps an optional value, if given a default value to fall back on in case the value of the optional is `None`.
-  ~~~inferno
-  fromOption "hi" (Some "hello") == "hello"
-  fromOption "hi" None == "hi"
-  ~~~;
-  fromOption : forall 'a. 'a -> option of 'a -> 'a :=
-    fun default ma -> match ma with {
-      | Some a -> a
-      | None -> default
-    };
+--   @doc The `fromOption` function unwraps an optional value, if given a default value to fall back on in case the value of the optional is `None`.
+--   ~~~inferno
+--   fromOption "hi" (Some "hello") == "hello"
+--   fromOption "hi" None == "hi"
+--   ~~~;
+--   fromOption : forall 'a. 'a -> option of 'a -> 'a :=
+--     fun default ma -> match ma with {
+--       | Some a -> a
+--       | None -> default
+--     };
 
-  @doc The `?` function unwraps an optional value, if given a default value to fall back on in case the value of the optional is `None`.
-  ~~~inferno
-  (Some "hello") ? "hi" == "hello"
-  None ? "hi" == "hi"
-  ~~~;
-  (?) : forall 'a. option of 'a -> 'a -> 'a :=
-    fun ma default -> match ma with {
-      | Some a -> a
-      | None -> default
-    };
+--   @doc The `?` function unwraps an optional value, if given a default value to fall back on in case the value of the optional is `None`.
+--   ~~~inferno
+--   (Some "hello") ? "hi" == "hello"
+--   None ? "hi" == "hi"
+--   ~~~;
+--   (?) : forall 'a. option of 'a -> 'a -> 'a :=
+--     fun ma default -> match ma with {
+--       | Some a -> a
+--       | None -> default
+--     };
 
-  // TODO fix parser and re-introduce this
-  // @doc The `<|>` operator implements choice: it returns the left value if not `None`, otherwise the right value.
-  // ~~~inferno
-  // (Some "hello") <|> Some "hi" == Some "hello"
-  // None <|> Some "hi" == Some "hi"
-  // ~~~;
-  // (<|>) : forall 'a. option of 'a -> option of 'a -> option of 'a :=
-  //   fun ma default -> match ma with {
-  //     | Some a -> Some a
-  //     | None -> default
-  //   };
+--   // TODO fix parser and re-introduce this
+--   // @doc The `<|>` operator implements choice: it returns the left value if not `None`, otherwise the right value.
+--   // ~~~inferno
+--   // (Some "hello") <|> Some "hi" == Some "hello"
+--   // None <|> Some "hi" == Some "hi"
+--   // ~~~;
+--   // (<|>) : forall 'a. option of 'a -> option of 'a -> option of 'a :=
+--   //   fun ma default -> match ma with {
+--   //     | Some a -> Some a
+--   //     | None -> default
+--   //   };
 
-  @doc Gets the first component of a tuple: `fst (x, y) == x`;
-  fst : forall 'a 'b. ('a, 'b) -> 'a := fun t -> match t with { (x, y) -> x };
+--   @doc Gets the first component of a tuple: `fst (x, y) == x`;
+--   fst : forall 'a 'b. ('a, 'b) -> 'a := fun t -> match t with { (x, y) -> x };
 
-  @doc Gets the second component of a tuple: `snd (x, y) == y`;
-  snd : forall 'a 'b. ('a, 'b) -> 'b := fun t -> match t with { (x, y) -> y };
+--   @doc Gets the second component of a tuple: `snd (x, y) == y`;
+--   snd : forall 'a 'b. ('a, 'b) -> 'b := fun t -> match t with { (x, y) -> y };
 
-  @doc Zip two arrays into a array of tuples/pairs. If one input array is shorter than the other, excess elements of the longer array are discarded. `zip [1, 2] ['a', 'b'] == [(1,'a'),(2,'b')]`;
-  zip : forall 'a 'b. array of 'a -> array of 'b -> array of ('a, 'b) := ###!zipFun###;
+--   @doc Zip two arrays into a array of tuples/pairs. If one input array is shorter than the other, excess elements of the longer array are discarded. `zip [1, 2] ['a', 'b'] == [(1,'a'),(2,'b')]`;
+--   zip : forall 'a 'b. array of 'a -> array of 'b -> array of ('a, 'b) := ###!zipFun###;
 
-  @doc `zipWith f xs ys` zips two arrays together by applying the pair-wise
-  function `f` to corresponding elements. If one input array is shorter than the
-  other, excess elements of the longer array are discarded.
-  Example: `zipWith (+) [1, 2, 3] [4, 5, 6] == [5, 7, 9]`;
-  zipWith : forall 'a 'b 'c. ('a -> 'b -> 'c) -> array of 'a -> array of 'b -> array of 'c := ###!zipWithFun###;
+--   @doc `zipWith f xs ys` zips two arrays together by applying the pair-wise
+--   function `f` to corresponding elements. If one input array is shorter than the
+--   other, excess elements of the longer array are discarded.
+--   Example: `zipWith (+) [1, 2, 3] [4, 5, 6] == [5, 7, 9]`;
+--   zipWith : forall 'a 'b 'c. ('a -> 'b -> 'c) -> array of 'a -> array of 'b -> array of 'c := ###!zipWithFun###;
 
-|]
+-- |]

--- a/inferno-core/src/Inferno/Module/Prelude.hs
+++ b/inferno-core/src/Inferno/Module/Prelude.hs
@@ -222,7 +222,6 @@ builtinModules = undefined -- FIXME Need to disable until parser is finished
 --   define addition on word64 word32 word64;
 --   define addition on word64 word64 word64;
 
-
 --   @doc Addition on `int`, `double`, `word16/32/64`, `time` and `timeDiff`;
 --   (+) : forall 'a 'b 'c. {requires addition on 'a 'b 'c} => 'a -> 'b -> 'c := ###sumFun###;
 
@@ -841,4 +840,4 @@ builtinModules = undefined -- FIXME Need to disable until parser is finished
 --   Example: `zipWith (+) [1, 2, 3] [4, 5, 6] == [5, 7, 9]`;
 --   zipWith : forall 'a 'b 'c. ('a -> 'b -> 'c) -> array of 'a -> array of 'b -> array of 'c := ###!zipWithFun###;
 
--- |]
+-- | ]

--- a/inferno-core/src/Inferno/Module/Prelude.hs
+++ b/inferno-core/src/Inferno/Module/Prelude.hs
@@ -183,661 +183,660 @@ preludeNameToTypeMap moduleMap =
 -- `define typeclass_name on t1 ... tn;`.
 
 builtinModules :: (MonadIO m, MonadThrow m, MonadCatch m, Pretty c, Eq c) => ModuleMap m c
-builtinModules = undefined -- FIXME Need to disable until parser is finished
---   [infernoModules|
-
--- module Number
+builtinModules =
+  [infernoModules|
+
+module Number
 
---   @doc The identity function;
---   id : forall 'a. 'a -> 'a := ###!idFun###;
-
---   infixl 12 !!;
---   infixl 12 !?;
-
---   infixr 11 **;
+  @doc The identity function;
+  id : forall 'a. 'a -> 'a := ###!idFun###;
+
+  infixl 12 !!;
+  infixl 12 !?;
+
+  infixr 11 **;
 
---   infixl 10 *;
---   infixl 10 /;
---   infixl 10 %;
+  infixl 10 *;
+  infixl 10 /;
+  infixl 10 %;
 
---   infixl 9 +;
---   infixl 9 -;
+  infixl 9 +;
+  infixl 9 -;
 
---   prefix 19 -;
+  prefix 19 -;
 
---   define addition on int int int;
---   define addition on int double double;
---   define addition on double int double;
---   define addition on double double double;
---   define addition on time timeDiff time;
---   define addition on timeDiff time time;
---   define addition on timeDiff timeDiff timeDiff;
---   define addition on word16 word16 word16;
---   define addition on word16 word32 word32;
---   define addition on word32 word16 word32;
---   define addition on word32 word32 word32;
---   define addition on word16 word64 word64;
---   define addition on word64 word16 word64;
---   define addition on word32 word64 word64;
---   define addition on word64 word32 word64;
---   define addition on word64 word64 word64;
+  define addition on int int int;
+  define addition on int double double;
+  define addition on double int double;
+  define addition on double double double;
+  define addition on time timeDiff time;
+  define addition on timeDiff time time;
+  define addition on timeDiff timeDiff timeDiff;
+  define addition on word16 word16 word16;
+  define addition on word16 word32 word32;
+  define addition on word32 word16 word32;
+  define addition on word32 word32 word32;
+  define addition on word16 word64 word64;
+  define addition on word64 word16 word64;
+  define addition on word32 word64 word64;
+  define addition on word64 word32 word64;
+  define addition on word64 word64 word64;
 
---   @doc Addition on `int`, `double`, `word16/32/64`, `time` and `timeDiff`;
---   (+) : forall 'a 'b 'c. {requires addition on 'a 'b 'c} => 'a -> 'b -> 'c := ###sumFun###;
+  @doc Addition on `int`, `double`, `word16/32/64`, `time` and `timeDiff`;
+  (+) : forall 'a 'b 'c. {requires addition on 'a 'b 'c} => 'a -> 'b -> 'c := ###sumFun###;
 
---   define subtraction on int int int;
---   define subtraction on int double double;
---   define subtraction on double int double;
---   define subtraction on double double double;
---   define subtraction on time timeDiff time;
---   define subtraction on timeDiff timeDiff timeDiff;
---   define subtraction on word16 word16 word16;
---   define subtraction on word32 word32 word32;
---   define subtraction on word64 word64 word64;
+  define subtraction on int int int;
+  define subtraction on int double double;
+  define subtraction on double int double;
+  define subtraction on double double double;
+  define subtraction on time timeDiff time;
+  define subtraction on timeDiff timeDiff timeDiff;
+  define subtraction on word16 word16 word16;
+  define subtraction on word32 word32 word32;
+  define subtraction on word64 word64 word64;
 
---   @doc Subtraction on `int`, `double`, `word16/32/64`, `time` and `timeDiff`;
---   (-) : forall 'a 'b 'c. {requires subtraction on 'a 'b 'c} => 'a -> 'b -> 'c := ###subFun###;
+  @doc Subtraction on `int`, `double`, `word16/32/64`, `time` and `timeDiff`;
+  (-) : forall 'a 'b 'c. {requires subtraction on 'a 'b 'c} => 'a -> 'b -> 'c := ###subFun###;
 
---   define division on int int int;
---   define division on int double double;
---   define division on double int double;
---   define division on double double double;
+  define division on int int int;
+  define division on int double double;
+  define division on double int double;
+  define division on double double double;
 
---   @doc Division on `int`, `double`;
---   (/) : forall 'a 'b 'c. {requires division on 'a 'b 'c} => 'a -> 'b -> 'c := ###divFun###;
+  @doc Division on `int`, `double`;
+  (/) : forall 'a 'b 'c. {requires division on 'a 'b 'c} => 'a -> 'b -> 'c := ###divFun###;
 
---   define multiplication on int int int;
---   define multiplication on int double double;
---   define multiplication on double int double;
---   define multiplication on double double double;
---   define multiplication on int timeDiff timeDiff;
---   define multiplication on timeDiff int timeDiff;
+  define multiplication on int int int;
+  define multiplication on int double double;
+  define multiplication on double int double;
+  define multiplication on double double double;
+  define multiplication on int timeDiff timeDiff;
+  define multiplication on timeDiff int timeDiff;
 
---   @doc Multiplication on `int`, `double`;
---   (*) : forall 'a 'b 'c. {requires multiplication on 'a 'b 'c} => 'a -> 'b -> 'c := ###mulFun###;
+  @doc Multiplication on `int`, `double`;
+  (*) : forall 'a 'b 'c. {requires multiplication on 'a 'b 'c} => 'a -> 'b -> 'c := ###mulFun###;
 
---   @doc Reciprocal fraction;
---   recip : double -> double := ###recipFun###;
+  @doc Reciprocal fraction;
+  recip : double -> double := ###recipFun###;
 
---   define power on int;
---   define power on double;
+  define power on int;
+  define power on double;
 
---   @doc `x ** y` raises `x` to the power of `y`, where the arguments are `int` or `double`;
---   (**) : forall 'a. {requires power on 'a} => 'a -> 'a -> 'a := ###powFun###;
+  @doc `x ** y` raises `x` to the power of `y`, where the arguments are `int` or `double`;
+  (**) : forall 'a. {requires power on 'a} => 'a -> 'a -> 'a := ###powFun###;
 
---   @doc Square root;
---   sqrt : double -> double := ###sqrtFun###;
+  @doc Square root;
+  sqrt : double -> double := ###sqrtFun###;
 
---   @doc Exponential function;
---   exp : double -> double := ###expFun###;
+  @doc Exponential function;
+  exp : double -> double := ###expFun###;
 
---   @doc Natural logarithm;
---   ln : double -> double := ###lnFun###;
+  @doc Natural logarithm;
+  ln : double -> double := ###lnFun###;
 
---   @doc Logarithm with base `10`;
---   log : double -> double := ###logFun###;
+  @doc Logarithm with base `10`;
+  log : double -> double := ###logFun###;
 
---   @doc Logarithm with base `b`;
---   logBase : double -> double -> double := ###logBaseFun###;
+  @doc Logarithm with base `b`;
+  logBase : double -> double -> double := ###logBaseFun###;
 
---   define negate on int;
---   define negate on double;
---   define negate on timeDiff;
+  define negate on int;
+  define negate on double;
+  define negate on timeDiff;
 
---   @doc Negation (unary) on `int`, `double`, or `timeDiff`;
---   - : forall 'a. {requires negate on 'a} => 'a -> 'a := ###negateFun###;
+  @doc Negation (unary) on `int`, `double`, or `timeDiff`;
+  - : forall 'a. {requires negate on 'a} => 'a -> 'a := ###negateFun###;
 
---   define abs on int;
---   define abs on double;
---   define abs on timeDiff;
+  define abs on int;
+  define abs on double;
+  define abs on timeDiff;
 
---   @doc Absolute value (sometimes written |x|) on `int`, `double`, or `timeDiff`;
---   abs : forall 'a. {requires abs on 'a} => 'a -> 'a := ###absFun###;
+  @doc Absolute value (sometimes written |x|) on `int`, `double`, or `timeDiff`;
+  abs : forall 'a. {requires abs on 'a} => 'a -> 'a := ###absFun###;
 
---   @doc Modulus operator. `n % m` is the remainder obtained when `n` is divided by `m`. E.g. `5 % 3 == 2`;
---   (%) : int -> int -> int := ###modFun###;
+  @doc Modulus operator. `n % m` is the remainder obtained when `n` is divided by `m`. E.g. `5 % 3 == 2`;
+  (%) : int -> int -> int := ###modFun###;
 
---   define roundable on double;
---   define roundable on int;
+  define roundable on double;
+  define roundable on int;
 
---   @doc Floor function (rounds down to nearest integer);
---   floor : forall 'a. {requires roundable on 'a} => 'a -> int := ###floorFun###;
+  @doc Floor function (rounds down to nearest integer);
+  floor : forall 'a. {requires roundable on 'a} => 'a -> int := ###floorFun###;
 
---   @doc Ceiling function (rounds up to nearest integer);
---   ceiling : forall 'a. {requires roundable on 'a} => 'a -> int := ###ceilingFun###;
+  @doc Ceiling function (rounds up to nearest integer);
+  ceiling : forall 'a. {requires roundable on 'a} => 'a -> int := ###ceilingFun###;
 
---   @doc `round x` returns the nearest integer to `x`
---   (the even integer if `x` is equidistant between two integers);
---   round : forall 'a. {requires roundable on 'a} => 'a -> int := ###roundFun###;
+  @doc `round x` returns the nearest integer to `x`
+  (the even integer if `x` is equidistant between two integers);
+  round : forall 'a. {requires roundable on 'a} => 'a -> int := ###roundFun###;
 
---   @doc `roundTo d x` rounds `x` to `d` decimal places;
---   roundTo : int -> double -> double := ###roundToFun###;
+  @doc `roundTo d x` rounds `x` to `d` decimal places;
+  roundTo : int -> double -> double := ###roundToFun###;
 
---   @doc `truncate x` returns the integer nearest `x` between zero and `x`;
---   truncate : forall 'a. {requires roundable on 'a} => 'a -> int := ###truncateFun###;
+  @doc `truncate x` returns the integer nearest `x` between zero and `x`;
+  truncate : forall 'a. {requires roundable on 'a} => 'a -> int := ###truncateFun###;
 
---   @doc `truncateTo d x` truncates `x` to `d` decimal places;
---   truncateTo : int -> double -> double := ###truncateToFun###;
+  @doc `truncateTo d x` truncates `x` to `d` decimal places;
+  truncateTo : int -> double -> double := ###truncateToFun###;
 
---   @doc `limit l u x = min l (max x u)` limits `x` to be between `l` and `u`;
---   limit : double -> double -> double -> double := ###limitFun###;
+  @doc `limit l u x = min l (max x u)` limits `x` to be between `l` and `u`;
+  limit : double -> double -> double -> double := ###limitFun###;
 
---   @doc Pi (`3.14159... :: double`), the constant;
---   pi : double := ###piFun###;
+  @doc Pi (`3.14159... :: double`), the constant;
+  pi : double := ###piFun###;
 
---   @doc Sine (trigonometric function) of a `double`;
---   sin : double -> double := ###sinFun###;
+  @doc Sine (trigonometric function) of a `double`;
+  sin : double -> double := ###sinFun###;
 
---   @doc Hyperbolic sine (trigonometric function) of a `double`;
---   sinh : double -> double := ###sinhFun###;
+  @doc Hyperbolic sine (trigonometric function) of a `double`;
+  sinh : double -> double := ###sinhFun###;
 
---   @doc Inverse sine (trigonometric function) of a `double`;
---   arcSin : double -> double := ###arcSinFun###;
+  @doc Inverse sine (trigonometric function) of a `double`;
+  arcSin : double -> double := ###arcSinFun###;
 
---   @doc Cosine (trigonometric function), on `double`;
---   cos : double -> double := ###cosFun###;
+  @doc Cosine (trigonometric function), on `double`;
+  cos : double -> double := ###cosFun###;
 
---   @doc Hyperbolic cosine (trigonometric function) of a `double`;
---   cosh : double -> double := ###coshFun###;
+  @doc Hyperbolic cosine (trigonometric function) of a `double`;
+  cosh : double -> double := ###coshFun###;
 
---   @doc Inverse cosine (trigonometric function) of a `double`;
---   arcCos : double -> double := ###arcCosFun###;
+  @doc Inverse cosine (trigonometric function) of a `double`;
+  arcCos : double -> double := ###arcCosFun###;
 
---   @doc Tan (trigonometric function), on `double`;
---   tan : double -> double := ###tanFun###;
+  @doc Tan (trigonometric function), on `double`;
+  tan : double -> double := ###tanFun###;
 
---   @doc Hyperbolic tangent (trigonometric function) of a `double`;
---   tanh : double -> double := ###tanhFun###;
+  @doc Hyperbolic tangent (trigonometric function) of a `double`;
+  tanh : double -> double := ###tanhFun###;
 
---   @doc Inverse tan (trigonometric function) of a `double`;
---   arcTan : double -> double := ###arcTanFun###;
+  @doc Inverse tan (trigonometric function) of a `double`;
+  arcTan : double -> double := ###arcTanFun###;
 
---   @doc Convert int to double;
---   intToDouble : int -> double := ###intToDouble###;
+  @doc Convert int to double;
+  intToDouble : int -> double := ###intToDouble###;
 
---   @doc Convert double to int;
---   doubleToInt : double -> int := ###doubleToInt###;
+  @doc Convert double to int;
+  doubleToInt : double -> int := ###doubleToInt###;
 
---   @doc A (pseudo)random `double` number in the `[0, 1)` interval. To obtain a random number between 20 and 30, use `(10 * random ()) + 20`. The `()` argument is needed so that each time `random` is called a new random value is generated.;
---   random : () -> double := ###!randomFun###;
+  @doc A (pseudo)random `double` number in the `[0, 1)` interval. To obtain a random number between 20 and 30, use `(10 * random ()) + 20`. The `()` argument is needed so that each time `random` is called a new random value is generated.;
+  random : () -> double := ###!randomFun###;
 
---   define scalar on int;
---   define scalar on double;
---   define scalar on bool{#true, #false};
+  define scalar on int;
+  define scalar on double;
+  define scalar on bool{#true, #false};
 
--- module Option
---   @doc `Option.reduce f o d` unwraps an optional value `o` and applies `f` to it, if o contains a `Some` value. Otherwise it returns the default value `d`.
---   ~~~inferno
---   Option.reduce (fun str -> `${str} there!`) "hi" (Some "hello") == "hello there!"
---   Option.reduce (fun str -> `${str} there!`) "hi" None == "hi"
---   ~~~;
---   reduce : forall 'a 'b. ('a -> 'b) -> 'b -> option of 'a -> 'b :=
---     fun f b ma -> match ma with {
---       | Some a -> f a
---       | None -> b
---     };
+module Option
+  @doc `Option.reduce f o d` unwraps an optional value `o` and applies `f` to it, if o contains a `Some` value. Otherwise it returns the default value `d`.
+  ~~~inferno
+  Option.reduce (fun str -> `${str} there!`) "hi" (Some "hello") == "hello there!"
+  Option.reduce (fun str -> `${str} there!`) "hi" None == "hi"
+  ~~~;
+  reduce : forall 'a 'b. ('a -> 'b) -> 'b -> option of 'a -> 'b :=
+    fun f b ma -> match ma with {
+      | Some a -> f a
+      | None -> b
+    };
 
---   @doc `Option.map f ma` applies `f` to the value inside `ma`, namely if `ma` is `Some a`, it will return `Some (f a)`.;
---   map : forall 'a 'b. ('a -> 'b) -> option of 'a -> option of 'b :=
---     fun f ma -> match ma with {
---       | Some a -> Some (f a)
---       | None -> None
---     };
+  @doc `Option.map f ma` applies `f` to the value inside `ma`, namely if `ma` is `Some a`, it will return `Some (f a)`.;
+  map : forall 'a 'b. ('a -> 'b) -> option of 'a -> option of 'b :=
+    fun f ma -> match ma with {
+      | Some a -> Some (f a)
+      | None -> None
+    };
 
---   @doc `Option.flatMap f ma` applies `f` to the value inside `ma` and flattens the result,
---   i.e. if `ma` is `Some a`, it returns the `option` result of `f a`, otherwise `None`.;
---   flatMap : forall 'a 'b. ('a -> option of 'b) -> option of 'a -> option of 'b :=
---     fun f ma -> match ma with {
---       | Some a -> f a
---       | None -> None
---     };
+  @doc `Option.flatMap f ma` applies `f` to the value inside `ma` and flattens the result,
+  i.e. if `ma` is `Some a`, it returns the `option` result of `f a`, otherwise `None`.;
+  flatMap : forall 'a 'b. ('a -> option of 'b) -> option of 'a -> option of 'b :=
+    fun f ma -> match ma with {
+      | Some a -> f a
+      | None -> None
+    };
 
---   @doc `Option.traverse f xs` applies `f` to each element of `xs`, returning `Some` of
---   the resulting array if all applications return `Some`, or `None` if any returns `None`.;
---   traverse : forall 'a 'b. ('a -> option of 'b) -> array of 'a -> option of (array of 'b) :=
---     ###!traverseOptionFun###;
+  @doc `Option.traverse f xs` applies `f` to each element of `xs`, returning `Some` of
+  the resulting array if all applications return `Some`, or `None` if any returns `None`.;
+  traverse : forall 'a 'b. ('a -> option of 'b) -> array of 'a -> option of (array of 'b) :=
+    ###!traverseOptionFun###;
 
---   singleton : forall 'a. 'a -> option of 'a := fun a -> Some a;
+  singleton : forall 'a. 'a -> option of 'a := fun a -> Some a;
 
---   @doc Given a tuple `(Some x , Some y)`, `Option.mergeTuple` returns `Some (x , y)`. If any of the components are `None` it returns `None`.;
---   mergeTuple : forall 'a 'b. (option of 'a, option of 'b) -> option of ('a, 'b) :=
---     fun ab -> match ab with {
---       | (Some a , Some b) -> Some (a , b)
---       | _ -> None
---     };
+  @doc Given a tuple `(Some x , Some y)`, `Option.mergeTuple` returns `Some (x , y)`. If any of the components are `None` it returns `None`.;
+  mergeTuple : forall 'a 'b. (option of 'a, option of 'b) -> option of ('a, 'b) :=
+    fun ab -> match ab with {
+      | (Some a , Some b) -> Some (a , b)
+      | _ -> None
+    };
 
---   @doc `Option.join` removes the outer "layer" of a nested option. (By definition, `Option.join == Option.reduce id None`).
---   ~~~inferno
---   Option.join None == None
---   Option.join (Some None) == None
---   Option.join (Some (Some a)) == Some a
---   ~~~;
---   join : forall 'a. option of (option of 'a) -> option of 'a := reduce Number.id None;
+  @doc `Option.join` removes the outer "layer" of a nested option. (By definition, `Option.join == Option.reduce id None`).
+  ~~~inferno
+  Option.join None == None
+  Option.join (Some None) == None
+  Option.join (Some (Some a)) == Some a
+  ~~~;
+  join : forall 'a. option of (option of 'a) -> option of 'a := reduce Number.id None;
 
--- module Array
+module Array
 
---   @doc Array construction. `cons x xs` is the array that has `x` as its first element and array `xs` as the rest of the array. For example, `cons 3 [1, 2] == [3, 1, 2]`;
---   cons : forall 'a. 'a -> array of 'a -> array of 'a := ###!consFun###;
-
---   @doc Array destruction into head and tail. `uncons xs` is `Some (x, xs1)` if array has at least one element and `xs == cons x xs1`, and is `None` if `xs == []`. For example, `uncons [1, 2, 3] == Some (1, [2, 3])`;
---   uncons : forall 'a. array of 'a -> option of ('a, array of 'a) := ###!unconsFun###;
-
---   @doc Array indexing: gets the ith element of an array. Throws a RuntimeError if i is out of bounds.;
---   get : forall 'a. array of 'a -> int -> 'a := ###!arrayIndexFun###;
-
---   @doc Safe array indexing: gets the ith element of an array. Returns None if i is out of bounds.;
---   getOpt : forall 'a. array of 'a -> int -> option of 'a := ###!arrayIndexOptFun###;
-
---   @doc This function can be used to create an array with a single element:
---   ~~~inferno
---   singleton 2
---   ~~~;
---   singleton : forall 'a. 'a -> array of 'a := ###!singletonFun###;
-
---   length : forall 'a. array of 'a -> int := ###!lengthFun###;
-
---   @doc The minimum value in an array, or `None` if empty;
---   minimum: forall 'a. {requires order on 'a} => array of 'a -> option of 'a := ###!minimumFun###;
-
---   @doc The maximum value in an array, or `None` if empty;
---   maximum: forall 'a. {requires order on 'a} => array of 'a -> option of 'a := ###!maximumFun###;
-
---   @doc The average of the values in an array, or `None` if empty;
---   average: forall 'a. {requires numeric on 'a} => array of 'a -> option of double := ###!averageFun###;
-
---   @doc Return the median of the values in an array, or `None` if empty;
---   median: forall 'a. {requires numeric on 'a} => array of 'a -> option of double := ###!medianFun###;
-
---   @doc The index of the minimum value in an array, or `None` if empty;
---   argmin: forall 'a. {requires order on 'a} => array of 'a -> option of int := ###!argminFun###;
-
---   @doc The index of the maximum value in an array, or `None` if empty;
---   argmax: forall 'a. {requires order on 'a} => array of 'a -> option of int := ###!argmaxFun###;
-
---   @doc Returns the indices that would sort an array;
---   argsort: forall 'a. {requires order on 'a} => array of 'a -> array of int := ###!argsortFun###;
+  @doc Array construction. `cons x xs` is the array that has `x` as its first element and array `xs` as the rest of the array. For example, `cons 3 [1, 2] == [3, 1, 2]`;
+  cons : forall 'a. 'a -> array of 'a -> array of 'a := ###!consFun###;
+
+  @doc Array destruction into head and tail. `uncons xs` is `Some (x, xs1)` if array has at least one element and `xs == cons x xs1`, and is `None` if `xs == []`. For example, `uncons [1, 2, 3] == Some (1, [2, 3])`;
+  uncons : forall 'a. array of 'a -> option of ('a, array of 'a) := ###!unconsFun###;
+
+  @doc Array indexing: gets the ith element of an array. Throws a RuntimeError if i is out of bounds.;
+  get : forall 'a. array of 'a -> int -> 'a := ###!arrayIndexFun###;
+
+  @doc Safe array indexing: gets the ith element of an array. Returns None if i is out of bounds.;
+  getOpt : forall 'a. array of 'a -> int -> option of 'a := ###!arrayIndexOptFun###;
+
+  @doc This function can be used to create an array with a single element:
+  ~~~inferno
+  singleton 2
+  ~~~;
+  singleton : forall 'a. 'a -> array of 'a := ###!singletonFun###;
+
+  length : forall 'a. array of 'a -> int := ###!lengthFun###;
+
+  @doc The minimum value in an array, or `None` if empty;
+  minimum: forall 'a. {requires order on 'a} => array of 'a -> option of 'a := ###!minimumFun###;
+
+  @doc The maximum value in an array, or `None` if empty;
+  maximum: forall 'a. {requires order on 'a} => array of 'a -> option of 'a := ###!maximumFun###;
+
+  @doc The average of the values in an array, or `None` if empty;
+  average: forall 'a. {requires numeric on 'a} => array of 'a -> option of double := ###!averageFun###;
+
+  @doc Return the median of the values in an array, or `None` if empty;
+  median: forall 'a. {requires numeric on 'a} => array of 'a -> option of double := ###!medianFun###;
+
+  @doc The index of the minimum value in an array, or `None` if empty;
+  argmin: forall 'a. {requires order on 'a} => array of 'a -> option of int := ###!argminFun###;
+
+  @doc The index of the maximum value in an array, or `None` if empty;
+  argmax: forall 'a. {requires order on 'a} => array of 'a -> option of int := ###!argmaxFun###;
+
+  @doc Returns the indices that would sort an array;
+  argsort: forall 'a. {requires order on 'a} => array of 'a -> array of int := ###!argsortFun###;
 
---   @doc Returns the Euclidean norm of an array, or `None` if empty;
---   magnitude: forall 'a. {requires numeric on 'a} => array of 'a -> option of double := ###!magnitudeFun###;
+  @doc Returns the Euclidean norm of an array, or `None` if empty;
+  magnitude: forall 'a. {requires numeric on 'a} => array of 'a -> option of double := ###!magnitudeFun###;
 
---   @doc Returns the Euclidean norm of an array, or `None` if empty;
---   norm: forall 'a. {requires numeric on 'a} => array of 'a -> option of double := ###!normFun###;
+  @doc Returns the Euclidean norm of an array, or `None` if empty;
+  norm: forall 'a. {requires numeric on 'a} => array of 'a -> option of double := ###!normFun###;
 
---   @doc The `Array.range` function takes two `int` arguments `n` and `m` and produces an array `[n,...,m]`.
---   If `m` > `n`, the empty array is returned.;
---   range := ###enumFromToInt64###;
+  @doc The `Array.range` function takes two `int` arguments `n` and `m` and produces an array `[n,...,m]`.
+  If `m` > `n`, the empty array is returned.;
+  range := ###enumFromToInt64###;
 
---   @doc The `Array.map` function takes a function `f` and an array of elements and applies `f` to each one;
---   map := fun f xs -> [f x | x <- xs];
+  @doc The `Array.map` function takes a function `f` and an array of elements and applies `f` to each one;
+  map := fun f xs -> [f x | x <- xs];
 
---   @doc `Array.keepSomes` discards any `None` values in an array and unwaps all `Some`s.
---   ~~~inferno
---   Array.keepSomes [None, Some "hello", None, Some "world"] = ["hello", "world"]
---   ~~~;
---   keepSomes : forall 'a. array of (option of 'a) -> array of 'a := ###!keepSomesFun###;
+  @doc `Array.keepSomes` discards any `None` values in an array and unwaps all `Some`s.
+  ~~~inferno
+  Array.keepSomes [None, Some "hello", None, Some "world"] = ["hello", "world"]
+  ~~~;
+  keepSomes : forall 'a. array of (option of 'a) -> array of 'a := ###!keepSomesFun###;
 
---   @doc `reduce` applied to a binary operator, a starting value (typically an identity of the operator, e.g. `0`), and an array, reduces the array using the binary operator, from left to right:
---   ~~~inferno
---   reduce f z [x1, x2, ..., xn] == (...((z `f` x1) `f` x2) `f`...) `f` xn
---   ~~~
---   Example: `reduce (+) 42 [1, 2, 3, 4] == 52`;
---   reduce : forall 'a 'b. ('b -> 'a -> 'b) -> 'b -> array of 'a -> 'b := ###!foldlFun###;
+  @doc `reduce` applied to a binary operator, a starting value (typically an identity of the operator, e.g. `0`), and an array, reduces the array using the binary operator, from left to right:
+  ~~~inferno
+  reduce f z [x1, x2, ..., xn] == (...((z `f` x1) `f` x2) `f`...) `f` xn
+  ~~~
+  Example: `reduce (+) 42 [1, 2, 3, 4] == 52`;
+  reduce : forall 'a 'b. ('b -> 'a -> 'b) -> 'b -> array of 'a -> 'b := ###!foldlFun###;
 
---   @doc `reduceRight`, applied to a binary operator, a starting value (typically an identity of the operator), and a array, reduces the array using the binary operator, from right to left:
---   ~~~inferno
---   reduceRight f z [x1, x2, ..., xn] == x1 `f` (x2 `f` ... (xn `f` z)...)
---   ~~~
---   Example: `reduceRight (+) 42 [1, 2, 3, 4] == 52`, but `reduceRight (-) 0 [5, 3] == 2` while `reduceRight (-) 0 [3, 5] == -2`;
---   reduceRight : forall 'a 'b. ('a -> 'b -> 'b) -> 'b -> array of 'a -> 'b := ###!foldrFun###;
+  @doc `reduceRight`, applied to a binary operator, a starting value (typically an identity of the operator), and a array, reduces the array using the binary operator, from right to left:
+  ~~~inferno
+  reduceRight f z [x1, x2, ..., xn] == x1 `f` (x2 `f` ... (xn `f` z)...)
+  ~~~
+  Example: `reduceRight (+) 42 [1, 2, 3, 4] == 52`, but `reduceRight (-) 0 [5, 3] == 2` while `reduceRight (-) 0 [3, 5] == -2`;
+  reduceRight : forall 'a 'b. ('a -> 'b -> 'b) -> 'b -> array of 'a -> 'b := ###!foldrFun###;
 
---   define zero on int;
---   define zero on double;
---   define zero on word16;
---   define zero on word32;
---   define zero on word64;
---   define zero on timeDiff;
+  define zero on int;
+  define zero on double;
+  define zero on word16;
+  define zero on word32;
+  define zero on word64;
+  define zero on timeDiff;
 
---   zero : forall 'a. {requires rep on 'a, requires zero on 'a} => 'a := ###!zeroFun###;
+  zero : forall 'a. {requires rep on 'a, requires zero on 'a} => 'a := ###!zeroFun###;
 
---   @doc `Array.sum` computes the sum of elements in an array. The elements can be of type `int`/`double`/`word`.;
---   sum := reduce Number.(+) zero;
+  @doc `Array.sum` computes the sum of elements in an array. The elements can be of type `int`/`double`/`word`.;
+  sum := reduce Number.(+) zero;
 
---   findFirstSome : forall 'a. array of (option of 'a) -> option of 'a :=
---     reduceRight
---       (fun a rest -> match a with {
---         | Some _ -> a
---         | None -> rest
---       })
---       None;
---   findLastSome : forall 'a. array of (option of 'a) -> option of 'a :=
---     reduce
---       (fun rest a -> match a with {
---         | Some _ -> a
---         | None -> rest
---       })
---       None;
---   findFirstAndLastSome : forall 'a. array of (option of 'a) -> option of ('a, 'a) :=
---     let firstLast =
---       reduce
---         (fun acc a -> match (a , acc) with {
---           | (Some _ , (None , _)) -> (a , a)
---           | (Some _ , (Some v , _)) -> (Some v , a)
---           | (None , _) -> acc
---         })
---         (None, None)
---     in fun arr -> Option.mergeTuple (firstLast arr);
+  findFirstSome : forall 'a. array of (option of 'a) -> option of 'a :=
+    reduceRight
+      (fun a rest -> match a with {
+        | Some _ -> a
+        | None -> rest
+      })
+      None;
+  findLastSome : forall 'a. array of (option of 'a) -> option of 'a :=
+    reduce
+      (fun rest a -> match a with {
+        | Some _ -> a
+        | None -> rest
+      })
+      None;
+  findFirstAndLastSome : forall 'a. array of (option of 'a) -> option of ('a, 'a) :=
+    let firstLast =
+      reduce
+        (fun acc a -> match (a , acc) with {
+          | (Some _ , (None , _)) -> (a , a)
+          | (Some _ , (Some v , _)) -> (Some v , a)
+          | (None , _) -> acc
+        })
+        (None, None)
+    in fun arr -> Option.mergeTuple (firstLast arr);
 
---   @doc `Array.reverse xs` returns the elements of `xs` in reverse order;
---   reverse : forall 'a. array of 'a -> array of 'a := ###!reverseFun###;
+  @doc `Array.reverse xs` returns the elements of `xs` in reverse order;
+  reverse : forall 'a. array of 'a -> array of 'a := ###!reverseFun###;
 
---   @doc `Array.take n xs` returns the first `n` elements of `xs`.
---   If `n` is greater than the length of `xs`, returns `xs`.;
---   take : forall 'a. int -> array of 'a -> array of 'a := ###!takeFun###;
+  @doc `Array.take n xs` returns the first `n` elements of `xs`.
+  If `n` is greater than the length of `xs`, returns `xs`.;
+  take : forall 'a. int -> array of 'a -> array of 'a := ###!takeFun###;
 
---   @doc `Array.drop n xs` returns `xs` with the first `n` elements removed.
---   If `n` is greater than the length of `xs`, returns the empty array.;
---   drop : forall 'a. int -> array of 'a -> array of 'a := ###!dropFun###;
+  @doc `Array.drop n xs` returns `xs` with the first `n` elements removed.
+  If `n` is greater than the length of `xs`, returns the empty array.;
+  drop : forall 'a. int -> array of 'a -> array of 'a := ###!dropFun###;
 
---   @doc `Array.filter p xs` returns an array containing only the elements of `xs`
---   that satisfy the predicate `p`;
---   filter : forall 'a. ('a -> bool{#true, #false}) -> array of 'a -> array of 'a := ###!filterFun###;
+  @doc `Array.filter p xs` returns an array containing only the elements of `xs`
+  that satisfy the predicate `p`;
+  filter : forall 'a. ('a -> bool{#true, #false}) -> array of 'a -> array of 'a := ###!filterFun###;
 
---   @doc `Array.takeWhile`, applied to a predicate `p` and a list `xs`, returns the longest prefix (possibly empty) of `xs` of elements that satisfy `p`;
---   takeWhile : forall 'a. ('a -> bool{#true, #false}) -> array of 'a -> array of 'a := ###!takeWhileFun###;
+  @doc `Array.takeWhile`, applied to a predicate `p` and a list `xs`, returns the longest prefix (possibly empty) of `xs` of elements that satisfy `p`;
+  takeWhile : forall 'a. ('a -> bool{#true, #false}) -> array of 'a -> array of 'a := ###!takeWhileFun###;
 
---   @doc `Array.dropWhile p xs` drops the longest (possibly empty) prefix of elements of `xs` satisfying the predicate `p` and returns the remainder;
---   dropWhile : forall 'a. ('a -> bool{#true, #false}) -> array of 'a -> array of 'a := ###!dropWhileFun###;
+  @doc `Array.dropWhile p xs` drops the longest (possibly empty) prefix of elements of `xs` satisfying the predicate `p` and returns the remainder;
+  dropWhile : forall 'a. ('a -> bool{#true, #false}) -> array of 'a -> array of 'a := ###!dropWhileFun###;
 
--- module Text
+module Text
 
---   append : text -> text -> text := ###appendText###;
+  append : text -> text -> text := ###appendText###;
 
---   length : text -> int := ###textLength###;
+  length : text -> int := ###textLength###;
 
---   strip : text -> text := ###stripText###;
+  strip : text -> text := ###stripText###;
 
---   @doc Converts text to uppercase;
---   toUpper : text -> text := ###toUpperText###;
+  @doc Converts text to uppercase;
+  toUpper : text -> text := ###toUpperText###;
 
---   @doc Converts text to lowercase;
---   toLower : text -> text := ###toLowerText###;
+  @doc Converts text to lowercase;
+  toLower : text -> text := ###toLowerText###;
 
---   @doc Joins an array of text values into a single text, separating each element
---   with a space. Useful for splitting large amounts of text across lines;
---   unwords : array of text -> text := ###unwordsText###;
+  @doc Joins an array of text values into a single text, separating each element
+  with a space. Useful for splitting large amounts of text across lines;
+  unwords : array of text -> text := ###unwordsText###;
 
---   splitAt : int -> text -> (text, text) := ###!textSplitAt###;
+  splitAt : int -> text -> (text, text) := ###!textSplitAt###;
 
---   @doc Encode text as UTF-8 bytes. Returns an array of `word16` values representing
---   the UTF-8 byte sequence. Each `word16` represents one byte (0-255). Note: We use
---   `word16` instead of `word8` because Inferno does not currently support `word8`.;
---   encodeUtf8 : text -> array of word16 := ###encodeUtf8Text###;
+  @doc Encode text as UTF-8 bytes. Returns an array of `word16` values representing
+  the UTF-8 byte sequence. Each `word16` represents one byte (0-255). Note: We use
+  `word16` instead of `word8` because Inferno does not currently support `word8`.;
+  encodeUtf8 : text -> array of word16 := ###encodeUtf8Text###;
 
---   @doc Decode UTF-8 bytes to text. Takes an array of `word16` values
---   (each representing a byte, 0-255) and converts them to text. Uses lenient
---   decoding to handle invalid UTF-8 sequences gracefully. Note: We use `word16`
---   instead of `word8` because Inferno does not currently support `word8`.;
---   decodeUtf8 : array of word16 -> text := ###decodeUtf8Text###;
+  @doc Decode UTF-8 bytes to text. Takes an array of `word16` values
+  (each representing a byte, 0-255) and converts them to text. Uses lenient
+  decoding to handle invalid UTF-8 sequences gracefully. Note: We use `word16`
+  instead of `word8` because Inferno does not currently support `word8`.;
+  decodeUtf8 : array of word16 -> text := ###decodeUtf8Text###;
 
--- module Time
+module Time
 
---   toTime : timeDiff -> time := ###!idFun###;
+  toTime : timeDiff -> time := ###!idFun###;
 
---   seconds : int -> timeDiff := ###secondsFun###;
+  seconds : int -> timeDiff := ###secondsFun###;
 
---   minutes : int -> timeDiff := ###minutesFun###;
+  minutes : int -> timeDiff := ###minutesFun###;
 
---   hours : int -> timeDiff := ###hoursFun###;
+  hours : int -> timeDiff := ###hoursFun###;
 
---   days : int -> timeDiff := ###daysFun###;
+  days : int -> timeDiff := ###daysFun###;
 
---   weeks : int -> timeDiff := ###weeksFun###;
+  weeks : int -> timeDiff := ###weeksFun###;
 
---   secondsBefore : time -> int -> time := ###secondsBeforeFun###;
+  secondsBefore : time -> int -> time := ###secondsBeforeFun###;
 
---   minutesBefore : time -> int -> time := ###minutesBeforeFun###;
+  minutesBefore : time -> int -> time := ###minutesBeforeFun###;
 
---   hoursBefore : time -> int -> time := ###hoursBeforeFun###;
+  hoursBefore : time -> int -> time := ###hoursBeforeFun###;
 
---   daysBefore : time -> int -> time := ###daysBeforeFun###;
+  daysBefore : time -> int -> time := ###daysBeforeFun###;
 
---   weeksBefore : time -> int -> time := ###weeksBeforeFun###;
+  weeksBefore : time -> int -> time := ###weeksBeforeFun###;
 
---   @doc Subtracts the given number of months, with days past the last day of the month clipped to the last day. For instance, 1 month before 2005-03-30 is 2005-02-28.;
---   monthsBefore : time -> int -> time := ###monthsBeforeFun###;
+  @doc Subtracts the given number of months, with days past the last day of the month clipped to the last day. For instance, 1 month before 2005-03-30 is 2005-02-28.;
+  monthsBefore : time -> int -> time := ###monthsBeforeFun###;
 
---   @doc Subtracts the given number of years, with days past the last day of the month clipped to the last day. For instance, 2 years before 2006-02-29 is 2004-02-28.;
---   yearsBefore : time -> int -> time := ###yearsBeforeFun###;
+  @doc Subtracts the given number of years, with days past the last day of the month clipped to the last day. For instance, 2 years before 2006-02-29 is 2004-02-28.;
+  yearsBefore : time -> int -> time := ###yearsBeforeFun###;
 
---   @doc Rounds down to the start of the nearest hour;
---   hour : time -> time := ###hourFun###;
+  @doc Rounds down to the start of the nearest hour;
+  hour : time -> time := ###hourFun###;
 
---   @doc Rounds down to the start of the nearest day;
---   day : time -> time := ###dayFun###;
+  @doc Rounds down to the start of the nearest day;
+  day : time -> time := ###dayFun###;
 
---   @doc Rounds down to the start of the nearest month;
---   month : time -> time := ###monthFun###;
+  @doc Rounds down to the start of the nearest month;
+  month : time -> time := ###monthFun###;
 
---   @doc Rounds down to the start of the nearest year;
---   year : time -> time := ###yearFun###;
+  @doc Rounds down to the start of the nearest year;
+  year : time -> time := ###yearFun###;
 
---   intervalEvery : timeDiff -> time -> time -> array of time := ###timeIntervalFun###;
+  intervalEvery : timeDiff -> time -> time -> array of time := ###timeIntervalFun###;
 
---   @doc Convert time to int (returned as number of seconds since January 1, 1970, 00:00, not counting leap seconds);
---   timeToInt : time -> int := ###timeToInt###;
+  @doc Convert time to int (returned as number of seconds since January 1, 1970, 00:00, not counting leap seconds);
+  timeToInt : time -> int := ###timeToInt###;
 
---   @doc Format time to string;
---   formatTime : time -> text -> text := ###formatTime###;
+  @doc Format time to string;
+  formatTime : time -> text -> text := ###formatTime###;
 
---   @doc `parseTime format str` parses the string input `str` into a `time` value
---   using the provided `format` string. If `str` cannot be parsed according to
---   `format`, then `None` is returned, otherwise `Some time`
+  @doc `parseTime format str` parses the string input `str` into a `time` value
+  using the provided `format` string. If `str` cannot be parsed according to
+  `format`, then `None` is returned, otherwise `Some time`
 
---   Example: `parseTime "%Y-%m-%d %H:%M:%S" "2025-09-17 07:23:46" == Some (toTime (seconds 1758093826))`
+  Example: `parseTime "%Y-%m-%d %H:%M:%S" "2025-09-17 07:23:46" == Some (toTime (seconds 1758093826))`
 
---   For available format characters, please see the documentation for
---   https://hackage-content.haskell.org/package/time-1.15/docs/Data-Time-Format.html#v:formatTime;
---   parseTime : text -> text -> option of time := ###!parseTimeFun###;
+  For available format characters, please see the documentation for
+  https://hackage-content.haskell.org/package/time-1.15/docs/Data-Time-Format.html#v:formatTime;
+  parseTime : text -> text -> option of time := ###!parseTimeFun###;
 
--- module Word
+module Word
 
---   infixr 5 &&;
---   infixr 4 XOR;
---   infixr 3 ||;
+  infixr 5 &&;
+  infixr 4 XOR;
+  infixr 3 ||;
 
---   prefix 19 !;
+  prefix 19 !;
 
---   define bitlike on bool{#true, #false};
---   define bitlike on word16;
---   define bitlike on word32;
---   define bitlike on word64;
+  define bitlike on bool{#true, #false};
+  define bitlike on word16;
+  define bitlike on word32;
+  define bitlike on word64;
 
---   @doc Checks if the bit at the provided offset is set;
---   testBit : forall 'a. {requires bitlike on 'a} => 'a -> int -> bool{#true, #false} := ###testBitFun###;
+  @doc Checks if the bit at the provided offset is set;
+  testBit : forall 'a. {requires bitlike on 'a} => 'a -> int -> bool{#true, #false} := ###testBitFun###;
 
---   @doc Sets the bit at the provided offset to `1`;
---   setBit : forall 'a. {requires bitlike on 'a} => 'a -> int -> 'a := ###setBitFun###;
+  @doc Sets the bit at the provided offset to `1`;
+  setBit : forall 'a. {requires bitlike on 'a} => 'a -> int -> 'a := ###setBitFun###;
 
---   @doc Clears the bit at the provided offset (i.e., sets it to `0`);
---   clearBit : forall 'a. {requires bitlike on 'a} => 'a -> int -> 'a := ###clearBitFun###;
+  @doc Clears the bit at the provided offset (i.e., sets it to `0`);
+  clearBit : forall 'a. {requires bitlike on 'a} => 'a -> int -> 'a := ###clearBitFun###;
 
---   @doc Switches the bit at the provided offset (`0` to `1` or vice versa);
---   complementBit : forall 'a. {requires bitlike on 'a} => 'a -> int -> 'a := ###complementBitFun###;
+  @doc Switches the bit at the provided offset (`0` to `1` or vice versa);
+  complementBit : forall 'a. {requires bitlike on 'a} => 'a -> int -> 'a := ###complementBitFun###;
 
---   @doc `shift x i` shifts `x` left by `i` bits if `i` is positive, or right by `-i` bits otherwise.  Right shifts perform sign extension on signed number types (i.e. they fill the top bits with `1` if `x` is negative and with `0` otherwise).
---   Examples:
---   ~~~inferno
---   shift 0x0F0 4 == 0xF00
---   shift 0x0F0 (-4) == 0x00F
---   shift 0x0F0 (-8) == 0x000
---   ~~~;
---   shift : forall 'a. {requires bitlike on 'a} => 'a -> int -> 'a := ###shiftFun###;
+  @doc `shift x i` shifts `x` left by `i` bits if `i` is positive, or right by `-i` bits otherwise.  Right shifts perform sign extension on signed number types (i.e. they fill the top bits with `1` if `x` is negative and with `0` otherwise).
+  Examples:
+  ~~~inferno
+  shift 0x0F0 4 == 0xF00
+  shift 0x0F0 (-4) == 0x00F
+  shift 0x0F0 (-8) == 0x000
+  ~~~;
+  shift : forall 'a. {requires bitlike on 'a} => 'a -> int -> 'a := ###shiftFun###;
 
---   @doc Bitwise AND;
---   (&&) : forall 'a. {requires bitlike on 'a} => 'a -> 'a -> 'a := ###andFun###;
+  @doc Bitwise AND;
+  (&&) : forall 'a. {requires bitlike on 'a} => 'a -> 'a -> 'a := ###andFun###;
 
---   @doc Bitwise OR;
---   (||) : forall 'a. {requires bitlike on 'a} => 'a -> 'a -> 'a := ###orFun###;
+  @doc Bitwise OR;
+  (||) : forall 'a. {requires bitlike on 'a} => 'a -> 'a -> 'a := ###orFun###;
 
---   @doc Bitwise XOR;
---   (XOR) : forall 'a. {requires bitlike on 'a} => 'a -> 'a -> 'a := ###xorFun###;
+  @doc Bitwise XOR;
+  (XOR) : forall 'a. {requires bitlike on 'a} => 'a -> 'a -> 'a := ###xorFun###;
 
---   @doc Complements (switches 0s and 1s) all bits in the argument;
---   ! : forall 'a. {requires bitlike on 'a} => 'a -> 'a := ###complementFun###;
+  @doc Complements (switches 0s and 1s) all bits in the argument;
+  ! : forall 'a. {requires bitlike on 'a} => 'a -> 'a := ###complementFun###;
 
---   define toWord64 on bool{#true, #false};
---   define toWord64 on int;
---   define toWord64 on word16;
---   define toWord64 on word32;
---   define toWord64 on word64;
+  define toWord64 on bool{#true, #false};
+  define toWord64 on int;
+  define toWord64 on word16;
+  define toWord64 on word32;
+  define toWord64 on word64;
 
---   @doc Convert an `int` or another word to a `word64`;
---   toWord64 : forall 'a. {requires toWord64 on 'a} => 'a -> word64 := ###toWord64Fun###;
+  @doc Convert an `int` or another word to a `word64`;
+  toWord64 : forall 'a. {requires toWord64 on 'a} => 'a -> word64 := ###toWord64Fun###;
 
---   define toWord32 on bool{#true, #false};
---   define toWord32 on int;
---   define toWord32 on word16;
---   define toWord32 on word32;
---   define toWord32 on word64;
+  define toWord32 on bool{#true, #false};
+  define toWord32 on int;
+  define toWord32 on word16;
+  define toWord32 on word32;
+  define toWord32 on word64;
 
---   @doc Convert an `int` or another word to a `word32`, dropping bits if necessary;
---   toWord32 : forall 'a. {requires toWord32 on 'a} => 'a -> word32 := ###toWord32Fun###;
+  @doc Convert an `int` or another word to a `word32`, dropping bits if necessary;
+  toWord32 : forall 'a. {requires toWord32 on 'a} => 'a -> word32 := ###toWord32Fun###;
 
---   define toWord16 on bool{#true, #false};
---   define toWord16 on int;
---   define toWord16 on word16;
---   define toWord16 on word32;
---   define toWord16 on word64;
+  define toWord16 on bool{#true, #false};
+  define toWord16 on int;
+  define toWord16 on word16;
+  define toWord16 on word32;
+  define toWord16 on word64;
 
---   @doc Convert an `int` or another word to a `word16`, dropping bits if necessary;
---   toWord16 : forall 'a. {requires toWord16 on 'a} => 'a -> word16 := ###toWord16Fun###;
+  @doc Convert an `int` or another word to a `word16`, dropping bits if necessary;
+  toWord16 : forall 'a. {requires toWord16 on 'a} => 'a -> word16 := ###toWord16Fun###;
 
---   define fromWord on bool{#true, #false};
---   define fromWord on word16;
---   define fromWord on word32;
---   define fromWord on word64;
+  define fromWord on bool{#true, #false};
+  define fromWord on word16;
+  define fromWord on word32;
+  define fromWord on word64;
 
---   @doc Convert a word to an `int`;
---   fromWord : forall 'a. {requires fromWord on 'a} => 'a -> int := ###fromWordFun###;
+  @doc Convert a word to an `int`;
+  fromWord : forall 'a. {requires fromWord on 'a} => 'a -> int := ###fromWordFun###;
 
---   @doc Decode a BCD-encoded word64;
---   fromBCD : word64 -> option of word64 := ###fromBCDFun###;
+  @doc Decode a BCD-encoded word64;
+  fromBCD : word64 -> option of word64 := ###fromBCDFun###;
 
---   @doc Encode a BCD-encoded word64;
---   toBCD : word64 -> word64 := ###toBCDFun###;
+  @doc Encode a BCD-encoded word64;
+  toBCD : word64 -> word64 := ###toBCDFun###;
 
--- module Base
+module Base
 
---   infix 7 >=;
---   infix 7 >;
---   infix 7 <=;
---   infix 7 <;
---   infix 6 ==;
---   infix 6 !=;
---   infix 19 ..;
+  infix 7 >=;
+  infix 7 >;
+  infix 7 <=;
+  infix 7 <;
+  infix 6 ==;
+  infix 6 !=;
+  infix 19 ..;
 
---   infixr 5 ?;
---   // infixl 5 <|>;
+  infixr 5 ?;
+  // infixl 5 <|>;
 
---   infixl 12 <<;
---   infixl 12 |>;
+  infixl 12 <<;
+  infixl 12 |>;
 
---   @doc Function composition. `(f << g) x == f (g x)`;
---   (<<) : forall 'a 'b 'c. ('b -> 'c) -> ('a -> 'b) -> 'a -> 'c := fun f g x -> f (g x);
+  @doc Function composition. `(f << g) x == f (g x)`;
+  (<<) : forall 'a 'b 'c. ('b -> 'c) -> ('a -> 'b) -> 'a -> 'c := fun f g x -> f (g x);
 
---   @doc The pipe operator. `x |> f |> g == g (f x)`;
---   (|>) : forall 'a 'b 'c. 'a -> ('a -> 'b) -> 'b := fun x f -> f x;
+  @doc The pipe operator. `x |> f |> g == g (f x)`;
+  (|>) : forall 'a 'b 'c. 'a -> ('a -> 'b) -> 'b := fun x f -> f x;
 
---   (..) := ###enumFromToInt64###;
+  (..) := ###enumFromToInt64###;
 
---   define order on int;
---   define order on double;
---   define order on time;
---   define order on timeDiff;
+  define order on int;
+  define order on double;
+  define order on time;
+  define order on timeDiff;
 
---   @doc Ordering on `int`, `double`, `word16/32/64`, `time` and `timeDiff`;
---   (>) : forall 'a. {requires order on 'a} => 'a -> 'a -> bool{#true, #false} := ###gtFun###;
+  @doc Ordering on `int`, `double`, `word16/32/64`, `time` and `timeDiff`;
+  (>) : forall 'a. {requires order on 'a} => 'a -> 'a -> bool{#true, #false} := ###gtFun###;
 
---   @doc Ordering on `int`, `double`, `word16/32/64`, `time` and `timeDiff`;
---   (>=) : forall 'a. {requires order on 'a} => 'a -> 'a -> bool{#true, #false} := ###geqFun###;
+  @doc Ordering on `int`, `double`, `word16/32/64`, `time` and `timeDiff`;
+  (>=) : forall 'a. {requires order on 'a} => 'a -> 'a -> bool{#true, #false} := ###geqFun###;
 
---   @doc Ordering on `int`, `double`, `word16/32/64`, `time` and `timeDiff`;
---   (<) : forall 'a. {requires order on 'a} => 'a -> 'a -> bool{#true, #false} := ###ltFun###;
+  @doc Ordering on `int`, `double`, `word16/32/64`, `time` and `timeDiff`;
+  (<) : forall 'a. {requires order on 'a} => 'a -> 'a -> bool{#true, #false} := ###ltFun###;
 
---   @doc Ordering on `int`, `double`, `word16/32/64`, `time` and `timeDiff`;
---   (<=) : forall 'a. {requires order on 'a} => 'a -> 'a -> bool{#true, #false} := ###leqFun###;
+  @doc Ordering on `int`, `double`, `word16/32/64`, `time` and `timeDiff`;
+  (<=) : forall 'a. {requires order on 'a} => 'a -> 'a -> bool{#true, #false} := ###leqFun###;
 
---   @doc The equality function works on any value of the same type. Always returns `#false` for functions;
---   (==) : forall 'a. 'a -> 'a -> bool{#true, #false} := ###!eqFun###;
+  @doc The equality function works on any value of the same type. Always returns `#false` for functions;
+  (==) : forall 'a. 'a -> 'a -> bool{#true, #false} := ###!eqFun###;
 
---   @doc The (not) equals function works on any value of the same type. Always returns `#true` for functions;
---   (!=) : forall 'a. 'a -> 'a -> bool{#true, #false} := ###!neqFun###;
+  @doc The (not) equals function works on any value of the same type. Always returns `#true` for functions;
+  (!=) : forall 'a. 'a -> 'a -> bool{#true, #false} := ###!neqFun###;
 
---   @doc Minimum function on `int`, `double`, `word16/32/64`, `time` and `timeDiff`;
---   min : forall 'a. {requires order on 'a} => 'a -> 'a -> 'a := ###minFun###;
+  @doc Minimum function on `int`, `double`, `word16/32/64`, `time` and `timeDiff`;
+  min : forall 'a. {requires order on 'a} => 'a -> 'a -> 'a := ###minFun###;
 
---   @doc Maximum function on `int`, `double`, `word16/32/64`, `time` and `timeDiff`;
---   max : forall 'a. {requires order on 'a} => 'a -> 'a -> 'a := ###maxFun###;
+  @doc Maximum function on `int`, `double`, `word16/32/64`, `time` and `timeDiff`;
+  max : forall 'a. {requires order on 'a} => 'a -> 'a -> 'a := ###maxFun###;
 
---   export Number;
---   export Word;
+  export Number;
+  export Word;
 
---   @doc Array indexing: an infix operator to get the ith element of an array. Throws a RuntimeError if i is out of bounds.;
---   (!!) : forall 'a. array of 'a -> int -> 'a := Array.get;
+  @doc Array indexing: an infix operator to get the ith element of an array. Throws a RuntimeError if i is out of bounds.;
+  (!!) : forall 'a. array of 'a -> int -> 'a := Array.get;
 
---   @doc Safe array indexing: an infix operator to get the ith element of an array. Returns None if i is out of bounds.;
---   (!?) : forall 'a. array of 'a -> int -> option of 'a := Array.getOpt;
+  @doc Safe array indexing: an infix operator to get the ith element of an array. Returns None if i is out of bounds.;
+  (!?) : forall 'a. array of 'a -> int -> option of 'a := Array.getOpt;
 
---   // TODO why doesn't this work?
---   // (:) : forall 'a. 'a -> array of 'a -> array of 'a := cons;
+  // TODO why doesn't this work?
+  // (:) : forall 'a. 'a -> array of 'a -> array of 'a := cons;
 
---   @doc The `fromOption` function unwraps an optional value, if given a default value to fall back on in case the value of the optional is `None`.
---   ~~~inferno
---   fromOption "hi" (Some "hello") == "hello"
---   fromOption "hi" None == "hi"
---   ~~~;
---   fromOption : forall 'a. 'a -> option of 'a -> 'a :=
---     fun default ma -> match ma with {
---       | Some a -> a
---       | None -> default
---     };
+  @doc The `fromOption` function unwraps an optional value, if given a default value to fall back on in case the value of the optional is `None`.
+  ~~~inferno
+  fromOption "hi" (Some "hello") == "hello"
+  fromOption "hi" None == "hi"
+  ~~~;
+  fromOption : forall 'a. 'a -> option of 'a -> 'a :=
+    fun default ma -> match ma with {
+      | Some a -> a
+      | None -> default
+    };
 
---   @doc The `?` function unwraps an optional value, if given a default value to fall back on in case the value of the optional is `None`.
---   ~~~inferno
---   (Some "hello") ? "hi" == "hello"
---   None ? "hi" == "hi"
---   ~~~;
---   (?) : forall 'a. option of 'a -> 'a -> 'a :=
---     fun ma default -> match ma with {
---       | Some a -> a
---       | None -> default
---     };
+  @doc The `?` function unwraps an optional value, if given a default value to fall back on in case the value of the optional is `None`.
+  ~~~inferno
+  (Some "hello") ? "hi" == "hello"
+  None ? "hi" == "hi"
+  ~~~;
+  (?) : forall 'a. option of 'a -> 'a -> 'a :=
+    fun ma default -> match ma with {
+      | Some a -> a
+      | None -> default
+    };
 
---   // TODO fix parser and re-introduce this
---   // @doc The `<|>` operator implements choice: it returns the left value if not `None`, otherwise the right value.
---   // ~~~inferno
---   // (Some "hello") <|> Some "hi" == Some "hello"
---   // None <|> Some "hi" == Some "hi"
---   // ~~~;
---   // (<|>) : forall 'a. option of 'a -> option of 'a -> option of 'a :=
---   //   fun ma default -> match ma with {
---   //     | Some a -> Some a
---   //     | None -> default
---   //   };
+  // TODO fix parser and re-introduce this
+  // @doc The `<|>` operator implements choice: it returns the left value if not `None`, otherwise the right value.
+  // ~~~inferno
+  // (Some "hello") <|> Some "hi" == Some "hello"
+  // None <|> Some "hi" == Some "hi"
+  // ~~~;
+  // (<|>) : forall 'a. option of 'a -> option of 'a -> option of 'a :=
+  //   fun ma default -> match ma with {
+  //     | Some a -> Some a
+  //     | None -> default
+  //   };
 
---   @doc Gets the first component of a tuple: `fst (x, y) == x`;
---   fst : forall 'a 'b. ('a, 'b) -> 'a := fun t -> match t with { (x, y) -> x };
+  @doc Gets the first component of a tuple: `fst (x, y) == x`;
+  fst : forall 'a 'b. ('a, 'b) -> 'a := fun t -> match t with { (x, y) -> x };
 
---   @doc Gets the second component of a tuple: `snd (x, y) == y`;
---   snd : forall 'a 'b. ('a, 'b) -> 'b := fun t -> match t with { (x, y) -> y };
+  @doc Gets the second component of a tuple: `snd (x, y) == y`;
+  snd : forall 'a 'b. ('a, 'b) -> 'b := fun t -> match t with { (x, y) -> y };
 
---   @doc Zip two arrays into a array of tuples/pairs. If one input array is shorter than the other, excess elements of the longer array are discarded. `zip [1, 2] ['a', 'b'] == [(1,'a'),(2,'b')]`;
---   zip : forall 'a 'b. array of 'a -> array of 'b -> array of ('a, 'b) := ###!zipFun###;
+  @doc Zip two arrays into a array of tuples/pairs. If one input array is shorter than the other, excess elements of the longer array are discarded. `zip [1, 2] ['a', 'b'] == [(1,'a'),(2,'b')]`;
+  zip : forall 'a 'b. array of 'a -> array of 'b -> array of ('a, 'b) := ###!zipFun###;
 
---   @doc `zipWith f xs ys` zips two arrays together by applying the pair-wise
---   function `f` to corresponding elements. If one input array is shorter than the
---   other, excess elements of the longer array are discarded.
---   Example: `zipWith (+) [1, 2, 3] [4, 5, 6] == [5, 7, 9]`;
---   zipWith : forall 'a 'b 'c. ('a -> 'b -> 'c) -> array of 'a -> array of 'b -> array of 'c := ###!zipWithFun###;
-
--- | ]
+  @doc `zipWith f xs ys` zips two arrays together by applying the pair-wise
+  function `f` to corresponding elements. If one input array is shorter than the
+  other, excess elements of the longer array are discarded.
+  Example: `zipWith (+) [1, 2, 3] [4, 5, 6] == [5, 7, 9]`;
+  zipWith : forall 'a 'b 'c. ('a -> 'b -> 'c) -> array of 'a -> array of 'b -> array of 'c := ###!zipWithFun###;
+|]

--- a/inferno-core/src/Inferno/Parse.hs
+++ b/inferno-core/src/Inferno/Parse.hs
@@ -3,9 +3,9 @@
 {-# LANGUAGE ExplicitForAll #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE NoFieldSelectors #-}
-
 {-# OPTIONS_GHC -Wno-unused-top-binds #-}
 
 module Inferno.Parse
@@ -27,13 +27,18 @@ where
 
 import Control.Applicative (asum, (<|>))
 import Control.Arrow ((&&&))
-import Control.Monad (void)
-import Control.Monad.Combinators.Expr (Operator, makeExprParser)
+import Control.Monad (join, void)
+import Control.Monad.Combinators.Expr
+  ( Operator (InfixL, InfixN, InfixR, Prefix),
+    makeExprParser,
+  )
 import Control.Monad.Reader (ReaderT, asks)
 import Control.Monad.State.Strict (StateT, modify')
+import Data.Bifunctor (first)
 import Data.Char (isAlphaNum, isSpace)
 import Data.Data (Data)
-import Data.Functor (($>))
+import Data.Foldable (foldl') -- foldl': DO NOT REMOVE; needed for older GHC compat
+import Data.Functor (($>), (<&>))
 import qualified Data.IntMap.Strict as IntMap
 import Data.List.NonEmpty (NonEmpty)
 import Data.Map.Strict (Map)
@@ -47,20 +52,38 @@ import Inferno.Parse.Error (prettyError)
 import Inferno.Types.Syntax
   ( Comment (BlockComment, LineComment),
     CustomType,
-    Expr (Lit, Var),
+    Expr
+      ( App,
+        Array,
+        Bracketed,
+        Empty,
+        Enum,
+        Lit,
+        One,
+        Op,
+        OpVar,
+        PreOp,
+        Record,
+        Tuple,
+        Var
+      ),
     ExtIdent (ExtIdent),
     Fixity (InfixOp, PrefixOp),
     Ident (Ident),
     ImplExpl (Expl, Impl),
     Import,
+    InfixFixity (LeftFix, NoFix, RightFix),
     Lit (LDouble, LHex, LInt, LText),
     ModuleName (ModuleName),
     Pat,
     RestOfRecord,
     Scoped (LocalScope, Scope),
     SigVar,
-    TList,
+    TList (TNil),
+    fromScoped,
     rws,
+    tListFromList,
+    unModuleName,
   )
 import Inferno.Types.Type
   ( InfernoType,
@@ -78,6 +101,7 @@ import Text.Megaparsec
     getSourcePos,
     manyTill,
     satisfy,
+    some,
     sourceColumn,
     unPos,
     (<?>),
@@ -104,9 +128,9 @@ instance ShowErrorComponent InfernoParsingError where
 
 type BaseParsec = Parsec InfernoParsingError Text
 
-type SomeParser r = ReaderT r (StateT [Comment SourcePos] BaseParsec)
+type ParserOver r = ReaderT r (StateT [Comment SourcePos] BaseParsec)
 
-type Parser = SomeParser ParseEnv
+type Parser = ParserOver ParseEnv
 
 data TopLevelDefn def
   = -- FIXME Don't use record fields in sum types, damn it!
@@ -128,7 +152,7 @@ data QQDefinition
   | InlineDef (Expr () SourcePos)
   deriving (Data)
 
-type TyParser = SomeParser TyParseEnv
+type TyParser = ParserOver TyParseEnv
 
 -- | Operator table entry.
 data OpEntry = OpEntry
@@ -216,6 +240,8 @@ mkParseEnv ops modOps cts = env
       _ -> Nothing
 
 -- | Converts a curried function to a function on a triple.
+--
+-- NOTE: Strict, unlike the version from @Data.Tuple.Extra@
 uncurry3 :: (a -> b -> c -> d) -> (a, b, c) -> d
 uncurry3 f (a, b, c) = f a b c
 
@@ -231,17 +257,17 @@ tryMany = \cases
   p [x] -> p x
   p (x : xs) -> try (p x) <|> tryMany p xs
 
-output :: Comment SourcePos -> SomeParser r ()
+output :: Comment SourcePos -> ParserOver r ()
 output c = modify' (c :)
 
-skipLineComment :: SomeParser r ()
+skipLineComment :: ParserOver r ()
 skipLineComment = do
   startPos <- getSourcePos
   comment <- string "//" *> takeWhileP (Just "character") (/= '\n')
   endPos <- getSourcePos
   output $ LineComment startPos (Text.strip comment) endPos
 
-skipBlockComment :: SomeParser r ()
+skipBlockComment :: ParserOver r ()
 skipBlockComment = do
   startPos <- getSourcePos
   comment <- string "/*" *> manyTill anySingle (string "*/")
@@ -254,31 +280,31 @@ skipBlockComment = do
         ws :: Text
         ws = Text.pack $ '\n' : replicate (unPos pos.sourceColumn - 1) ' '
 
-sc :: SomeParser r ()
+sc :: ParserOver r ()
 sc = Lexer.space (void spaceChar) skipLineComment skipBlockComment
 
-lexeme :: SomeParser r a -> SomeParser r a
+lexeme :: ParserOver r a -> ParserOver r a
 lexeme = Lexer.lexeme sc
 
-symbol :: Text -> SomeParser r Text
+symbol :: Text -> ParserOver r Text
 symbol = Lexer.symbol sc
 
 -- | 'parens' parses something between parenthesis.
-parens :: SomeParser r a -> SomeParser r a
+parens :: ParserOver r a -> ParserOver r a
 parens = hidden . between (symbol "(") (symbol ")")
 
 -- | 'rword' for parsing reserved words.
-rword :: Text -> SomeParser r ()
+rword :: Text -> ParserOver r ()
 rword w = string w *> notFollowedBy alphaNumCharOrSeparator *> sc
 
 isAlphaNumOrSeparator :: Char -> Bool
 isAlphaNumOrSeparator = (||) <$> isAlphaNum <*> (== '_')
 
-alphaNumCharOrSeparator :: SomeParser r Char
+alphaNumCharOrSeparator :: ParserOver r Char
 alphaNumCharOrSeparator =
   satisfy isAlphaNumOrSeparator <?> "alphanumeric character or '_'"
 
-withSourcePos :: (SourcePos -> SomeParser r a) -> SomeParser r a
+withSourcePos :: (SourcePos -> ParserOver r a) -> ParserOver r a
 withSourcePos = (getSourcePos >>=)
 
 variable :: Parser Text
@@ -289,7 +315,7 @@ variable =
   where
     p :: Parser Text
     p =
-      labelled "a variable" $
+      label "a variable" $
         Text.cons
           <$> letterChar
           <*> hidden (takeWhileP Nothing isAlphaNumOrSeparator)
@@ -307,7 +333,7 @@ variable =
 
 mIdent :: Parser (SourcePos, Maybe Ident)
 mIdent = lexeme . withSourcePos $ \pos ->
-  labelled "a wildcard parameter '_'" $
+  label "a wildcard parameter '_'" $
     asum
       [ (pos,) . Just . Ident <$> variable
       , char '_' *> takeWhileP Nothing isAlphaNumOrSeparator $> (pos, Nothing)
@@ -315,7 +341,7 @@ mIdent = lexeme . withSourcePos $ \pos ->
 
 mExtIdent :: Parser (SourcePos, Maybe ExtIdent)
 mExtIdent = lexeme . withSourcePos $ \pos ->
-  labelled "a wildcard parameter '_'" $
+  label "a wildcard parameter '_'" $
     asum
       [ (pos,) . Just . ExtIdent . Right <$> variable
       , char '_' *> takeWhileP Nothing isAlphaNumOrSeparator $> (pos, Nothing)
@@ -327,7 +353,7 @@ implicitVariable = hidden $ char '?' *> t
     t :: Parser Text
     t = Text.cons <$> letterChar <*> takeWhileP Nothing isAlphaNumOrSeparator
 
-enumConstructor :: SomeParser r Ident
+enumConstructor :: ParserOver r Ident
 enumConstructor =
   Ident <$> lexeme (char '#' *> takeWhile1P Nothing isAlphaNumOrSeparator)
     <?> "an enum constructor\nfor example: #true, #false"
@@ -402,7 +428,7 @@ arrayComprE :: Parser (Expr () SourcePos)
 arrayComprE = undefined
 
 array :: Parser a -> Parser (SourcePos, [(a, Maybe SourcePos)], SourcePos)
-array p = undefined
+array = undefined
 
 record :: Parser a -> Parser (SourcePos, [(Ident, a, Maybe SourcePos)], SourcePos)
 record = undefined
@@ -434,13 +460,13 @@ casePatts = undefined
 caseE :: Parser (Expr () SourcePos)
 caseE = undefined
 
-tupleArgs :: SomeParser r a -> SomeParser r [(a, Maybe SourcePos)]
+tupleArgs :: ParserOver r a -> ParserOver r [(a, Maybe SourcePos)]
 tupleArgs = undefined
 
 isHSpace :: Char -> Bool
 isHSpace c = isSpace c && c /= '\n' && c /= '\r'
 
-tuple :: SomeParser r a -> SomeParser r (SourcePos, TList (a, Maybe SourcePos), SourcePos)
+tuple :: ParserOver r a -> ParserOver r (SourcePos, TList (a, Maybe SourcePos), SourcePos)
 tuple = undefined
 
 assertE :: Parser (Expr () SourcePos)
@@ -452,32 +478,134 @@ ifE = undefined
 -- | Parses an op in prefix syntax WITHOUT opening paren @(@ but with closing paren @)@
 -- E.g. @+)@
 prefixOpsWithoutModule :: SourcePos -> Parser (Expr () SourcePos)
-prefixOpsWithoutModule = undefined
+prefixOpsWithoutModule pos = hidden $ asks (.localOps) >>= choiceOf prefixOp
+  where
+    prefixOp :: Text -> Parser (Expr () SourcePos)
+    prefixOp s = symbol (s <> ")") $> OpVar pos () LocalScope (Ident s)
 
--- | Parses a op in prefix syntax of the form @Mod.(+)@
+-- | Parses an op in prefix syntax of the form @Mod.(+)@
 prefixOpsWithModule :: SourcePos -> Parser (Expr () SourcePos)
-prefixOpsWithModule = undefined
+prefixOpsWithModule pos = hidden $ asks (.qualOps) >>= tryMany prefixOp
+  where
+    prefixOp :: (Scoped ModuleName, Text) -> Parser (Expr () SourcePos)
+    prefixOp (ns, s) = symbol t $> OpVar pos () ns (Ident s)
+      where
+        t :: Text
+        t =
+          mconcat
+            [ fromScoped mempty $ (<> ".") . unModuleName <$> ns
+            , "("
+            , s
+            , ")"
+            ]
 
--- | Parses a tuple @a, b, c, ...)@ WITHOUT opening paren @(@ but with closing paren @)@
--- Returns (list of (expr, commaPos), endParenPos)
+-- | Parses @a, b, c, ...)@ WITHOUT the opening paren but WITH the closing paren.
 tupleElems :: Parser ([(Expr () SourcePos, Maybe SourcePos)], SourcePos)
-tupleElems = undefined
+tupleElems =
+  asum
+    [ expr >>= \e ->
+        asum
+          [ char ')' *> withSourcePos (pure . ([(e, Nothing)],))
+          , lexeme (char ',' *> getSourcePos) >>= \commaPos ->
+              fmap (first ((e, Just commaPos) :)) tupleElems
+          ]
+    , char ')' *> withSourcePos (pure . ([],))
+    ]
 
--- | Parses any bracketed expression: tuples, bracketed exprs (1 + 2), and prefix ops (+)
+-- | Parses any bracketed expression: tuples, bracketed exprs, and prefix ops.
 bracketedE :: Parser (Expr () SourcePos)
-bracketedE = undefined
+bracketedE = withSourcePos $ \pos ->
+  symbol "(" *> (prefixOpsWithoutModule pos <|> bracketedOrTuple pos)
+  where
+    bracketedOrTuple :: SourcePos -> Parser (Expr () SourcePos)
+    bracketedOrTuple pos =
+      tupleElems >>= \(es, endPos) ->
+        lexeme . pure $ case es of
+          [] -> Tuple pos TNil endPos
+          [(e, _)] -> Bracketed pos e endPos
+          _ -> Tuple pos (tListFromList es) endPos
 
 term :: Parser (Expr () SourcePos)
-term = undefined
+term =
+  asum
+    [ bracketedE
+    , try $ hexadecimal Lit
+    , try doubleE
+    , intE
+    , enumE Enum
+    , withSourcePos $ \pos ->
+        lexeme $
+          asum
+            [ try $ qualVar pos <$> variable <*> (char '.' *> variable)
+            , prefixOpsWithModule pos
+            , try $
+                Var pos () LocalScope . Expl . ExtIdent . Right
+                  <$> variable
+                  <* notFollowedBy (char '.')
+            ]
+    , noneE Empty
+    , someE One expr
+    , ifE
+    , try renameModE
+    , letE
+    , openModE
+    , assertE
+    , funE
+    , caseE
+    , try implVarE
+    , stringE Lit
+    , interpolatedStringE
+    , try $ uncurry3 Array <$> array expr
+    , try $ uncurry3 Record <$> record expr
+    , arrayComprE
+    ]
+  where
+    qualVar :: SourcePos -> Text -> Text -> Expr () SourcePos
+    qualVar pos ns x = Var pos () (Scope $ ModuleName ns) . Expl . ExtIdent $ Right x
 
 app :: Parser (Expr () SourcePos)
-app = undefined
+app =
+  term >>= \x ->
+    asum
+      [ foldl' App x <$> some term
+      , pure x
+      ]
 
 expr :: Parser (Expr () SourcePos)
-expr = undefined
+expr = join $ asks (.exprP)
 
 mkOperators :: OpsTable -> [[Operator Parser (Expr () SourcePos)]]
-mkOperators = undefined
+mkOperators tbl =
+  IntMap.toDescList tbl <&> \(prec, grp) -> fmap (uncurry3 (mkOp prec)) grp
+  where
+    opStr :: Scoped ModuleName -> Text -> Text
+    opStr = \cases
+      LocalScope s -> s
+      (Scope (ModuleName ns)) s -> ns <> "." <> s
+
+    fixCtor :: InfixFixity -> Parser (a -> a -> a) -> Operator Parser a
+    fixCtor = \cases
+      NoFix -> InfixN
+      LeftFix -> InfixL
+      RightFix -> InfixR
+
+    mkOp ::
+      Int ->
+      Fixity ->
+      Scoped ModuleName ->
+      Text ->
+      Operator Parser (Expr () SourcePos)
+    mkOp = \cases
+      prec (InfixOp fix) ns o ->
+        fixCtor fix . label "an infix operator\nfor example: +, *, ==, >, <" $
+          opP ns o >>= \pos -> pure $ \e1 e2 ->
+            Op e1 pos () (prec, fix) ns (Ident o) e2
+      prec PrefixOp ns o ->
+        Prefix . label "a prefix operator\nfor example: -, !" $
+          opP ns o >>= \pos -> pure . PreOp pos () prec ns $ Ident o
+
+    opP :: Scoped ModuleName -> Text -> Parser SourcePos
+    opP ns o = lexeme $ getSourcePos <* string (opStr ns o)
 
 parseExpr ::
   OpsTable ->
@@ -520,7 +648,7 @@ parseType ::
   Either
     (NonEmpty (ParseError Text InfernoParsingError, SourcePos))
     InfernoType
-parseType s = undefined
+parseType = undefined
 
 parseTCScheme :: Text -> Either String TCScheme
 parseTCScheme = undefined
@@ -578,8 +706,5 @@ modulesParser ::
   Parser [(ModuleName, OpsTable, [TopLevelDefn (Maybe TCScheme, QQDefinition)])]
 modulesParser = undefined
 
-topLevel :: SomeParser r a -> SomeParser r a
-topLevel p = undefined
-
-labelled :: String -> Parser a -> Parser a
-labelled t = (<?> t)
+topLevel :: ParserOver r a -> ParserOver r a
+topLevel = undefined

--- a/inferno-core/src/Inferno/Parse.hs
+++ b/inferno-core/src/Inferno/Parse.hs
@@ -1,6 +1,12 @@
 {-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE ExplicitForAll #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE NoFieldSelectors #-}
+
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
 
 module Inferno.Parse
   ( Comment (..),
@@ -19,125 +25,214 @@ module Inferno.Parse
   )
 where
 
-import Control.Applicative (Alternative ((<|>)))
-import Control.Monad (foldM, void, when)
-import Control.Monad.Combinators.Expr
-  ( Operator (InfixL, InfixN, InfixR, Prefix),
-    makeExprParser,
-  )
-import Control.Monad.Reader (ReaderT (..), ask, withReaderT)
-import Control.Monad.Writer (WriterT (..), tell)
-import Data.Bifunctor (Bifunctor (first))
+import Control.Applicative (asum, (<|>))
+import Control.Arrow ((&&&))
+import Control.Monad (void)
+import Control.Monad.Combinators.Expr (Operator, makeExprParser)
+import Control.Monad.Reader (ReaderT, asks)
+import Control.Monad.State.Strict (StateT, modify')
 import Data.Char (isAlphaNum, isSpace)
 import Data.Data (Data)
-import Data.Either (partitionEithers)
 import Data.Functor (($>))
-import qualified Data.IntMap as IntMap
-import qualified Data.List as List
+import qualified Data.IntMap.Strict as IntMap
 import Data.List.NonEmpty (NonEmpty)
-import qualified Data.List.NonEmpty as NEList
-import qualified Data.Map as Map
-import Data.Monoid (Endo (..))
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Maybe (mapMaybe)
+import Data.Set (Set)
 import qualified Data.Set as Set
-import Data.Text (Text, pack, singleton, unpack)
+import Data.Text (Text)
 import qualified Data.Text as Text
-import Inferno.Infer.Env (closeOver)
 import Inferno.Parse.Error (prettyError)
 import Inferno.Types.Syntax
-  ( Comment (..),
-    CustomType (),
-    Expr (..),
+  ( Comment (BlockComment, LineComment),
+    CustomType,
+    Expr (Lit, Var),
     ExtIdent (ExtIdent),
-    Fixity (..),
+    Fixity (InfixOp, PrefixOp),
     Ident (Ident),
     ImplExpl (Expl, Impl),
-    Import (..),
-    InfixFixity (..),
-    Lit (..),
-    ModuleName (..),
-    Pat (..),
-    RestOfRecord (..),
-    Scoped (..),
-    SigVar (..),
-    TList (..),
-    fromEitherList,
-    fromScoped,
+    Import,
+    Lit (LDouble, LHex, LInt, LText),
+    ModuleName (ModuleName),
+    Pat,
+    RestOfRecord,
+    Scoped (LocalScope, Scope),
+    SigVar,
+    TList,
     rws,
-    tListFromList,
   )
 import Inferno.Types.Type
-  ( BaseType (..),
-    ImplType (..),
-    InfernoType (..),
-    TCScheme (..),
-    TV (TV),
-    TypeClass (TypeClass),
+  ( InfernoType,
+    TCScheme,
+    TypeClass,
   )
-import Inferno.Utils.Prettyprinter (renderPretty)
 import Text.Megaparsec
-  ( MonadParsec
-      ( eof,
-        hidden,
-        label,
-        notFollowedBy,
-        takeWhile1P,
-        takeWhileP,
-        try
-      ),
+  ( MonadParsec (hidden, label, notFollowedBy, takeWhile1P, takeWhileP, try),
     ParseError,
-    ParseErrorBundle (ParseErrorBundle),
     Parsec,
-    ShowErrorComponent (..),
-    SourcePos (..),
+    ShowErrorComponent (showErrorComponent),
+    SourcePos,
     anySingle,
-    attachSourcePos,
     between,
-    choice,
-    customFailure,
-    errorOffset,
     getSourcePos,
-    many,
     manyTill,
-    optional,
-    runParser,
     satisfy,
-    sepBy1,
-    some,
+    sourceColumn,
     unPos,
     (<?>),
   )
-import Text.Megaparsec.Char
-  ( alphaNumChar,
-    char,
-    char',
-    letterChar,
-    spaceChar,
-    string,
-  )
+import Text.Megaparsec.Char (char, char', letterChar, spaceChar, string)
 import qualified Text.Megaparsec.Char.Lexer as Lexer
 
+data InfernoParsingError
+  = ModuleNotFound ModuleName
+  | InfixOpNotFound ModuleName Ident
+  | UnboundTyVar Text
+  | ImplicitVarTypeAnnot
+  deriving (Eq, Show, Ord)
+
+instance ShowErrorComponent InfernoParsingError where
+  showErrorComponent (ModuleNotFound (ModuleName modNm)) =
+    "Module '" <> Text.unpack modNm <> "' could not be found"
+  showErrorComponent (InfixOpNotFound (ModuleName modNm) (Ident op)) =
+    "Module " <> Text.unpack modNm <> " does not export `(" <> Text.unpack op <> ")`"
+  showErrorComponent (UnboundTyVar ty) =
+    "Unbound type variable '" <> Text.unpack ty
+  showErrorComponent ImplicitVarTypeAnnot =
+    "Implicit variables cannot have type annotations"
+
+type BaseParsec = Parsec InfernoParsingError Text
+
+type SomeParser r = ReaderT r (StateT [Comment SourcePos] BaseParsec)
+
+type Parser = SomeParser ParseEnv
+
+data TopLevelDefn def
+  = -- FIXME Don't use record fields in sum types, damn it!
+    Signature
+      { documentation :: Maybe Text
+      , name :: SigVar
+      , def :: def
+      }
+  | EnumDef (Maybe Text) Text [Ident]
+  | TypeClassInstance TypeClass
+  | Export ModuleName
+  deriving (Eq, Show, Data)
+
+type OpsTable = IntMap.IntMap [(Fixity, Scoped ModuleName, Text)]
+
+data QQDefinition
+  = QQRawDef String
+  | QQToValueDef String
+  | InlineDef (Expr () SourcePos)
+  deriving (Data)
+
+type TyParser = SomeParser TyParseEnv
+
+-- | Operator table entry.
+data OpEntry = OpEntry
+  { fixity :: !Fixity
+  , scope :: !(Scoped ModuleName)
+  , name :: !Text
+  }
+
+-- | A bracketed, separator-delimited sequence with positional metadata.
+data Delimited a = Delimited
+  { open :: !SourcePos
+  , items :: [Separated a]
+  , close :: !SourcePos
+  }
+
+-- | An element followed by an optional separator position.
+data Separated a = Separated
+  { val :: a
+  , sep :: !(Maybe SourcePos)
+  }
+
+-- | A record field binding.
+data Field a = Field
+  { name :: !Ident
+  , val :: a
+  }
+
+-- | Parser environment; precomputed data derived from the operator table.
+data ParseEnv = ParseEnv
+  { ops :: !OpsTable
+  , modOps :: !(Map ModuleName OpsTable)
+  , customTypes :: ![CustomType]
+  , reserved :: !(Set Text)
+  , localOps :: ![Text]
+  , qualOps :: ![(Scoped ModuleName, Text)]
+  , infixOps :: ![Text]
+  , prefixOps :: ![Text]
+  , -- NOTE: This is *intentionally lazy*, used for recursive knot-tying. If
+    -- @StrictData@ is ever enabled for this module, please use @~@ explicitly
+    exprP :: Parser (Expr () SourcePos)
+  }
+
+-- | Type parser environment.
+data TyParseEnv = TyParseEnv
+  { tyVars :: !(Map Text Int)
+  , ops :: !OpsTable
+  , modOps :: !(Map ModuleName OpsTable)
+  , ctypes :: ![CustomType]
+  }
+
+fromOpTuple :: (Fixity, Scoped ModuleName, Text) -> OpEntry
+fromOpTuple (f, s, n) = OpEntry{fixity = f, scope = s, name = n}
+
+toOpTuple :: OpEntry -> (Fixity, Scoped ModuleName, Text)
+toOpTuple e = (e.fixity, e.scope, e.name)
+
+mkParseEnv :: OpsTable -> Map ModuleName OpsTable -> [CustomType] -> ParseEnv
+mkParseEnv ops modOps cts = env
+  where
+    env :: ParseEnv
+    env =
+      ParseEnv
+        { ops
+        , modOps
+        , customTypes = cts
+        , reserved = Set.fromList $ rws <> fmap (.name) allOps
+        , localOps = fmap (.name) . filter ((== LocalScope) . (.scope)) $ allOps
+        , qualOps = fmap ((.scope) &&& (.name)) . filter ((/= LocalScope) . (.scope)) $ allOps
+        , infixOps = mapMaybe infixName allOps
+        , prefixOps = mapMaybe prefixName allOps
+        , exprP = makeExprParser app $ mkOperators ops
+        }
+
+    allOps :: [OpEntry]
+    allOps = fmap fromOpTuple . concat . IntMap.elems $ ops
+
+    infixName :: OpEntry -> Maybe Text
+    infixName e = case e.fixity of
+      InfixOp _ -> Just e.name
+      _ -> Nothing
+
+    prefixName :: OpEntry -> Maybe Text
+    prefixName e = case e.fixity of
+      PrefixOp -> Just e.name
+      _ -> Nothing
+
 -- | Converts a curried function to a function on a triple.
-uncurry3 :: (a -> b -> c -> d) -> ((a, b, c) -> d)
-uncurry3 f ~(a, b, c) = f a b c
+uncurry3 :: (a -> b -> c -> d) -> (a, b, c) -> d
+uncurry3 f (a, b, c) = f a b c
 
 choiceOf :: (t -> Parser a) -> [t] -> Parser a
-choiceOf _ [] = fail "none of the operators matched"
-choiceOf p [x] = p x
-choiceOf p (x : xs) = p x <|> choiceOf p xs
+choiceOf = \cases
+  _ [] -> fail "none of the operators matched"
+  p [x] -> p x
+  p (x : xs) -> p x <|> choiceOf p xs
 
 tryMany :: (t -> Parser a) -> [t] -> Parser a
-tryMany _ [] = fail "none of the operators matched"
-tryMany p [x] = p x
-tryMany p (x : xs) = try (p x) <|> tryMany p xs
-
-type Comments = Endo [Comment SourcePos]
+tryMany = \cases
+  _ [] -> fail "none of the operators matched"
+  p [x] -> p x
+  p (x : xs) -> try (p x) <|> tryMany p xs
 
 output :: Comment SourcePos -> SomeParser r ()
-output x = tell $ Endo ([x] <>)
-
-type Parser = ReaderT (OpsTable, Map.Map ModuleName OpsTable, [CustomType]) (WriterT Comments (Parsec InfernoParsingError Text))
-
-type SomeParser r = ReaderT r (WriterT Comments (Parsec InfernoParsingError Text))
+output c = modify' (c :)
 
 skipLineComment :: SomeParser r ()
 skipLineComment = do
@@ -148,14 +243,16 @@ skipLineComment = do
 
 skipBlockComment :: SomeParser r ()
 skipBlockComment = do
-  startPos@(SourcePos _ _ col) <- getSourcePos
-  comment <- string "/*" >> manyTill anySingle (string "*/")
+  startPos <- getSourcePos
+  comment <- string "/*" *> manyTill anySingle (string "*/")
   endPos <- getSourcePos
-  output $
-    BlockComment
-      startPos
-      (Text.replace (pack $ '\n' : List.replicate (unPos col - 1) ' ') "\n" $ Text.pack comment)
-      endPos
+  output $ BlockComment startPos (stripIndent startPos comment) endPos
+  where
+    stripIndent :: SourcePos -> [Char] -> Text
+    stripIndent pos = Text.replace ws "\n" . Text.pack
+      where
+        ws :: Text
+        ws = Text.pack $ '\n' : replicate (unPos pos.sourceColumn - 1) ' '
 
 sc :: SomeParser r ()
 sc = Lexer.space (void spaceChar) skipLineComment skipBlockComment
@@ -168,602 +265,219 @@ symbol = Lexer.symbol sc
 
 -- | 'parens' parses something between parenthesis.
 parens :: SomeParser r a -> SomeParser r a
-parens p = hidden $ between (symbol "(") (symbol ")") p
+parens = hidden . between (symbol "(") (symbol ")")
 
 -- | 'rword' for parsing reserved words.
 rword :: Text -> SomeParser r ()
 rword w = string w *> notFollowedBy alphaNumCharOrSeparator *> sc
 
 isAlphaNumOrSeparator :: Char -> Bool
-isAlphaNumOrSeparator c = isAlphaNum c || c == '_'
-{-# INLINE isAlphaNumOrSeparator #-}
+isAlphaNumOrSeparator = (||) <$> isAlphaNum <*> (== '_')
 
 alphaNumCharOrSeparator :: SomeParser r Char
-alphaNumCharOrSeparator = satisfy isAlphaNumOrSeparator <?> "alphanumeric character or '_'"
-{-# INLINE alphaNumCharOrSeparator #-}
+alphaNumCharOrSeparator =
+  satisfy isAlphaNumOrSeparator <?> "alphanumeric character or '_'"
+
+withSourcePos :: (SourcePos -> SomeParser r a) -> SomeParser r a
+withSourcePos = (getSourcePos >>=)
 
 variable :: Parser Text
-variable = do
-  (opsTable, _, _) <- ask
-  try (p >>= check opsTable)
+variable =
+  -- Checks the set of known keywords, making lookup O(1) instead of the previous
+  -- O(n) linear scan every time
+  asks (.reserved) >>= try . (p >>=) . check
   where
-    p = pack <$> (((:) <$> letterChar <*> hidden (many alphaNumCharOrSeparator)) <?> "a variable")
-    check oT x =
-      if x `elem` rws ++ map (\(_, _, i) -> i) (concat oT)
-        then fail $ "Keyword " <> show x <> " cannot be a variable/function name"
-        else return x
+    p :: Parser Text
+    p =
+      labelled "a variable" $
+        Text.cons
+          <$> letterChar
+          <*> hidden (takeWhileP Nothing isAlphaNumOrSeparator)
+
+    check :: Set Text -> Text -> Parser Text
+    check res x
+      | Set.member x res =
+          fail $
+            unwords
+              [ "Keyword"
+              , show x
+              , "cannot be a variable/function name"
+              ]
+      | otherwise = pure x
 
 mIdent :: Parser (SourcePos, Maybe Ident)
-mIdent = lexeme $ do
-  startPos <- getSourcePos
-  (startPos,) . Just . Ident <$> variable
-    <|> (char '_' *> takeWhileP Nothing isAlphaNumOrSeparator $> (startPos, Nothing))
-    <?> "a wildcard parameter '_'"
+mIdent = lexeme . withSourcePos $ \pos ->
+  labelled "a wildcard parameter '_'" $
+    asum
+      [ (pos,) . Just . Ident <$> variable
+      , char '_' *> takeWhileP Nothing isAlphaNumOrSeparator $> (pos, Nothing)
+      ]
 
 mExtIdent :: Parser (SourcePos, Maybe ExtIdent)
-mExtIdent = lexeme $ do
-  startPos <- getSourcePos
-  (startPos,) . Just . ExtIdent . Right <$> variable
-    <|> (char '_' *> takeWhileP Nothing isAlphaNumOrSeparator $> (startPos, Nothing))
-    <?> "a wildcard parameter '_'"
+mExtIdent = lexeme . withSourcePos $ \pos ->
+  labelled "a wildcard parameter '_'" $
+    asum
+      [ (pos,) . Just . ExtIdent . Right <$> variable
+      , char '_' *> takeWhileP Nothing isAlphaNumOrSeparator $> (pos, Nothing)
+      ]
 
 implicitVariable :: Parser Text
-implicitVariable = hidden $ char '?' *> (Text.cons <$> letterChar <*> takeWhileP Nothing isAlphaNumOrSeparator)
+implicitVariable = hidden $ char '?' *> t
+  where
+    t :: Parser Text
+    t = Text.cons <$> letterChar <*> takeWhileP Nothing isAlphaNumOrSeparator
 
 enumConstructor :: SomeParser r Ident
 enumConstructor =
-  Ident
-    <$> lexeme (char '#' *> takeWhile1P Nothing isAlphaNumOrSeparator)
+  Ident <$> lexeme (char '#' *> takeWhile1P Nothing isAlphaNumOrSeparator)
     <?> "an enum constructor\nfor example: #true, #false"
 
--- | 'signedInteger' parses an integer with an optional sign (with no space)
+-- | Parses an integer with an optional sign (with no space).
 signedInteger :: (Num a) => Parser a
-signedInteger = Lexer.signed (takeWhileP Nothing isHSpace $> ()) Lexer.decimal
+signedInteger =
+  flip Lexer.signed Lexer.decimal $
+    takeWhileP Nothing isHSpace $> ()
 
--- | 'signedInteger' parses a float/double with an optional sign (with no space)
+-- | Parses a float/double with an optional sign (with no space).
 signedFloat :: Parser Double
-signedFloat = Lexer.signed (takeWhileP Nothing isHSpace $> ()) Lexer.float
+signedFloat =
+  flip Lexer.signed Lexer.float $
+    takeWhileP Nothing isHSpace $> ()
 
 enumE :: (SourcePos -> () -> Scoped ModuleName -> Ident -> f) -> Parser f
-enumE f = do
-  startPos <- getSourcePos
-  lexeme $
-    try (f startPos () . Scope . ModuleName <$> variable <*> (char '.' *> enumConstructor))
-      <|> f startPos () LocalScope <$> enumConstructor
+enumE f = lexeme . withSourcePos $ \pos ->
+  asum
+    [ try $ f pos () . Scope . ModuleName <$> variable <*> (char '.' *> enumConstructor)
+    , f pos () LocalScope <$> enumConstructor
+    ]
 
 implVarE :: Parser (Expr () SourcePos)
-implVarE = do
-  startPos <- getSourcePos
-  lexeme $ Var startPos () LocalScope . Impl . ExtIdent . Right <$> implicitVariable
+implVarE = lexeme . withSourcePos $ \pos ->
+  Var pos () LocalScope . Impl . ExtIdent . Right <$> implicitVariable
 
--- | 'intE' and 'doubleE' parse unsigned numbers
+-- | Parses unsigned integer and double literals.
 intE, doubleE :: Parser (Expr () SourcePos)
-intE = label "a number\nfor example: 42, 3.1415, (-6)" $ do
-  startPos <- getSourcePos
-  lexeme $ Lit startPos . LInt <$> Lexer.decimal
-doubleE = label "a number\nfor example: 42, 3.1415, (-6)" $ do
-  startPos <- getSourcePos
-  lexeme $ Lit startPos . LDouble <$> Lexer.float
+intE =
+  label "a number\nfor example: 42, 3.1415, (-6)" . lexeme . withSourcePos $
+    \pos -> Lit pos . LInt <$> Lexer.decimal
+doubleE =
+  label "a number\nfor example: 42, 3.1415, (-6)" . lexeme . withSourcePos $
+    \pos -> Lit pos . LDouble <$> Lexer.float
 
 hexadecimal :: (SourcePos -> Lit -> f SourcePos) -> Parser (f SourcePos)
-hexadecimal f = label "a hexadecimal number\nfor example: 0xE907, 0XE907" $ do
-  startPos <- getSourcePos
-  lexeme $ f startPos . LHex <$> (char '0' *> char' 'x' *> Lexer.hexadecimal)
+hexadecimal f =
+  label "a hexadecimal number\nfor example: 0xE907, 0XE907" . lexeme . withSourcePos $
+    \pos -> f pos . LHex <$> (char '0' *> char' 'x' *> Lexer.hexadecimal)
 
 signedIntE, signedDoubleE :: (SourcePos -> Lit -> f SourcePos) -> Parser (f SourcePos)
-signedIntE f = label "a number\nfor example: 42, 3.1415, (-6)" $ do
-  startPos <- getSourcePos
-  lexeme $ f startPos . LInt <$> signedInteger
-signedDoubleE f = label "a number\nfor example: 42, 3.1415, (-6)" $ do
-  startPos <- getSourcePos
-  lexeme $ f startPos . LDouble <$> signedFloat
+signedIntE f =
+  label "a number\nfor example: 42, 3.1415, (-6)" . lexeme . withSourcePos $
+    \pos -> f pos . LInt <$> signedInteger
+signedDoubleE f =
+  label "a number\nfor example: 42, 3.1415, (-6)" . lexeme . withSourcePos $
+    \pos -> f pos . LDouble <$> signedFloat
 
 noneE :: (SourcePos -> a) -> Parser a
-noneE e = label "an optional\nfor example: Some x, None" $ do
-  startPos <- getSourcePos
-  lexeme (e startPos <$ hidden (string "None"))
+noneE e =
+  label "an optional\nfor example: Some x, None" . lexeme . withSourcePos $
+    \pos -> e pos <$ hidden (string "None")
 
 someE :: (SourcePos -> t -> a) -> Parser t -> Parser a
-someE f p = label "an optional\nfor example: Some x, None" $ do
-  startPos <- getSourcePos
-  lexeme (hidden $ string "Some")
-  f startPos <$> p
+someE f p =
+  label "an optional\nfor example: Some x, None" . withSourcePos $
+    \pos -> lexeme (hidden $ string "Some") *> fmap (f pos) p
 
 stringE :: (SourcePos -> Lit -> f SourcePos) -> Parser (f SourcePos)
-stringE f = label "a string\nfor example: \"hello world\"" $ do
-  startPos <- getSourcePos
-  lexeme $ f startPos . LText . pack <$> (char '\"' *> manyTill charNoNewline (char '\"'))
+stringE f =
+  label "a string\nfor example: \"hello world\"" . lexeme . withSourcePos $
+    \pos -> f pos . LText . Text.pack <$> (char '"' *> manyTill charNoNewline (char '"'))
   where
+    charNoNewline :: Parser Char
     charNoNewline = notFollowedBy (char '\n') *> Lexer.charLiteral
 
-interpolatedStringE, arrayComprE :: Parser (Expr () SourcePos)
-interpolatedStringE = label "an interpolated string\nfor example: `hello ${1 + 2}`" $
-  lexeme $ do
-    startPos@(SourcePos _ _ col) <- getSourcePos
-    es <- mkInterpolatedString <$> (char '`' *> go)
-    InterpolatedString startPos (fromEitherList $ fixSpacing (unPos col) es) <$> getSourcePos
-  where
-    go =
-      [] <$ char '`'
-        <|> try ((:) . Left . singleton <$> hidden (char '\\' *> char '\\') <*> go)
-        <|> try ((:) . Left . singleton <$> hidden (char '\\' *> char '`') <*> go)
-        <|> try ((:) . Left . singleton <$> hidden (char '\\' *> char '$') <*> go)
-        <|> (:) . Right
-          <$> hidden
-            ( do
-                startPos <- getSourcePos
-                e <- char '$' *> char '{' *> sc *> expr <* char '}'
-                endPos <- getSourcePos
-                pure (startPos, e, endPos)
-            )
-          <*> go
-        <|> (:) . Left . singleton <$> Lexer.charLiteral <*> go
+interpolatedStringE :: Parser (Expr () SourcePos)
+interpolatedStringE = undefined
 
-    fixSpacing newlineSpaceLength =
-      map (first (Text.replace (pack $ '\n' : List.replicate (newlineSpaceLength - 1) ' ') "\n"))
-arrayComprE = label "array builder\nfor example: [n * 2 + 1 | n <- range 0 10, if n % 2 == 0]" $
-  lexeme $ do
-    startPos <- getSourcePos
-    symbol "["
-    e <- expr
-    midPos <- getSourcePos
-    symbol "|"
-    (sels, cond) <- rhsE
-    endPos <- getSourcePos
-    _ <- optional $ symbol ","
-    char ']'
-    return $ ArrayComp startPos e midPos (NEList.fromList sels) cond endPos
-  where
-    selectE :: Parser (SourcePos, Ident, SourcePos, Expr () SourcePos)
-    selectE = do
-      startPos <- getSourcePos
-      var <- lexeme $ Ident <$> variable
-      arrPos <- getSourcePos
-      e <- symbol "<-" *> expr
-      return (startPos, var, arrPos, e)
-
-    rhsE :: Parser ([(SourcePos, Ident, SourcePos, Expr () SourcePos, Maybe SourcePos)], Maybe (SourcePos, Expr () SourcePos))
-    rhsE =
-      try
-        ( do
-            (startPos, var, arrPos, e) <- selectE
-            pos <- getSourcePos <* symbol ","
-            (xs, mcond) <- try rhsE <|> (\c -> ([], Just c)) <$> condE
-            pure ((startPos, var, arrPos, e, Just pos) : xs, mcond)
-        )
-        <|> (\(startPos, var, arrPos, e) -> ([(startPos, var, arrPos, e, Nothing)], Nothing)) <$> selectE
-
-    condE :: Parser (SourcePos, Expr () SourcePos)
-    condE = do
-      ifPos <- getSourcePos
-      (ifPos,) <$> (rword "if" *> expr)
+arrayComprE :: Parser (Expr () SourcePos)
+arrayComprE = undefined
 
 array :: Parser a -> Parser (SourcePos, [(a, Maybe SourcePos)], SourcePos)
-array p = label "array\nfor example: [1,2,3,4,5]" $
-  lexeme $ do
-    startPos <- getSourcePos
-    symbol "["
-    args <- argsE
-    endPos <- getSourcePos
-    char ']'
-    return (startPos, args, endPos)
-  where
-    argsE =
-      try
-        ( do
-            e <- p
-            commaPos <- getSourcePos
-            symbol ","
-            es <- argsE
-            return ((e, Just commaPos) : es)
-        )
-        <|> try
-          ( do
-              e1 <- p
-              return [(e1, Nothing)]
-          )
-        <|> pure []
+array p = undefined
 
 record :: Parser a -> Parser (SourcePos, [(Ident, a, Maybe SourcePos)], SourcePos)
-record p = label "record\nfor example: {name = \"Zaphod\"; age = 391}" $
-  lexeme $ do
-    startPos <- getSourcePos
-    symbol "{"
-    args <- argsE
-    endPos <- getSourcePos
-    char '}'
-    return (startPos, args, endPos)
-  where
-    argsE =
-      try
-        ( do
-            f <- lexeme $ Ident <$> variable
-            symbol "="
-            e <- p
-            commaPos <- getSourcePos
-            symbol ";"
-            es <- argsE
-            return ((f, e, Just commaPos) : es)
-        )
-        <|> try
-          ( do
-              f <- lexeme $ Ident <$> variable
-              symbol "="
-              e1 <- p
-              return [(f, e1, Nothing)]
-          )
-        <|> pure []
+record = undefined
 
 mkInterpolatedString :: [Either Text e] -> [Either Text e]
-mkInterpolatedString [] = []
-mkInterpolatedString (Left x : Left y : xs) = mkInterpolatedString (Left (x <> y) : xs)
-mkInterpolatedString (x : xs) = x : mkInterpolatedString xs
+mkInterpolatedString = undefined
 
 funE :: Parser (Expr () SourcePos)
-funE = label "a function\nfor example: fun x y -> x + y" $ do
-  startPos <- getSourcePos
-  hidden $ rword "fun"
-  args <- some mExtIdent
-  arrPos <- getSourcePos
-  symbol "->" <?> "'->'"
-  Lam startPos (NEList.fromList args) arrPos <$> expr
+funE = undefined
 
 renameModE :: Parser (Expr () SourcePos)
-renameModE = label "a 'let module' expression\nfor example: let module A = Base in A.#true" $
-  do
-    hidden $ rword "let"
-    hidden $ rword "module"
-    newNmPos <- getSourcePos
-    newNm <- lexeme (ModuleName <$> variable <?> "module name")
-    symbol "=" <?> "'='"
-    oldNmPos <- getSourcePos
-    oldNm <- lexeme (ModuleName <$> variable <?> "name of an existing module")
-    inPos <- getSourcePos
-    (opsTable, modOpsTables, customTypes) <- ask
-    case Map.lookup oldNm modOpsTables of
-      Nothing -> customFailure $ ModuleNotFound oldNm
-      Just opsTableOldNm -> do
-        let opsTable' = IntMap.unionWith (<>) opsTable $ IntMap.map (\xs -> [(fix, Scope newNm, op) | (fix, _, op) <- xs]) opsTableOldNm
-        let modOpsTables' = Map.insert newNm opsTableOldNm modOpsTables
-        e <- withReaderT (const (opsTable', modOpsTables', customTypes)) $ (rword "in" <?> "_the 'in' keyword") *> expr
-        pure $ RenameModule newNmPos newNm oldNmPos oldNm inPos e
-
-data InfernoParsingError
-  = ModuleNotFound ModuleName
-  | InfixOpNotFound ModuleName Ident
-  | UnboundTyVar Text
-  | ImplicitVarTypeAnnot
-  deriving (Eq, Show, Ord)
-
-instance ShowErrorComponent InfernoParsingError where
-  showErrorComponent (ModuleNotFound (ModuleName modNm)) =
-    "Module '" <> unpack modNm <> "' could not be found"
-  showErrorComponent (InfixOpNotFound (ModuleName modNm) (Ident op)) =
-    "Module " <> unpack modNm <> " does not export `(" <> unpack op <> ")`"
-  showErrorComponent (UnboundTyVar ty) =
-    "Unbound type variable '" <> unpack ty
-  showErrorComponent ImplicitVarTypeAnnot =
-    "Implicit variables cannot have type annotations"
+renameModE = undefined
 
 openModArgs :: ModuleName -> Parser ([(Import SourcePos, Maybe SourcePos)], SourcePos, Expr () SourcePos)
-openModArgs modNm = do
-  symbol "("
-  is <- go
-  _ <- optional $ symbol ","
-  symbol ")"
-  (opsTable, modOpsTables, customTypes) <- ask
-  opsTable' <-
-    foldM
-      ( \oTbl i -> case i of
-          IOpVar _ op -> do
-            foundOpTbl <- findOp op modOpsTables
-            return $ IntMap.unionWith (<>) oTbl foundOpTbl
-          _ -> pure oTbl
-      )
-      opsTable
-      (map fst is)
-  inPos <- getSourcePos
-  e <- withReaderT (const (opsTable', modOpsTables, customTypes)) $ (rword "in" <?> "_the 'in' keyword") *> expr
-  return (is, inPos, e)
-  where
-    findOp :: Ident -> Map.Map ModuleName OpsTable -> Parser OpsTable
-    findOp i@(Ident op) modOpsTables =
-      case Map.lookup modNm modOpsTables of
-        Just opsTable -> do
-          let filteredOpsTable =
-                IntMap.mapMaybe
-                  (\xs -> let xs' = [(fix, LocalScope, op') | (fix, _modNm, op') <- xs, op == op'] in if null xs' then Nothing else Just xs')
-                  opsTable
-          when (null filteredOpsTable) $ customFailure $ InfixOpNotFound modNm i
-          return filteredOpsTable
-        Nothing -> customFailure $ ModuleNotFound modNm
-    go =
-      try
-        ((:) <$> ((,) <$> parseImport <*> lexeme (Just <$> getSourcePos <* symbol ",")) <*> go)
-        <|> (\i -> [(i, Nothing)]) <$> parseImport
-
-    parseImport =
-      try (IOpVar <$> getSourcePos <*> lexeme (char '(' *> (Ident <$> takeWhile1P Nothing isAlphaNum) <* char ')'))
-        <|> try (IEnum <$> lexeme (getSourcePos <* string "enum") <*> getSourcePos <*> lexeme (Ident <$> variable))
-        <|> IVar <$> getSourcePos <*> lexeme (Ident <$> variable)
+openModArgs = undefined
 
 openModE :: Parser (Expr () SourcePos)
-openModE = label "an 'open' module expression\nfor example: open A in ..." $
-  do
-    hidden $ rword "open"
-    nmPos <- getSourcePos
-    nm <- lexeme (ModuleName <$> variable <?> "module name")
-    uncurry3 (OpenModule nmPos () nm) <$> (try (openModArgs nm) <|> (\inPos e -> ([], inPos, e)) <$> getSourcePos <*> openAll nm)
-  where
-    openAll modNm = do
-      (opsTable, modOpsTables, customTypes) <- ask
-      case Map.lookup modNm modOpsTables of
-        Just opsTable' ->
-          withReaderT (const (IntMap.unionWith (<>) opsTable opsTable', modOpsTables, customTypes)) $
-            (rword "in" <?> "_the 'in' keyword") *> expr
-        Nothing -> customFailure $ ModuleNotFound modNm
+openModE = undefined
 
 letE :: Parser (Expr () SourcePos)
-letE = label ("a 'let' expression" ++ example "x") $
-  do
-    startPos <- getSourcePos
-    hidden $ rword "let"
-    varPos <- getSourcePos
-    x <- lexeme ((Expl . ExtIdent . Right <$> variable <|> Impl . ExtIdent . Right <$> implicitVariable) <?> "a variable")
-    let xStr = unpack $ renderPretty x
-    tPos <- getSourcePos
-    maybeTy <-
-      optional $
-        symbol ":"
-          *> withReaderT (\(ops, m, customTypes) -> (mempty, ops, m, customTypes)) schemeParser
-    eqPos <- getSourcePos
-    symbol "=" <?> "'='"
-    e1 <- expr <?> ("an expression to bind to '" ++ xStr ++ "'" ++ example xStr)
-    inPos <- getSourcePos
-    e2 <- (rword "in" <?> "_the 'in' keyword") *> expr
-    case (x, maybeTy) of
-      (Expl x', Just t) -> pure $ LetAnnot startPos varPos x' tPos t eqPos e1 inPos e2
-      (Impl _, Just _) -> customFailure ImplicitVarTypeAnnot
-      (_, Nothing) -> pure $ Let startPos varPos x eqPos e1 inPos e2
-  where
-    example x = "\nfor example: let " ++ x ++ " = 2 * 5 in ...\nor: let " ++ x ++ " : double = 1 + 2 in ..."
+letE = undefined
 
 pat :: Parser (Pat () SourcePos)
-pat =
-  uncurry3 PArray <$> array pat
-    <|> uncurry3 PRecord <$> record pat
-    <|> try (uncurry3 PTuple <$> tuple pat)
-    <|> parens pat
-    <|> try (hexadecimal PLit)
-    <|> try (signedDoubleE PLit)
-    <|> signedIntE PLit
-    <|> enumE PEnum
-    <|> uncurry PVar <$> mIdent
-    <|> noneE PEmpty
-    <|> someE POne pat
-    <|> stringE PLit
+pat = undefined
 
 casePatts :: Parser [(SourcePos, Pat () SourcePos, SourcePos, Expr () SourcePos)]
-casePatts = do
-  -- The | is optional before the first match clause:
-  _ <- optional (symbol "|" <?> "'|'")
-  onePat `sepBy1` (symbol "|" <?> "'|'")
-  where
-    onePat :: Parser (SourcePos, Pat () SourcePos, SourcePos, Expr () SourcePos)
-    onePat = label "_a pattern match clause\nfor example: #true -> ..." $ do
-      startPos <- getSourcePos
-      p <- pat
-      arrPos <- getSourcePos
-      symbol "->" <?> "'->'"
-      e <- expr
-      return (startPos, p, arrPos, e)
+casePatts = undefined
 
 caseE :: Parser (Expr () SourcePos)
-caseE = label "a pattern-match expression\nfor example: match x with { 1 -> #true | _ -> #false }" $
-  lexeme $ do
-    startPos <- getSourcePos
-    rword "match"
-    e <- expr <?> "an expression to pattern match on\nfor example: match (x, y) with { ... }"
-    rword "with"
-    brPos <- getSourcePos
-    symbol "{"
-    cs <- casePatts
-    endPos <- getSourcePos
-    char '}'
-    return $ Case startPos e brPos (NEList.fromList cs) endPos
+caseE = undefined
 
 tupleArgs :: SomeParser r a -> SomeParser r [(a, Maybe SourcePos)]
-tupleArgs p =
-  try
-    ( do
-        e <- p
-        commaPos <- lexeme $ char ',' *> getSourcePos
-        es <- tupleArgs p
-        return ((e, Just commaPos) : es)
-    )
-    <|> do
-      e1 <- p
-      commaPos <- lexeme $ char ',' *> getSourcePos
-      e2 <- p
-      return [(e1, Just commaPos), (e2, Nothing)]
+tupleArgs = undefined
 
 isHSpace :: Char -> Bool
-isHSpace x = isSpace x && x /= '\n' && x /= '\r'
+isHSpace c = isSpace c && c /= '\n' && c /= '\r'
 
 tuple :: SomeParser r a -> SomeParser r (SourcePos, TList (a, Maybe SourcePos), SourcePos)
-tuple p = label "a tuple\nfor example: (2, #true, 4.4)" $
-  lexeme $ do
-    startPos <- getSourcePos
-    symbol "("
-    r <- tListFromList <$> tupleArgs p <|> takeWhileP Nothing isHSpace $> TNil
-    endPos <- getSourcePos
-    char ')'
-    return (startPos, r, endPos)
+tuple = undefined
 
 assertE :: Parser (Expr () SourcePos)
-assertE = label "an assertion\nfor example: assert x > 10 in ..." $ do
-  startPos <- getSourcePos
-  hidden $ rword "assert"
-  e1 <- expr <?> "a boolean expression\nfor example: x > 10 && x <= 25"
-  inPos <- getSourcePos
-  e2 <- (rword "in" <?> "_the 'in' keyword") *> expr
-  return $ Assert startPos e1 inPos e2
+assertE = undefined
 
 ifE :: Parser (Expr () SourcePos)
-ifE = do
-  ifPos <- getSourcePos
-  hidden $ rword "if"
-  cond <- hidden expr <?> "_a conditional expression\nfor example: x > 2"
-  thenPos <- getSourcePos
-  tr <- (rword "then" *> expr) <?> "_the 'then' branch\nfor example: if x > 2 then 1 else 0"
-  elsePos <- getSourcePos
-  fl <- (rword "else" *> expr) <?> "_the 'else' branch\nfor example: if x > 2 then 1 else 0"
-  return $ If ifPos cond thenPos tr elsePos fl
+ifE = undefined
 
 -- | Parses an op in prefix syntax WITHOUT opening paren @(@ but with closing paren @)@
 -- E.g. @+)@
 prefixOpsWithoutModule :: SourcePos -> Parser (Expr () SourcePos)
-prefixOpsWithoutModule startPos =
-  hidden (ask >>= choiceOf (prefixOp startPos) . opsInLocalScope)
-  where
-    opsInLocalScope (ops, _, _) = [s | (_, modNm, s) <- concat ops, modNm == LocalScope]
-    prefixOp :: SourcePos -> Text -> Parser (Expr () SourcePos)
-    prefixOp pos s = do
-      _ <- symbol $ s <> ")"
-      return $ OpVar pos () LocalScope $ Ident s
+prefixOpsWithoutModule = undefined
 
 -- | Parses a op in prefix syntax of the form @Mod.(+)@
 prefixOpsWithModule :: SourcePos -> Parser (Expr () SourcePos)
-prefixOpsWithModule startPos =
-  hidden (ask >>= tryMany prefixOp . opsNotInLocal)
-  where
-    opsNotInLocal (ops, _, _) = [(modNm, s) | (_, modNm, s) <- concat ops, modNm /= LocalScope]
-    prefixOp :: (Scoped ModuleName, Text) -> Parser (Expr () SourcePos)
-    prefixOp (modNm, s) = do
-      _ <- symbol $ fromScoped "" (unModuleName <$> modNm) <> ".(" <> s <> ")"
-      return $ OpVar startPos () modNm $ Ident s
+prefixOpsWithModule = undefined
 
 -- | Parses a tuple @a, b, c, ...)@ WITHOUT opening paren @(@ but with closing paren @)@
 -- Returns (list of (expr, commaPos), endParenPos)
 tupleElems :: Parser ([(Expr () SourcePos, Maybe SourcePos)], SourcePos)
-tupleElems =
-  ( do
-      e <- expr
-      ( do
-          char ')'
-          endPos <- getSourcePos
-          return ([(e, Nothing)], endPos)
-        )
-        <|> ( do
-                commaPos <- lexeme $ char ',' *> getSourcePos
-                (es, endPos) <- tupleElems
-                return ((e, Just commaPos) : es, endPos)
-            )
-  )
-    <|> do
-      char ')'
-      endPos <- getSourcePos
-      return ([], endPos)
+tupleElems = undefined
 
 -- | Parses any bracketed expression: tuples, bracketed exprs (1 + 2), and prefix ops (+)
 bracketedE :: Parser (Expr () SourcePos)
-bracketedE = do
-  startPos <- getSourcePos
-  symbol "("
-  -- Either a prefix op or a tuple. bracketed exprs are 1-tuples
-  prefixOpsWithoutModule startPos <|> bracketedOrTuple startPos
-  where
-    bracketedOrTuple startPos = do
-      (es, endPos) <- tupleElems
-      lexeme $ pure $ case es of
-        [] -> Tuple startPos TNil endPos
-        [(e, _)] -> Bracketed startPos e endPos
-        _ -> Tuple startPos (tListFromList es) endPos
+bracketedE = undefined
 
 term :: Parser (Expr () SourcePos)
-term =
-  bracketedE
-    <|> try (hexadecimal Lit)
-    <|> try doubleE
-    <|> intE
-    <|> enumE Enum
-    <|> do
-      -- Variable: foo or Mod.foo or Mod.(+)
-      -- Record field access rec.field is also parsed as Var and converted to RecordField
-      -- in pinExpr
-      startPos <- getSourcePos
-      lexeme $
-        try
-          ( ( \nmspc x ->
-                Var startPos () (Scope $ ModuleName nmspc) $
-                  Expl $
-                    ExtIdent $
-                      Right x
-            )
-              <$> variable
-              <*> (char '.' *> variable)
-          )
-          <|> prefixOpsWithModule startPos
-          <|> try
-            ( Var startPos () LocalScope . Expl . ExtIdent . Right
-                <$> variable
-                <* notFollowedBy (char '.')
-            )
-    <|> noneE Empty
-    <|> someE One expr
-    <|> ifE
-    <|> try renameModE
-    <|> letE
-    <|> openModE
-    <|> assertE
-    <|> funE
-    <|> caseE
-    <|> try implVarE
-    <|> stringE Lit
-    <|> interpolatedStringE
-    <|> try (uncurry3 Array <$> array expr)
-    <|> try (uncurry3 Record <$> record expr)
-    <|> arrayComprE
+term = undefined
 
 app :: Parser (Expr () SourcePos)
-app =
-  term >>= \x ->
-    (some term >>= \xs -> return (foldl App x xs))
-      <|> return x
+app = undefined
 
 expr :: Parser (Expr () SourcePos)
-expr = ask >>= \(opsTable, _, _) -> makeExprParser app $ mkOperators opsTable
+expr = undefined
 
 mkOperators :: OpsTable -> [[Operator Parser (Expr () SourcePos)]]
-mkOperators opsTable =
-  [ map (uncurry3 $ mkOperatorP prec) opGrp | (prec, opGrp) <- IntMap.toDescList opsTable
-  ]
-  where
-    infixLabel = label "an infix operator\nfor example: +, *, ==, >, <"
-    prefixLabel = label "a prefix operator\nfor example: -, !"
-
-    opString :: Scoped ModuleName -> Text -> Text
-    opString modNm s = case modNm of
-      LocalScope -> s
-      Scope (ModuleName ns) -> ns <> "." <> s
-
-    mkOperatorP :: Int -> Fixity -> Scoped ModuleName -> Text -> Operator Parser (Expr () SourcePos)
-    mkOperatorP prec (InfixOp NoFix) ns o =
-      InfixN $
-        infixLabel $
-          (\pos e1 e2 -> Op e1 pos () (prec, NoFix) ns (Ident o) e2) <$> lexeme (getSourcePos <* string (opString ns o))
-    mkOperatorP prec (InfixOp LeftFix) ns o =
-      InfixL $
-        infixLabel $
-          (\pos e1 e2 -> Op e1 pos () (prec, LeftFix) ns (Ident o) e2) <$> lexeme (getSourcePos <* string (opString ns o))
-    mkOperatorP prec (InfixOp RightFix) ns o =
-      InfixR $
-        infixLabel $
-          (\pos e1 e2 -> Op e1 pos () (prec, RightFix) ns (Ident o) e2) <$> lexeme (getSourcePos <* string (opString ns o))
-    mkOperatorP prec PrefixOp ns o =
-      Prefix $
-        prefixLabel $
-          (\pos e -> PreOp pos () prec ns (Ident o) e) <$> lexeme (getSourcePos <* string (opString ns o))
+mkOperators = undefined
 
 parseExpr ::
   OpsTable ->
@@ -773,301 +487,99 @@ parseExpr ::
   Either
     (NonEmpty (ParseError Text InfernoParsingError, SourcePos))
     (Expr () SourcePos, [Comment SourcePos])
-parseExpr opsTable modOpsTables customTypes s =
-  case runParser (runWriterT $ flip runReaderT (opsTable, modOpsTables, customTypes) $ topLevel expr) "<stdin>" s of
-    Left (ParseErrorBundle errs pos) -> Left $ fst $ attachSourcePos errorOffset errs pos
-    Right (e, comments) -> Right (e, appEndo comments [])
+parseExpr = undefined
 
--- parsing types
-
-type TyParser = ReaderT (Map.Map Text Int, OpsTable, Map.Map ModuleName OpsTable, [CustomType]) (WriterT Comments (Parsec InfernoParsingError Text))
+-- Parsing types
 
 rwsType :: [Text] -- list of reserved type sig words
-rwsType = ["define", "on", "forall"]
+rwsType = undefined
 
 typeIdent :: TyParser Text
-typeIdent = try (p >>= check)
-  where
-    p = pack <$> (((:) <$> letterChar <*> hidden (many alphaNumChar)) <?> "a type")
-    check x =
-      if x `elem` rwsType
-        then fail $ "Keyword " <> show x <> " cannot be a variable/function name"
-        else return x
+typeIdent = undefined
 
 baseType :: TyParser InfernoType
-baseType = do
-  (_, _, _, customTypes) <- ask
-  TBase
-    <$> ( symbol "int" $> TInt
-            <|> symbol "double" $> TDouble
-            <|> symbol "word16" $> TWord16
-            <|> symbol "word32" $> TWord32
-            <|> symbol "word64" $> TWord64
-            <|> symbol "text" $> TText
-            <|> try (symbol "timeDiff" $> TTimeDiff)
-            <|> symbol "time" $> TTime
-            <|> symbol "resolution" $> TResolution
-            <|> choice (map (\t -> symbol (pack t) $> TCustom t) customTypes)
-        )
+baseType = undefined
 
 typeVariableRaw :: TyParser Text
-typeVariableRaw = char '\'' *> takeWhile1P Nothing isAlphaNum
+typeVariableRaw = undefined
 
 typeVariable :: TyParser Int
-typeVariable = do
-  nm <- typeVariableRaw
-  (tys, _, _, _) <- ask
-  case Map.lookup nm tys of
-    Just i -> return i
-    Nothing -> customFailure $ UnboundTyVar nm
+typeVariable = undefined
 
 recordType :: TyParser (Map.Map Ident InfernoType, RestOfRecord)
-recordType = label "record type\nfor example: {name: text; age: int}" $
-  lexeme $ do
-    symbol "{"
-    (fields, rest) <- argsE
-    return (Map.fromList fields, rest)
-  where
-    argsE =
-      try
-        ( do
-            f <- lexeme $ Ident <$> fieldName
-            symbol ":"
-            e <- typeParser
-            symbol ";"
-            (fields, rest) <- argsE
-            return ((f, e) : fields, rest)
-        )
-        <|> ( do
-                f <- lexeme $ Ident <$> fieldName
-                symbol ":"
-                e1 <- typeParser
-                char '}'
-                return ([(f, e1)], RowAbsent)
-            )
-        <|> ( do
-                t <- typeVariable
-                char '}'
-                return ([], RowVar $ TV t)
-            )
-        <|> ( do
-                char '}'
-                pure ([], RowAbsent)
-            )
-    keywords = Set.fromList $ rws ++ rwsType
-    fieldName :: TyParser Text
-    fieldName = f >>= check
-      where
-        f = pack <$> (((:) <$> letterChar <*> hidden (many alphaNumCharOrSeparator)) <?> "a record field name")
-        check x =
-          if x `Set.member` keywords
-            then fail $ "Keyword " <> show x <> " cannot be a record field name"
-            else return x
+recordType = undefined
 
 typeParserBase :: TyParser InfernoType
-typeParserBase =
-  try ((\(_, tys, _) -> TTuple $ fmap fst tys) <$> tuple typeParser)
-    <|> parens typeParser
-    <|> try (lexeme baseType)
-    <|> uncurry TRecord <$> recordType
-    <|> lexeme (TBase <$> (TEnum <$> typeIdent <*> (Set.fromList <$> (symbol "{" *> enumList <* symbol "}"))))
-    <|> lexeme (TVar . TV <$> typeVariable)
-  where
-    enumList =
-      try
-        ((:) <$> enumConstructor <* symbol "," <*> enumList)
-        <|> (: []) <$> enumConstructor
+typeParserBase = undefined
 
 typeParser :: TyParser InfernoType
-typeParser =
-  makeExprParser
-    typeParserBase
-    [
-      [ Prefix (TArray <$ rword "array" <* rword "of")
-      , Prefix (TSeries <$ rword "series" <* rword "of")
-      , Prefix (TOptional <$ rword "option" <* rword "of")
-      ]
-    ,
-      [ InfixR (TArr <$ symbol "->")
-      , InfixR (TArr <$ symbol "→")
-      ]
-    ]
+typeParser = undefined
 
 parseType ::
   Text ->
   Either
     (NonEmpty (ParseError Text InfernoParsingError, SourcePos))
     InfernoType
-parseType s = case runParser (runWriterT $ flip runReaderT (mempty, mempty, mempty, []) $ topLevel typeParser) "<stdin>" s of
-  Left (ParseErrorBundle errs pos) -> Left $ fst $ attachSourcePos errorOffset errs pos
-  Right (e, _) -> Right e
+parseType s = undefined
 
 parseTCScheme :: Text -> Either String TCScheme
-parseTCScheme s =
-  case runParser (runWriterT $ flip runReaderT (mempty, mempty, mempty, []) $ topLevel schemeParser) "<stdin>" s of
-    Left (ParseErrorBundle errs pos) -> Left $ show $ fst $ attachSourcePos errorOffset errs pos
-    Right (e, _) -> Right e
+parseTCScheme = undefined
 
 listParser :: TyParser a -> TyParser [a]
-listParser p =
-  try
-    ( do
-        e <- p
-        symbol ","
-        es <- listParser p
-        return (e : es)
-    )
-    <|> do
-      e1 <- p
-      return [e1]
+listParser = undefined
 
 tyContext :: TyParser [Either TypeClass (Text, InfernoType)]
-tyContext = lexeme $ do
-  _ <- symbol "{"
-  res <- listParser tyContextSingle
-  _ <- symbol "}"
-  _ <- symbol "=>" <|> symbol "⇒"
-  return res
+tyContext = undefined
 
 typeClass :: TyParser TypeClass
-typeClass = TypeClass <$> (lexeme typeIdent <* symbol "on") <*> many typeParser
+typeClass = undefined
 
 tyContextSingle :: TyParser (Either TypeClass (Text, InfernoType))
-tyContextSingle = Left <$> (symbol "requires" *> typeClass) <|> Right <$> ((,) <$> (symbol "implicit" *> lexeme (withReaderT (\(_, ops, m, customTypes) -> (ops, m, customTypes)) variable)) <*> (symbol ":" *> typeParser))
+tyContextSingle = undefined
 
 schemeParser :: TyParser TCScheme
-schemeParser = do
-  vars <- try (rword "forall" *> many (lexeme typeVariableRaw) <* rword ".") <|> pure mempty
-  withReaderT (\(_, ops, m, ts) -> (Map.fromList $ zip vars [0 ..], ops, m, ts)) $
-    constructScheme <$> (try tyContext <|> pure []) <*> typeParser
-  where
-    constructScheme :: [Either TypeClass (Text, InfernoType)] -> InfernoType -> TCScheme
-    constructScheme cs t =
-      let (tcs, impls) = partitionEithers cs
-       in closeOver (Set.fromList tcs) $ ImplType (Map.fromList $ map (first (ExtIdent . Right)) impls) t
+schemeParser = undefined
 
 doc :: Parser Text
-doc = do
-  _ <- symbol "@doc"
-  txt <- takeWhileP Nothing (/= ';')
-  _ <- symbol ";"
-  return txt
-
-data TopLevelDefn def
-  = Signature
-      { documentation :: Maybe Text
-      , name :: SigVar
-      , def :: def
-      }
-  | EnumDef (Maybe Text) Text [Ident]
-  | TypeClassInstance TypeClass
-  | Export ModuleName
-  deriving (Eq, Show, Data)
+doc = undefined
 
 enumConstructors :: Parser [Ident]
-enumConstructors = try ((:) <$> (lexeme enumConstructor <* symbol "|") <*> enumConstructors) <|> (: []) <$> lexeme enumConstructor
+enumConstructors = undefined
 
 sigVariable :: Parser SigVar
-sigVariable =
-  ask >>= \(opsTable, _, _) ->
-    let opList =
-          concatMap
-            ( \case
-                (InfixOp _, _ns, i) -> [i]
-                _ -> []
-            )
-            $ concat
-            $ IntMap.elems opsTable
-        preOpList =
-          concatMap
-            ( \case
-                (PrefixOp, _ns, i) -> [i]
-                _ -> []
-            )
-            $ concat
-            $ IntMap.elems opsTable
-     in lexeme $
-          tryMany (\op -> char '(' *> (SigOpVar <$> string op) <* char ')') opList
-            <|> tryMany (fmap SigVar . string) preOpList
-            <|> SigVar <$> variable
-
-data QQDefinition = QQRawDef String | QQToValueDef String | InlineDef (Expr () SourcePos) deriving (Data)
+sigVariable = undefined
 
 exprOrBuiltin :: Parser QQDefinition
-exprOrBuiltin =
-  try (QQToValueDef . unpack <$> lexeme (string "###" *> withReaderT (const (mempty, mempty, [])) variable <* string "###"))
-    <|> try (QQRawDef . unpack <$> lexeme (string "###!" *> withReaderT (const (mempty, mempty, [])) variable <* string "###"))
-    <|> InlineDef <$> expr
+exprOrBuiltin = undefined
 
 sigParser :: Parser (TopLevelDefn (Maybe TCScheme, QQDefinition))
-sigParser =
-  ( try (Signature <$> (try (Just <$> doc) <|> pure Nothing) <*> sigVariable <*> ((,) <$> (try (Just <$> (symbol ":" *> withReaderT (\(ops, m, customTypes) -> (mempty, ops, m, customTypes)) schemeParser)) <|> pure Nothing) <*> (symbol ":=" *> exprOrBuiltin)))
-      <|> try ((EnumDef . Just <$> doc) <*> (symbol "enum" *> lexeme variable <* symbol ":=") <*> enumConstructors)
-      <|> EnumDef Nothing <$> (symbol "enum" *> lexeme variable <* symbol ":=") <*> enumConstructors
-      <|> TypeClassInstance <$> (symbol "define" *> withReaderT (\(ops, m, customTypes) -> (mempty, ops, m, customTypes)) typeClass)
-      <|> Export <$> (symbol "export" *> (ModuleName <$> lexeme variable))
-  )
-    <* symbol ";"
+sigParser = undefined
 
 fixityP :: Parser Fixity
-fixityP =
-  lexeme $
-    try (rword "infixr" $> InfixOp RightFix)
-      <|> try (rword "infixl" $> InfixOp LeftFix)
-      <|> try (rword "infix" $> InfixOp NoFix)
-      <|> try (rword "prefix" $> PrefixOp)
-
-type OpsTable = IntMap.IntMap [(Fixity, Scoped ModuleName, Text)]
+fixityP = undefined
 
 fixityLvl :: Parser Int
-fixityLvl = try (lexeme Lexer.decimal >>= check)
-  where
-    check x =
-      if x >= 0 && x < 20
-        then return x
-        else fail "Fixity level annotation must be between 0 and 19 (inclusive)"
+fixityLvl = undefined
 
 sigsParser :: Parser (OpsTable, [TopLevelDefn (Maybe TCScheme, QQDefinition)])
-sigsParser =
-  try (opDeclP >>= \opsTable' -> withReaderT (const opsTable') sigsParser)
-    <|> try
-      ( do
-          def <- sigParser
-          (opsTable, defs) <- sigsParser
-          return (opsTable, def : defs)
-      )
-    <|> try
-      ( do
-          (opsTable, _, _) <- opDeclP
-          return (opsTable, [])
-      )
-    <|> (sigParser >>= \r -> ask >>= \(opsTable, _, _) -> return (opsTable, [r]))
-  where
-    opDeclP = ask >>= \(opsTable, modOpsTables, customTypes) -> (\f l o -> (insertIntoOpsTable opsTable f l o, modOpsTables, customTypes)) <$> fixityP <*> fixityLvl <*> (operatorP <* symbol ";")
-    operatorP = lexeme $ takeWhile1P (Just "operator") (\c -> c /= ';' && not (isSpace c))
+sigsParser = undefined
 
 insertIntoOpsTable :: OpsTable -> Fixity -> Int -> Text -> OpsTable
-insertIntoOpsTable opsTable fixity lvl op =
-  IntMap.alter
-    ( \case
-        Nothing -> Just [(fixity, LocalScope, op)]
-        Just xs -> Just $ xs ++ [(fixity, LocalScope, op)]
-    )
-    lvl
-    opsTable
+insertIntoOpsTable tbl f lvl op = IntMap.alter go lvl tbl
+  where
+    go ::
+      Maybe [(Fixity, Scoped ModuleName, Text)] ->
+      Maybe [(Fixity, Scoped ModuleName, Text)]
+    go = \cases
+      Nothing -> Just [(f, LocalScope, op)]
+      (Just xs) -> Just $ (f, LocalScope, op) : xs
 
-modulesParser :: Parser [(ModuleName, OpsTable, [TopLevelDefn (Maybe TCScheme, QQDefinition)])]
-modulesParser = do
-  symbol "module"
-  moduleNm <- ModuleName <$> lexeme variable
-  (ops, sigs) <- sigsParser
-  let opsQualified = IntMap.map (map (\(fix, _, t) -> (fix, Scope moduleNm, t))) ops
-  try
-    ( do
-        ms <- withReaderT (\(prevOps, modOpsTables, customTypes) -> (IntMap.unionWith (<>) prevOps opsQualified, Map.insert moduleNm ops modOpsTables, customTypes)) modulesParser
-        pure $ (moduleNm, ops, sigs) : ms
-    )
-    <|> pure [(moduleNm, ops, sigs)]
+modulesParser ::
+  Parser [(ModuleName, OpsTable, [TopLevelDefn (Maybe TCScheme, QQDefinition)])]
+modulesParser = undefined
 
 topLevel :: SomeParser r a -> SomeParser r a
-topLevel p = sc *> p <* eof
+topLevel p = undefined
+
+labelled :: String -> Parser a -> Parser a
+labelled t = (<?> t)

--- a/inferno-core/src/Inferno/Parse.hs
+++ b/inferno-core/src/Inferno/Parse.hs
@@ -34,8 +34,8 @@ import Control.Monad.Combinators.Expr
   ( Operator (InfixL, InfixN, InfixR, Prefix),
     makeExprParser,
   )
-import Control.Monad.Reader (ReaderT, ask, asks, withReaderT)
-import Control.Monad.State.Strict (StateT, modify')
+import Control.Monad.Reader (ReaderT, ask, asks, runReaderT, withReaderT)
+import Control.Monad.State.Strict (StateT, modify', runStateT)
 import Data.Bifunctor (first)
 import Data.Bool (bool)
 import Data.Char (isAlphaNum, isSpace)
@@ -52,7 +52,8 @@ import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
-import Data.Tuple.Extra (second3)
+import Data.Tuple.Extra (second3, snd3)
+import Inferno.Infer.Env (closeOver)
 import Inferno.Parse.Error (prettyError)
 import Inferno.Types.Syntax
   ( Comment (BlockComment, LineComment),
@@ -60,12 +61,14 @@ import Inferno.Types.Syntax
     Expr
       ( App,
         Array,
+        ArrayComp,
         Assert,
         Bracketed,
         Case,
         Empty,
         Enum,
         If,
+        InterpolatedString,
         Lam,
         Let,
         LetAnnot,
@@ -93,36 +96,73 @@ import Inferno.Types.Syntax
     Scoped (LocalScope, Scope),
     SigVar (SigOpVar, SigVar),
     TList (TNil),
+    fromEitherList,
     fromScoped,
     rws,
     tListFromList,
     unModuleName,
   )
 import Inferno.Types.Type
-  ( InfernoType,
+  ( BaseType
+      ( TCustom,
+        TDouble,
+        TEnum,
+        TInt,
+        TResolution,
+        TText,
+        TTime,
+        TTimeDiff,
+        TWord16,
+        TWord32,
+        TWord64
+      ),
+    ImplType (ImplType),
+    InfernoType
+      ( TArr,
+        TArray,
+        TBase,
+        TOptional,
+        TRecord,
+        TSeries,
+        TTuple,
+        TVar
+      ),
+    RestOfRecord (RowAbsent, RowVar),
     TCScheme,
-    TypeClass,
+    TV (TV),
+    TypeClass (TypeClass),
   )
 import Inferno.Utils.Prettyprinter (renderPretty)
 import Text.Megaparsec
-  ( MonadParsec (hidden, label, notFollowedBy, takeWhile1P, takeWhileP, try),
+  ( MonadParsec (eof, hidden, label, notFollowedBy, takeWhile1P, takeWhileP, try),
     ParseError,
+    ParseErrorBundle (ParseErrorBundle),
     Parsec,
     ShowErrorComponent (showErrorComponent),
     SourcePos,
     anySingle,
+    attachSourcePos,
     between,
+    choice,
     customFailure,
+    errorOffset,
     getSourcePos,
     many,
     manyTill,
+    runParser,
     satisfy,
     some,
     sourceColumn,
     unPos,
     (<?>),
   )
-import Text.Megaparsec.Char (char, char', letterChar, spaceChar, string)
+import Text.Megaparsec.Char
+  ( char,
+    char',
+    letterChar,
+    spaceChar,
+    string,
+  )
 import qualified Text.Megaparsec.Char.Lexer as Lexer
 
 data InfernoParsingError
@@ -171,6 +211,15 @@ data QQDefinition
   deriving stock (Data)
 
 type TyParser = ParserOver TyParseEnv
+
+-- | A single selector in an array comprehension: @x <- expr@.
+data CompSel = CompSel
+  { varPos :: !SourcePos
+  , var :: !Ident
+  , arrPos :: !SourcePos
+  , body :: Expr () SourcePos
+  , sep :: !(Maybe SourcePos)
+  }
 
 -- | Operator table entry.
 data OpEntry = OpEntry
@@ -235,6 +284,15 @@ data TyParseEnv = TyParseEnv
   , modOps :: !(Map ModuleName OpsTable)
   , ctypes :: ![CustomType]
   }
+
+toTyEnv :: ParseEnv -> TyParseEnv
+toTyEnv env =
+  TyParseEnv
+    { tyVars = mempty
+    , ops = env.ops
+    , modOps = env.modOps
+    , ctypes = env.customTypes
+    }
 
 fromOpTuple :: (Fixity, Scoped ModuleName, Text) -> OpEntry
 fromOpTuple (f, s, n) = OpEntry{fixity = f, scope = s, name = n}
@@ -455,10 +513,105 @@ stringE f =
     charNoNewline = notFollowedBy (char '\n') *> Lexer.charLiteral
 
 interpolatedStringE :: Parser (Expr () SourcePos)
-interpolatedStringE = undefined
+interpolatedStringE =
+  label "an interpolated string\nfor example: `hello ${1 + 2}`" . lexeme . withSourcePos $
+    \startPos ->
+      let col :: Int
+          col = unPos startPos.sourceColumn
+       in ((char '`' *> go) >>=) . (. mkInterpolatedString) $ \es ->
+            flip fmap getSourcePos
+              $ InterpolatedString startPos
+                . fromEitherList
+              $ flip fmap es
+                . first
+              $ fixSpacing col
+  where
+    go :: Parser [Either Text (SourcePos, Expr () SourcePos, SourcePos)]
+    go =
+      asum
+        [ mempty <$ char '`'
+        , try $ (:) . Left . Text.singleton <$> hidden (escaped '\\') <*> go
+        , try $ (:) . Left . Text.singleton <$> hidden (escaped '`') <*> go
+        , try $ (:) . Left . Text.singleton <$> hidden (escaped '$') <*> go
+        , (:) . Right <$> hidden interpolation <*> go
+        , (:) . Left . Text.singleton <$> Lexer.charLiteral <*> go
+        ]
+
+    escaped :: Char -> Parser Char
+    escaped c = char '\\' *> char c
+
+    interpolation :: Parser (SourcePos, Expr () SourcePos, SourcePos)
+    interpolation = withSourcePos $ \startPos ->
+      char '$' *> char '{' *> sc *> expr <* char '}' >>= \e ->
+        getSourcePos <&> (startPos,e,)
+
+    fixSpacing :: Int -> Text -> Text
+    fixSpacing col = Text.replace ws "\n"
+      where
+        ws :: Text
+        ws = Text.pack $ '\n' : replicate (col - 1) ' '
+
+    mkInterpolatedString :: [Either Text e] -> [Either Text e]
+    mkInterpolatedString = \case
+      [] -> mempty
+      (Left x : Left y : xs) -> mkInterpolatedString $ Left (x <> y) : xs
+      (x : xs) -> x : mkInterpolatedString xs
 
 arrayComprE :: Parser (Expr () SourcePos)
-arrayComprE = undefined
+arrayComprE =
+  label "array builder\nfor example: [n * 2 + 1 | n <- range 0 10, if n % 2 == 0]"
+    . lexeme
+    $ do
+      startPos <- getSourcePos
+      void $ symbol "["
+      e <- expr
+      midPos <- getSourcePos
+      void $ symbol "|"
+      (sels, cond) <- selectors
+      endPos <- getSourcePos
+      void . optional $ symbol ","
+      void $ char ']'
+      pure $ ArrayComp startPos e midPos (fmap toTuple sels) cond endPos
+  where
+    -- Return the AST to tuple soup
+    toTuple ::
+      CompSel -> (SourcePos, Ident, SourcePos, Expr () SourcePos, Maybe SourcePos)
+    toTuple s = (s.varPos, s.var, s.arrPos, s.body, s.sep)
+
+    selectors :: Parser (NonEmpty CompSel, Maybe (SourcePos, Expr () SourcePos))
+    selectors =
+      selectE >>= \sel ->
+        asum
+          [ try . withSourcePos $ \pos ->
+              symbol ","
+                *> let sel' :: CompSel
+                       sel' = CompSel sel.varPos sel.var sel.arrPos sel.body (Just pos)
+                    in try (fmap (first (sel' `consNE`)) selectors) <|> condE (sel' :| [])
+          , pure (sel :| [], Nothing)
+          ]
+
+    consNE :: a -> NonEmpty a -> NonEmpty a
+    consNE x (y :| ys) = x :| (y : ys)
+
+    selectE :: Parser CompSel
+    selectE = withSourcePos $ \varPos -> do
+      var <- lexeme $ Ident <$> variable
+      arrPos <- getSourcePos
+      body <- symbol "<-" *> expr
+      pure
+        CompSel
+          { varPos
+          , var
+          , arrPos
+          , body
+          , sep = Nothing
+          }
+
+    condE ::
+      NonEmpty CompSel ->
+      Parser (NonEmpty CompSel, Maybe (SourcePos, Expr () SourcePos))
+    condE sels = withSourcePos $ \ifPos ->
+      (sels,) . Just . (ifPos,) <$> (rword "if" *> expr)
 
 array :: forall a. Parser a -> Parser (Delimited a)
 array p =
@@ -477,8 +630,8 @@ array p =
     rest e =
       asum
         [ withSourcePos $ \pos ->
-            symbol "," *> fmap (Separated{val = e, sep = Just pos} :) argsE
-        , pure [Separated{val = e, sep = Nothing}]
+            symbol "," *> fmap (Separated e (Just pos) :) argsE
+        , pure [Separated e Nothing]
         ]
 
 record :: forall a. Parser a -> Parser (Delimited (Field a))
@@ -519,9 +672,6 @@ mkRecord del = Record del.open (fmap toTriple del.items) del.close
       Separated (Field (Expr () SourcePos)) ->
       (Ident, Expr () SourcePos, Maybe SourcePos)
     toTriple s = (s.val.name, s.val.val, s.sep)
-
-mkInterpolatedString :: [Either Text e] -> [Either Text e]
-mkInterpolatedString = undefined
 
 funE :: Parser (Expr () SourcePos)
 funE = label "a function\nfor example: fun x y -> x + y" $ do
@@ -714,15 +864,6 @@ letE = label ("a 'let' expression" <> example "x") $ do
         , "'" <> x <> "'"
         , example x
         ]
-
-    toTyEnv :: ParseEnv -> TyParseEnv
-    toTyEnv env =
-      TyParseEnv
-        { tyVars = mempty
-        , ops = env.ops
-        , modOps = env.modOps
-        , ctypes = env.customTypes
-        }
 
 pat :: Parser (Pat () SourcePos)
 pat =
@@ -980,70 +1121,302 @@ mkOperators tbl =
 
 parseExpr ::
   OpsTable ->
-  Map.Map ModuleName OpsTable ->
+  Map ModuleName OpsTable ->
   [CustomType] ->
   Text ->
   Either
     (NonEmpty (ParseError Text InfernoParsingError, SourcePos))
     (Expr () SourcePos, [Comment SourcePos])
-parseExpr = undefined
+parseExpr ops mOps cts src =
+  runParser run "<stdin>" src & \case
+    Left (ParseErrorBundle errs pos) ->
+      Left . fst $ attachSourcePos errorOffset errs pos
+    Right (e, comments) -> Right (e, reverse comments)
+  where
+    run :: BaseParsec (Expr () SourcePos, [Comment SourcePos])
+    run =
+      flip runStateT mempty
+        . flip runReaderT (mkParseEnv ops mOps cts)
+        $ topLevel expr
 
 -- Parsing types
 
-rwsType :: [Text] -- list of reserved type sig words
-rwsType = undefined
+rwsType :: [Text]
+rwsType = ["define", "on", "forall"]
 
 typeIdent :: TyParser Text
-typeIdent = undefined
+typeIdent = try $ p >>= check
+  where
+    p :: TyParser Text
+    p = label "a type" $ Text.cons <$> letterChar <*> hidden (takeWhileP Nothing isAlphaNum)
+
+    check :: Text -> TyParser Text
+    check x =
+      bool (fail $ "Keyword " <> show x <> " cannot be a variable/function name") (pure x) $
+        notElem x rwsType
 
 baseType :: TyParser InfernoType
-baseType = undefined
+baseType =
+  asks (.ctypes) >>= \cts ->
+    TBase
+      <$> asum
+        [ symbol "int" $> TInt
+        , symbol "double" $> TDouble
+        , symbol "word16" $> TWord16
+        , symbol "word32" $> TWord32
+        , symbol "word64" $> TWord64
+        , symbol "text" $> TText
+        , try $ symbol "timeDiff" $> TTimeDiff
+        , symbol "time" $> TTime
+        , symbol "resolution" $> TResolution
+        , choice $ fmap customType cts
+        ]
+  where
+    customType :: String -> TyParser BaseType
+    customType t = symbol (Text.pack t) $> TCustom t
 
 typeVariableRaw :: TyParser Text
-typeVariableRaw = undefined
+typeVariableRaw = char '\'' *> takeWhile1P Nothing isAlphaNum
 
 typeVariable :: TyParser Int
-typeVariable = undefined
+typeVariable =
+  typeVariableRaw >>= \nm ->
+    asks (.tyVars) >>= maybe (customFailure (UnboundTyVar nm)) pure . Map.lookup nm
 
-recordType :: TyParser (Map.Map Ident InfernoType, RestOfRecord)
-recordType = undefined
+recordType :: TyParser (Map Ident InfernoType, RestOfRecord)
+recordType =
+  label "record type\nfor example: {name: text; age: int}" . lexeme $
+    symbol "{" *> fields mempty
+  where
+    fields ::
+      Map Ident InfernoType ->
+      TyParser (Map Ident InfernoType, RestOfRecord)
+    fields acc =
+      asum
+        [ try $ fields =<< fieldSemicolon acc
+        , fieldClose acc
+        , rowVarClose acc
+        , char '}' $> (acc, RowAbsent)
+        ]
+
+    fieldSemicolon :: Map Ident InfernoType -> TyParser (Map Ident InfernoType)
+    fieldSemicolon acc = do
+      f <- lexeme . fmap Ident $ fieldName
+      void $ symbol ":"
+      e <- typeParser
+      void $ symbol ";"
+      pure $ Map.insert f e acc
+
+    fieldClose ::
+      Map Ident InfernoType -> TyParser (Map Ident InfernoType, RestOfRecord)
+    fieldClose acc = do
+      f <- lexeme . fmap Ident $ fieldName
+      void $ symbol ":"
+      e <- typeParser
+      void $ char '}'
+      pure (Map.insert f e acc, RowAbsent)
+
+    rowVarClose ::
+      Map Ident InfernoType -> TyParser (Map Ident InfernoType, RestOfRecord)
+    rowVarClose acc =
+      fmap ((acc,) . RowVar . TV) $
+        typeVariable <* char '}'
+
+    keywords :: Set Text
+    keywords = Set.fromList $ rws <> rwsType
+
+    fieldName :: TyParser Text
+    fieldName = check =<< p
+      where
+        p :: TyParser Text
+        p =
+          label "a record field name" $
+            Text.cons
+              <$> letterChar
+              <*> hidden (takeWhileP Nothing isAlphaNumOrSeparator)
+
+        check :: Text -> TyParser Text
+        check x =
+          bool (fail msg) (pure x) . not $
+            Set.member x keywords
+          where
+            msg :: String
+            msg =
+              unwords
+                [ "Keyword"
+                , show x
+                , "cannot be a record field name"
+                ]
 
 typeParserBase :: TyParser InfernoType
-typeParserBase = undefined
+typeParserBase =
+  asum
+    [ try . fmap mkTuple $ tuple typeParser
+    , parens typeParser
+    , try $ lexeme baseType
+    , uncurry TRecord <$> recordType
+    , lexeme . fmap TBase $ enum
+    , lexeme $ TVar . TV <$> typeVariable
+    ]
+  where
+    mkTuple :: (a, TList (InfernoType, Maybe SourcePos), c) -> InfernoType
+    mkTuple = TTuple . fmap fst . snd3
+
+    enumSet :: TyParser (Set Ident)
+    enumSet = go mempty
+      where
+        go :: Set Ident -> TyParser (Set Ident)
+        go acc =
+          enumConstructor >>= \c ->
+            let acc' :: Set Ident
+                acc' = Set.insert c acc
+             in asum [symbol "," *> go acc', pure acc']
+
+    enum :: TyParser BaseType
+    enum =
+      TEnum
+        <$> typeIdent
+        <*> (symbol "{" *> enumSet <* symbol "}")
 
 typeParser :: TyParser InfernoType
-typeParser = undefined
+typeParser =
+  makeExprParser
+    typeParserBase
+    [
+      [ Prefix (TArray <$ rword "array" <* rword "of")
+      , Prefix (TSeries <$ rword "series" <* rword "of")
+      , Prefix (TOptional <$ rword "option" <* rword "of")
+      ]
+    ,
+      [ InfixR (TArr <$ (symbol "->" <|> symbol "\x2192"))
+      ]
+    ]
 
 parseType ::
   Text ->
   Either
     (NonEmpty (ParseError Text InfernoParsingError, SourcePos))
     InfernoType
-parseType = undefined
+parseType src =
+  runParser run "<stdin>" src & \case
+    Left (ParseErrorBundle errs pos) -> Left . fst $ attachSourcePos errorOffset errs pos
+    Right (e, _) -> Right e
+  where
+    env :: TyParseEnv
+    env =
+      TyParseEnv
+        { tyVars = mempty
+        , ops = mempty
+        , modOps = mempty
+        , ctypes = mempty
+        }
+
+    run :: BaseParsec (InfernoType, [Comment SourcePos])
+    run = flip runStateT mempty . flip runReaderT env $ topLevel typeParser
 
 parseTCScheme :: Text -> Either String TCScheme
-parseTCScheme = undefined
+parseTCScheme src =
+  runParser run "<stdin>" src & \case
+    Left (ParseErrorBundle errs pos) ->
+      Left . show . fst $ attachSourcePos errorOffset errs pos
+    Right (e, _) -> Right e
+  where
+    env :: TyParseEnv
+    env =
+      TyParseEnv
+        { tyVars = mempty
+        , ops = mempty
+        , modOps = mempty
+        , ctypes = mempty
+        }
 
-listParser :: TyParser a -> TyParser [a]
-listParser = undefined
+    run :: BaseParsec (TCScheme, [Comment SourcePos])
+    run = flip runStateT mempty . flip runReaderT env $ topLevel schemeParser
 
-tyContext :: TyParser [Either TypeClass (Text, InfernoType)]
-tyContext = undefined
+-- | A single entry in a type context: either a class constraint or an implicit binding.
+data TyContextEntry
+  = ClassConstraint TypeClass
+  | ImplicitBinding Text InfernoType
+
+tyContext :: TyParser [TyContextEntry]
+tyContext =
+  lexeme $
+    symbol "{" *> go id <* symbol "}" <* (symbol "=>" <|> symbol "\x21D2")
+  where
+    go ::
+      ([TyContextEntry] -> [TyContextEntry]) ->
+      TyParser [TyContextEntry]
+    go acc =
+      tyContextSingle >>= \entry ->
+        let acc' :: [TyContextEntry] -> [TyContextEntry]
+            acc' = acc . (entry :)
+         in asum [symbol "," *> go acc', pure $ acc' mempty]
 
 typeClass :: TyParser TypeClass
-typeClass = undefined
+typeClass =
+  TypeClass
+    <$> (lexeme typeIdent <* symbol "on")
+    <*> many typeParser
 
-tyContextSingle :: TyParser (Either TypeClass (Text, InfernoType))
-tyContextSingle = undefined
+tyContextSingle :: TyParser TyContextEntry
+tyContextSingle =
+  asum
+    [ fmap ClassConstraint $ symbol "requires" *> typeClass
+    , implicitBinding
+    ]
+  where
+    implicitBinding :: TyParser TyContextEntry
+    implicitBinding =
+      ImplicitBinding
+        <$> (symbol "implicit" *> lexeme tyVariable)
+        <*> (symbol ":" *> typeParser)
+
+    tyVariable :: TyParser Text
+    tyVariable = withReaderT toParseEnv variable
+
+    toParseEnv :: TyParseEnv -> ParseEnv
+    toParseEnv env = mkParseEnv env.ops env.modOps env.ctypes
 
 schemeParser :: TyParser TCScheme
-schemeParser = undefined
+schemeParser =
+  vars >>= \vs ->
+    withReaderT (bindVars vs) $
+      constructScheme
+        <$> (try tyContext <|> pure mempty)
+        <*> typeParser
+  where
+    vars :: TyParser [Text]
+    vars =
+      asum
+        [ try $ rword "forall" *> many (lexeme typeVariableRaw) <* rword "."
+        , pure mempty
+        ]
+
+    bindVars :: [Text] -> TyParseEnv -> TyParseEnv
+    bindVars vs env = env{tyVars = Map.fromList $ zip vs [0 ..]}
+
+    constructScheme :: [TyContextEntry] -> InfernoType -> TCScheme
+    constructScheme cs t = closeOver tcs $ ImplType impls t
+      where
+        tcs :: Set TypeClass
+        impls :: Map ExtIdent InfernoType
+        (tcs, impls) = foldl' partitionEntry (mempty, mempty) cs
+
+    partitionEntry ::
+      (Set TypeClass, Map ExtIdent InfernoType) ->
+      TyContextEntry ->
+      (Set TypeClass, Map ExtIdent InfernoType)
+    partitionEntry = \cases
+      (tcs, impls) (ClassConstraint tc) -> (Set.insert tc tcs, impls)
+      (tcs, impls) (ImplicitBinding nm ty) -> (tcs, Map.insert (ExtIdent (Right nm)) ty impls)
 
 doc :: Parser Text
-doc = undefined
+doc = symbol "@doc" *> takeWhileP Nothing (/= ';') <* symbol ";"
 
 enumConstructors :: Parser [Ident]
-enumConstructors = undefined
+enumConstructors =
+  try ((:) <$> (lexeme enumConstructor <* symbol "|") <*> enumConstructors)
+    <|> (: mempty) <$> lexeme enumConstructor
 
 sigVariable :: Parser SigVar
 sigVariable =
@@ -1057,10 +1430,43 @@ sigVariable =
     infixOp op = char '(' *> fmap SigOpVar (string op) <* char ')'
 
 exprOrBuiltin :: Parser QQDefinition
-exprOrBuiltin = undefined
+exprOrBuiltin =
+  asum
+    [ try $
+        QQToValueDef . Text.unpack
+          <$> lexeme (string "###" *> withReaderT (const emptyEnv) variable <* string "###")
+    , try $
+        QQRawDef . Text.unpack
+          <$> lexeme (string "###!" *> withReaderT (const emptyEnv) variable <* string "###")
+    , InlineDef <$> expr
+    ]
+  where
+    emptyEnv :: ParseEnv
+    emptyEnv = mkParseEnv mempty mempty mempty
 
 sigParser :: Parser (TopLevelDefn (Maybe TCScheme, QQDefinition))
-sigParser = undefined
+sigParser =
+  asum
+    [ try sig
+    , try $ EnumDef . Just <$> doc <*> enumName <*> enumConstructors
+    , EnumDef Nothing <$> enumName <*> enumConstructors
+    , TypeClassInstance <$> (symbol "define" *> withReaderT toTyEnv typeClass)
+    , Export . ModuleName <$> (symbol "export" *> lexeme variable)
+    ]
+    <* symbol ";"
+  where
+    sig :: Parser (TopLevelDefn (Maybe TCScheme, QQDefinition))
+    sig =
+      Signature
+        <$> optional (try doc)
+        <*> sigVariable
+        <*> ((,) <$> optScheme <*> (symbol ":=" *> exprOrBuiltin))
+
+    optScheme :: Parser (Maybe TCScheme)
+    optScheme = optional . try $ symbol ":" *> withReaderT toTyEnv schemeParser
+
+    enumName :: Parser Text
+    enumName = symbol "enum" *> lexeme variable <* symbol ":="
 
 fixityP :: Parser Fixity
 fixityP =
@@ -1145,4 +1551,4 @@ modulesParser = do
         env.customTypes
 
 topLevel :: ParserOver r a -> ParserOver r a
-topLevel = undefined
+topLevel p = sc *> p <* eof

--- a/inferno-core/src/Inferno/Parse.hs
+++ b/inferno-core/src/Inferno/Parse.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE ApplicativeDo #-}
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE ExplicitForAll #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE NoFieldSelectors #-}
@@ -25,22 +25,24 @@ module Inferno.Parse
   )
 where
 
-import Control.Applicative (asum, (<|>))
+import Control.Applicative (asum, optional, (<|>))
 import Control.Arrow ((&&&))
-import Control.Monad (join, void)
+import Control.Monad (foldM, join, void)
 import Control.Monad.Combinators.Expr
   ( Operator (InfixL, InfixN, InfixR, Prefix),
     makeExprParser,
   )
-import Control.Monad.Reader (ReaderT, asks)
+import Control.Monad.Reader (ReaderT, ask, asks, withReaderT)
 import Control.Monad.State.Strict (StateT, modify')
 import Data.Bifunctor (first)
+import Data.Bool (bool)
 import Data.Char (isAlphaNum, isSpace)
 import Data.Data (Data)
 import Data.Foldable (foldl') -- foldl': DO NOT REMOVE; needed for older GHC compat
+import Data.Function ((&))
 import Data.Functor (($>), (<&>))
 import qualified Data.IntMap.Strict as IntMap
-import Data.List.NonEmpty (NonEmpty)
+import Data.List.NonEmpty (NonEmpty ((:|)))
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (mapMaybe)
@@ -55,15 +57,23 @@ import Inferno.Types.Syntax
     Expr
       ( App,
         Array,
+        Assert,
         Bracketed,
+        Case,
         Empty,
         Enum,
+        If,
+        Lam,
+        Let,
+        LetAnnot,
         Lit,
         One,
         Op,
         OpVar,
+        OpenModule,
         PreOp,
         Record,
+        RenameModule,
         Tuple,
         Var
       ),
@@ -71,11 +81,11 @@ import Inferno.Types.Syntax
     Fixity (InfixOp, PrefixOp),
     Ident (Ident),
     ImplExpl (Expl, Impl),
-    Import,
+    Import (IEnum, IOpVar, IVar),
     InfixFixity (LeftFix, NoFix, RightFix),
     Lit (LDouble, LHex, LInt, LText),
     ModuleName (ModuleName),
-    Pat,
+    Pat (PArray, PEmpty, PEnum, PLit, POne, PRecord, PTuple, PVar),
     RestOfRecord,
     Scoped (LocalScope, Scope),
     SigVar,
@@ -90,6 +100,7 @@ import Inferno.Types.Type
     TCScheme,
     TypeClass,
   )
+import Inferno.Utils.Prettyprinter (renderPretty)
 import Text.Megaparsec
   ( MonadParsec (hidden, label, notFollowedBy, takeWhile1P, takeWhileP, try),
     ParseError,
@@ -98,7 +109,9 @@ import Text.Megaparsec
     SourcePos,
     anySingle,
     between,
+    customFailure,
     getSourcePos,
+    many,
     manyTill,
     satisfy,
     some,
@@ -178,6 +191,21 @@ data Separated a = Separated
 data Field a = Field
   { name :: !Ident
   , val :: a
+  }
+
+-- | The body of an @open@/@let module@ expression: imported names, @in@ position, and body.
+data ModuleBody = ModuleBody
+  { imports :: [Separated (Import SourcePos)]
+  , inPos :: !SourcePos
+  , body :: Expr () SourcePos
+  }
+
+-- | A single clause in a @match ... with@ expression.
+data CaseClause = CaseClause
+  { patPos :: !SourcePos
+  , pat :: Pat () SourcePos
+  , arrPos :: !SourcePos
+  , body :: Expr () SourcePos
   }
 
 -- | Parser environment; precomputed data derived from the operator table.
@@ -427,53 +455,391 @@ interpolatedStringE = undefined
 arrayComprE :: Parser (Expr () SourcePos)
 arrayComprE = undefined
 
-array :: Parser a -> Parser (SourcePos, [(a, Maybe SourcePos)], SourcePos)
-array = undefined
+array :: forall a. Parser a -> Parser (Delimited a)
+array p =
+  label "array\nfor example: [1,2,3,4,5]" . lexeme $ do
+    open <- getSourcePos
+    void $ symbol "["
+    items <- argsE
+    close <- getSourcePos
+    void $ char ']'
+    pure Delimited{open, items, close}
+  where
+    argsE :: Parser [Separated a]
+    argsE = asum [p >>= rest, pure mempty]
 
-record :: Parser a -> Parser (SourcePos, [(Ident, a, Maybe SourcePos)], SourcePos)
-record = undefined
+    rest :: a -> Parser [Separated a]
+    rest e =
+      asum
+        [ withSourcePos $ \pos ->
+            symbol "," *> fmap (Separated{val = e, sep = Just pos} :) argsE
+        , pure [Separated{val = e, sep = Nothing}]
+        ]
+
+record :: forall a. Parser a -> Parser (Delimited (Field a))
+record p =
+  label "record\nfor example: {name = \"Zaphod\"; age = 391}" . lexeme $ do
+    open <- getSourcePos
+    void $ symbol "{"
+    items <- argsE
+    close <- getSourcePos
+    void $ char '}'
+    pure Delimited{open, items, close}
+  where
+    argsE :: Parser [Separated (Field a)]
+    argsE = fieldP <|> pure mempty
+
+    fieldP :: Parser [Separated (Field a)]
+    fieldP = do
+      name <- lexeme $ Ident <$> variable
+      void $ symbol "="
+      val <- p
+      rest Field{name, val}
+
+    rest :: Field a -> Parser [Separated (Field a)]
+    rest fld =
+      asum
+        [ withSourcePos $ \pos ->
+            symbol ";" *> fmap (Separated fld (Just pos) :) argsE
+        , pure [Separated fld Nothing]
+        ]
+
+mkArray :: Delimited (Expr () SourcePos) -> Expr () SourcePos
+mkArray del = flip (Array del.open) del.close $ fmap ((.val) &&& (.sep)) del.items
+
+mkRecord :: Delimited (Field (Expr () SourcePos)) -> Expr () SourcePos
+mkRecord del = Record del.open (fmap toTriple del.items) del.close
+  where
+    toTriple ::
+      Separated (Field (Expr () SourcePos)) ->
+      (Ident, Expr () SourcePos, Maybe SourcePos)
+    toTriple s = (s.val.name, s.val.val, s.sep)
 
 mkInterpolatedString :: [Either Text e] -> [Either Text e]
 mkInterpolatedString = undefined
 
 funE :: Parser (Expr () SourcePos)
-funE = undefined
+funE = label "a function\nfor example: fun x y -> x + y" $ do
+  startPos <- getSourcePos
+  hidden $ rword "fun"
+  args <- (:|) <$> mExtIdent <*> many mExtIdent
+  arrPos <- getSourcePos
+  void . label "'->'" $ symbol "->"
+  Lam startPos args arrPos <$> expr
 
 renameModE :: Parser (Expr () SourcePos)
-renameModE = undefined
+renameModE =
+  label "a 'let module' expression\nfor example: let module A = Base in A.#true" $ do
+    hidden $ rword "let"
+    hidden $ rword "module"
+    newNmPos <- getSourcePos
+    newNm <- label "module name" . lexeme $ ModuleName <$> variable
+    void . label "'='" $ symbol "="
+    oldNmPos <- getSourcePos
+    oldNm <- label "name of an existing module" . lexeme $ ModuleName <$> variable
+    env <- ask
+    Map.lookup oldNm env.modOps & \case
+      Nothing -> customFailure $ ModuleNotFound oldNm
+      Just oldTbl -> do
+        withSourcePos $ \inPos ->
+          fmap (RenameModule newNmPos newNm oldNmPos oldNm inPos)
+            . flip withReaderT inExpr
+            . const
+            $ mkParseEnv ops modOps env.customTypes
+        where
+          ops :: OpsTable
+          ops =
+            IntMap.unionWith (<>) env.ops
+              . flip IntMap.map oldTbl
+              $ fmap (toOpTuple . reScope newNm . fromOpTuple)
 
-openModArgs :: ModuleName -> Parser ([(Import SourcePos, Maybe SourcePos)], SourcePos, Expr () SourcePos)
-openModArgs = undefined
+          modOps :: Map ModuleName OpsTable
+          modOps = Map.insert newNm oldTbl env.modOps
+
+          reScope :: ModuleName -> OpEntry -> OpEntry
+          reScope nm e = e{scope = Scope nm}
+
+inExpr :: Parser (Expr () SourcePos)
+inExpr = label "_the 'in' keyword" (rword "in") *> expr
+
+openModArgs :: ModuleName -> Parser ModuleBody
+openModArgs modNm = do
+  void $ symbol "("
+  is <- importList
+  void . optional $ symbol ","
+  void $ symbol ")"
+  env <- ask
+  ops <- foldM mergeOp env.ops $ fmap (.val) is
+  inPos <- getSourcePos
+  fmap (ModuleBody is inPos)
+    . flip withReaderT inExpr
+    . const
+    $ mkParseEnv ops env.modOps env.customTypes
+  where
+    mergeOp :: OpsTable -> Import SourcePos -> Parser OpsTable
+    mergeOp tbl = \case
+      IOpVar _ op -> IntMap.unionWith (<>) tbl <$> findOp op
+      _ -> pure tbl
+
+    findOp :: Ident -> Parser OpsTable
+    findOp i@(Ident op) =
+      asks (.modOps) >>= \mOps ->
+        Map.lookup modNm mOps & \case
+          Nothing -> customFailure $ ModuleNotFound modNm
+          Just tbl ->
+            bool
+              (pure filtered)
+              (customFailure (InfixOpNotFound modNm i))
+              $ IntMap.null filtered
+            where
+              filtered :: OpsTable
+              filtered = IntMap.mapMaybe filterOp tbl
+
+              filterOp ::
+                [(Fixity, Scoped ModuleName, Text)] ->
+                Maybe [(Fixity, Scoped ModuleName, Text)]
+              filterOp xs =
+                xs
+                  & filter ((== op) . (.name) . fromOpTuple)
+                  <&> toOpTuple . reLocal . fromOpTuple
+                  & \case
+                    [] -> Nothing
+                    ys -> Just ys
+
+    importList :: Parser [Separated (Import SourcePos)]
+    importList =
+      asum
+        [ try $
+            parseImport >>= \i -> withSourcePos $ \pos ->
+              symbol "," *> fmap (Separated i (Just pos) :) importList
+        , pure . (`Separated` Nothing) <$> parseImport
+        ]
+
+    parseImport :: Parser (Import SourcePos)
+    parseImport =
+      asum
+        [ try $
+            IOpVar
+              <$> getSourcePos
+              <*> lexeme
+                ( char '('
+                    *> fmap Ident (takeWhile1P Nothing isAlphaNum)
+                    <* char ')'
+                )
+        , try $
+            IEnum
+              <$> lexeme (getSourcePos <* string "enum")
+              <*> getSourcePos
+              <*> lexeme (fmap Ident variable)
+        , IVar <$> getSourcePos <*> lexeme (fmap Ident variable)
+        ]
+
+    reLocal :: OpEntry -> OpEntry
+    reLocal e = e{scope = LocalScope}
 
 openModE :: Parser (Expr () SourcePos)
-openModE = undefined
+openModE = label "an 'open' module expression\nfor example: open A in ..." $ do
+  hidden $ rword "open"
+  nmPos <- getSourcePos
+  nm <- label "module name" . lexeme $ ModuleName <$> variable
+  fmap (mkOpenModule nmPos nm) $ try (openModArgs nm) <|> openAll nm
+  where
+    openAll :: ModuleName -> Parser ModuleBody
+    openAll modNm =
+      ask >>= \env ->
+        Map.lookup modNm env.modOps & \case
+          Nothing -> customFailure $ ModuleNotFound modNm
+          Just tbl -> withSourcePos $ \inPos ->
+            fmap (ModuleBody mempty inPos)
+              . flip withReaderT inExpr
+              . const
+              $ mkParseEnv
+                (IntMap.unionWith (<>) env.ops tbl)
+                env.modOps
+                env.customTypes
+
+    mkOpenModule :: SourcePos -> ModuleName -> ModuleBody -> Expr () SourcePos
+    mkOpenModule nmPos nm mb =
+      OpenModule
+        nmPos
+        ()
+        nm
+        (fmap ((.val) &&& (.sep)) mb.imports)
+        mb.inPos
+        mb.body
 
 letE :: Parser (Expr () SourcePos)
-letE = undefined
+letE = label ("a 'let' expression" <> example "x") $ do
+  startPos <- getSourcePos
+  hidden $ rword "let"
+  varPos <- getSourcePos
+  x <-
+    label "a variable" . lexeme $
+      asum
+        [ Expl . ExtIdent . Right <$> variable
+        , Impl . ExtIdent . Right <$> implicitVariable
+        ]
+  tPos <- getSourcePos
+  maybeTy <- optional $ symbol ":" *> withReaderT toTyEnv schemeParser
+  eqPos <- getSourcePos
+  void . label "'='" $ symbol "="
+  e1 <- expr <?> (bindMsg . Text.unpack . renderPretty) x
+  inPos <- getSourcePos
+  e2 <- inExpr
+  (x, maybeTy) & \case
+    (Expl y, Just t) ->
+      pure $ LetAnnot startPos varPos y tPos t eqPos e1 inPos e2
+    (Impl _, Just _) -> customFailure ImplicitVarTypeAnnot
+    (_, Nothing) -> pure $ Let startPos varPos x eqPos e1 inPos e2
+  where
+    example :: String -> String
+    example x =
+      unwords
+        [ "\nfor example: let"
+        , x
+        , "= 2 * 5 in ...\nor: let"
+        , x
+        , ": double = 1 + 2 in ..."
+        ]
+
+    bindMsg :: String -> String
+    bindMsg x =
+      unwords
+        [ "an expression to bind to"
+        , "'" <> x <> "'"
+        , example x
+        ]
+
+    toTyEnv :: ParseEnv -> TyParseEnv
+    toTyEnv env =
+      TyParseEnv
+        { tyVars = mempty
+        , ops = env.ops
+        , modOps = env.modOps
+        , ctypes = env.customTypes
+        }
 
 pat :: Parser (Pat () SourcePos)
-pat = undefined
+pat =
+  asum
+    [ mkPArray <$> array pat
+    , mkPRecord <$> record pat
+    , try $ uncurry3 PTuple <$> tuple pat
+    , parens pat
+    , try $ hexadecimal PLit
+    , try $ signedDoubleE PLit
+    , signedIntE PLit
+    , enumE PEnum
+    , uncurry PVar <$> mIdent
+    , noneE PEmpty
+    , someE POne pat
+    , stringE PLit
+    ]
+  where
+    mkPArray ::
+      Delimited (Pat () SourcePos) -> Pat () SourcePos
+    mkPArray del = PArray del.open (fmap ((.val) &&& (.sep)) del.items) del.close
 
-casePatts :: Parser [(SourcePos, Pat () SourcePos, SourcePos, Expr () SourcePos)]
-casePatts = undefined
+    mkPRecord ::
+      Delimited (Field (Pat () SourcePos)) -> Pat () SourcePos
+    mkPRecord del = PRecord del.open (fmap toTriple del.items) del.close
+      where
+        toTriple ::
+          Separated (Field (Pat () SourcePos)) ->
+          (Ident, Pat () SourcePos, Maybe SourcePos)
+        toTriple s = (s.val.name, s.val.val, s.sep)
+
+caseClause :: Parser CaseClause
+caseClause = label "_a pattern match clause\nfor example: #true -> ..." $ do
+  patPos <- getSourcePos
+  p <- pat
+  arrPos <- getSourcePos
+  void . label "'->'" $ symbol "->"
+  CaseClause patPos p arrPos <$> expr
 
 caseE :: Parser (Expr () SourcePos)
-caseE = undefined
+caseE =
+  label "a pattern-match expression\nfor example: match x with { 1 -> #true | _ -> #false }"
+    . lexeme
+    $ do
+      startPos <- getSourcePos
+      rword "match"
+      e <-
+        expr
+          <?> "an expression to pattern match on\nfor example: match (x, y) with { ... }"
+      rword "with"
+      brPos <- getSourcePos
+      void $ symbol "{"
+      cs <- casePatts
+      endPos <- getSourcePos
+      void $ char '}'
+      pure $ mkCase startPos e brPos cs endPos
+  where
+    casePatts :: Parser (NonEmpty CaseClause)
+    casePatts = do
+      void . optional . label "'|'" $ symbol "|"
+      (:|) <$> caseClause <*> many (label "'|'" (symbol "|") *> caseClause)
 
-tupleArgs :: ParserOver r a -> ParserOver r [(a, Maybe SourcePos)]
-tupleArgs = undefined
+    mkCase ::
+      SourcePos ->
+      Expr () SourcePos ->
+      SourcePos ->
+      NonEmpty CaseClause ->
+      SourcePos ->
+      Expr () SourcePos
+    mkCase startPos e brPos cs = Case startPos e brPos $ fmap toTuple cs
+      where
+        toTuple ::
+          CaseClause -> (SourcePos, Pat () SourcePos, SourcePos, Expr () SourcePos)
+        toTuple c = (c.patPos, c.pat, c.arrPos, c.body)
 
 isHSpace :: Char -> Bool
 isHSpace c = isSpace c && c /= '\n' && c /= '\r'
 
 tuple :: ParserOver r a -> ParserOver r (SourcePos, TList (a, Maybe SourcePos), SourcePos)
-tuple = undefined
+tuple p = label "a tuple\nfor example: (2, #true, 4.4)" . lexeme $ do
+  startPos <- getSourcePos
+  void $ symbol "("
+  r <-
+    tListFromList . fmap ((.val) &&& (.sep)) <$> tupleArgs p
+      <|> takeWhileP Nothing isHSpace $> TNil
+  endPos <- getSourcePos
+  void $ char ')'
+  pure (startPos, r, endPos)
+
+tupleArgs :: forall r a. ParserOver r a -> ParserOver r [Separated a]
+tupleArgs p = mid <|> end
+  where
+    mid, end :: ParserOver r [Separated a]
+    mid = try $ do
+      e <- p
+      commaPos <- lexeme $ char ',' *> getSourcePos
+      (Separated e (Just commaPos) :) <$> tupleArgs p
+    end = do
+      e1 <- p
+      commaPos <- lexeme $ char ',' *> getSourcePos
+      e2 <- p
+      pure [Separated e1 $ Just commaPos, Separated e2 Nothing]
 
 assertE :: Parser (Expr () SourcePos)
-assertE = undefined
+assertE = label "an assertion\nfor example: assert x > 10 in ..." $ do
+  startPos <- getSourcePos
+  hidden $ rword "assert"
+  e1 <- expr <?> "a boolean expression\nfor example: x > 10 && x <= 25"
+  inPos <- getSourcePos
+  Assert startPos e1 inPos <$> (label "_the 'in' keyword" (rword "in") *> expr)
 
 ifE :: Parser (Expr () SourcePos)
-ifE = undefined
+ifE = do
+  ifPos <- getSourcePos
+  hidden $ rword "if"
+  cond <- hidden expr <?> "_a conditional expression\nfor example: x > 2"
+  thenPos <- getSourcePos
+  tr <- (rword "then" *> expr) <?> "_the 'then' branch\nfor example: if x > 2 then 1 else 0"
+  elsePos <- getSourcePos
+  fmap (If ifPos cond thenPos tr elsePos)
+    . label "_the 'else' branch\nfor example: if x > 2 then 1 else 0"
+    $ rword "else" *> expr
 
 -- | Parses an op in prefix syntax WITHOUT opening paren @(@ but with closing paren @)@
 -- E.g. @+)@
@@ -499,19 +865,6 @@ prefixOpsWithModule pos = hidden $ asks (.qualOps) >>= tryMany prefixOp
             , ")"
             ]
 
--- | Parses @a, b, c, ...)@ WITHOUT the opening paren but WITH the closing paren.
-tupleElems :: Parser ([(Expr () SourcePos, Maybe SourcePos)], SourcePos)
-tupleElems =
-  asum
-    [ expr >>= \e ->
-        asum
-          [ char ')' *> withSourcePos (pure . ([(e, Nothing)],))
-          , lexeme (char ',' *> getSourcePos) >>= \commaPos ->
-              fmap (first ((e, Just commaPos) :)) tupleElems
-          ]
-    , char ')' *> withSourcePos (pure . ([],))
-    ]
-
 -- | Parses any bracketed expression: tuples, bracketed exprs, and prefix ops.
 bracketedE :: Parser (Expr () SourcePos)
 bracketedE = withSourcePos $ \pos ->
@@ -522,8 +875,21 @@ bracketedE = withSourcePos $ \pos ->
       tupleElems >>= \(es, endPos) ->
         lexeme . pure $ case es of
           [] -> Tuple pos TNil endPos
-          [(e, _)] -> Bracketed pos e endPos
-          _ -> Tuple pos (tListFromList es) endPos
+          [s] -> Bracketed pos s.val endPos
+          _ -> flip (Tuple pos) endPos . tListFromList $ fmap ((.val) &&& (.sep)) es
+
+    -- Parses `a, b, c, ...)` WITHOUT the opening paren but WITH the closing paren.
+    tupleElems :: Parser ([Separated (Expr () SourcePos)], SourcePos)
+    tupleElems =
+      asum
+        [ expr >>= \e ->
+            asum
+              [ char ')' *> withSourcePos (pure . ([Separated e Nothing],))
+              , lexeme (char ',' *> getSourcePos) >>= \commaPos ->
+                  fmap (first (Separated e (Just commaPos) :)) tupleElems
+              ]
+        , char ')' *> withSourcePos (pure . (mempty,))
+        ]
 
 term :: Parser (Expr () SourcePos)
 term =
@@ -555,8 +921,8 @@ term =
     , try implVarE
     , stringE Lit
     , interpolatedStringE
-    , try $ uncurry3 Array <$> array expr
-    , try $ uncurry3 Record <$> record expr
+    , try $ mkArray <$> array expr
+    , try $ mkRecord <$> record expr
     , arrayComprE
     ]
   where

--- a/inferno-core/src/Inferno/Parse.hs
+++ b/inferno-core/src/Inferno/Parse.hs
@@ -504,11 +504,14 @@ implVarE :: Parser (Expr () SourcePos)
 implVarE = lexeme . withSourcePos $ \pos ->
   Var pos () LocalScope . Impl . ExtIdent . Right <$> implicitVariable
 
--- | Parses unsigned integer and double literals.
-intE, doubleE :: Parser (Expr () SourcePos)
+-- | Parses unsigned integer literals.
+intE :: Parser (Expr () SourcePos)
 intE =
   label "a number\nfor example: 42, 3.1415, (-6)" . lexeme . withSourcePos $
     \pos -> Lit pos . LInt <$> Lexer.decimal
+
+-- | Parses unsigned double literals.
+doubleE :: Parser (Expr () SourcePos)
 doubleE =
   label "a number\nfor example: 42, 3.1415, (-6)" . lexeme . withSourcePos $
     \pos -> Lit pos . LDouble <$> Lexer.float
@@ -518,13 +521,17 @@ hexadecimal f =
   label "a hexadecimal number\nfor example: 0xE907, 0XE907" . lexeme . withSourcePos $
     \pos -> f pos . LHex <$> (char '0' *> char' 'x' *> Lexer.hexadecimal)
 
-signedIntE, signedDoubleE :: (SourcePos -> Lit -> f SourcePos) -> Parser (f SourcePos)
+-- | Parses signed integer literals.
+signedIntE :: (SourcePos -> Lit -> f SourcePos) -> Parser (f SourcePos)
 signedIntE f =
   label "a number\nfor example: 42, 3.1415, (-6)" . lexeme . withSourcePos $
     \pos -> f pos . LInt <$> signedInteger
   where
     signedInteger :: (Num a) => Parser a
     signedInteger = flip Lexer.signed Lexer.decimal $ takeWhileP Nothing isHSpace $> ()
+
+-- | Parses signed double literals.
+signedDoubleE :: (SourcePos -> Lit -> f SourcePos) -> Parser (f SourcePos)
 signedDoubleE f =
   label "a number\nfor example: 42, 3.1415, (-6)" . lexeme . withSourcePos $
     \pos -> f pos . LDouble <$> signedFloat

--- a/inferno-core/src/Inferno/Parse.hs
+++ b/inferno-core/src/Inferno/Parse.hs
@@ -336,6 +336,39 @@ mkParseEnv ops modOps cts = env
       PrefixOp -> Just e.name
       _ -> Nothing
 
+    mkOperators :: OpsTable -> [[Operator Parser (Expr () SourcePos)]]
+    mkOperators tbl =
+      IntMap.toDescList tbl <&> \(prec, grp) -> fmap (uncurry3 (mkOp prec)) grp
+      where
+        opStr :: Scoped ModuleName -> Text -> Text
+        opStr = \cases
+          LocalScope s -> s
+          (Scope (ModuleName ns)) s -> ns <> "." <> s
+
+        fixCtor :: InfixFixity -> Parser (a -> a -> a) -> Operator Parser a
+        fixCtor = \cases
+          NoFix -> InfixN
+          LeftFix -> InfixL
+          RightFix -> InfixR
+
+        mkOp ::
+          Int ->
+          Fixity ->
+          Scoped ModuleName ->
+          Text ->
+          Operator Parser (Expr () SourcePos)
+        mkOp = \cases
+          prec (InfixOp fix) ns o ->
+            fixCtor fix . label "an infix operator\nfor example: +, *, ==, >, <" $
+              opP ns o >>= \pos -> pure $ \e1 e2 ->
+                Op e1 pos () (prec, fix) ns (Ident o) e2
+          prec PrefixOp ns o ->
+            Prefix . label "a prefix operator\nfor example: -, !" $
+              opP ns o >>= \pos -> pure . PreOp pos () prec ns $ Ident o
+
+        opP :: Scoped ModuleName -> Text -> Parser SourcePos
+        opP ns o = lexeme $ getSourcePos <* string (opStr ns o)
+
 -- | Converts a curried function to a function on a triple.
 --
 -- NOTE: Strict, unlike the version from @Data.Tuple.Extra@
@@ -357,28 +390,28 @@ tryMany = \cases
 output :: Comment SourcePos -> ParserOver r ()
 output c = modify' (c :)
 
-skipLineComment :: ParserOver r ()
-skipLineComment = do
-  startPos <- getSourcePos
-  comment <- string "//" *> takeWhileP (Just "character") (/= '\n')
-  endPos <- getSourcePos
-  output $ LineComment startPos (Text.strip comment) endPos
-
-skipBlockComment :: ParserOver r ()
-skipBlockComment = do
-  startPos <- getSourcePos
-  comment <- string "/*" *> manyTill anySingle (string "*/")
-  endPos <- getSourcePos
-  output $ BlockComment startPos (stripIndent startPos comment) endPos
+sc :: ParserOver r ()
+sc = Lexer.space (void spaceChar) skipLineComment skipBlockComment
   where
+    skipLineComment :: ParserOver r ()
+    skipLineComment = do
+      startPos <- getSourcePos
+      comment <- string "//" *> takeWhileP (Just "character") (/= '\n')
+      endPos <- getSourcePos
+      output $ LineComment startPos (Text.strip comment) endPos
+
+    skipBlockComment :: ParserOver r ()
+    skipBlockComment = do
+      startPos <- getSourcePos
+      comment <- string "/*" *> manyTill anySingle (string "*/")
+      endPos <- getSourcePos
+      output $ BlockComment startPos (stripIndent startPos comment) endPos
+
     stripIndent :: SourcePos -> [Char] -> Text
     stripIndent pos = Text.replace ws "\n" . Text.pack
       where
         ws :: Text
         ws = Text.pack $ '\n' : replicate (unPos pos.sourceColumn - 1) ' '
-
-sc :: ParserOver r ()
-sc = Lexer.space (void spaceChar) skipLineComment skipBlockComment
 
 lexeme :: ParserOver r a -> ParserOver r a
 lexeme = Lexer.lexeme sc
@@ -393,13 +426,13 @@ parens = hidden . between (symbol "(") (symbol ")")
 -- | 'rword' for parsing reserved words.
 rword :: Text -> ParserOver r ()
 rword w = string w *> notFollowedBy alphaNumCharOrSeparator *> sc
+  where
+    alphaNumCharOrSeparator :: ParserOver r Char
+    alphaNumCharOrSeparator =
+      satisfy isAlphaNumOrSeparator <?> "alphanumeric character or '_'"
 
 isAlphaNumOrSeparator :: Char -> Bool
 isAlphaNumOrSeparator = (||) <$> isAlphaNum <*> (== '_')
-
-alphaNumCharOrSeparator :: ParserOver r Char
-alphaNumCharOrSeparator =
-  satisfy isAlphaNumOrSeparator <?> "alphanumeric character or '_'"
 
 withSourcePos :: (SourcePos -> ParserOver r a) -> ParserOver r a
 withSourcePos = (getSourcePos >>=)
@@ -455,18 +488,6 @@ enumConstructor =
   Ident <$> lexeme (char '#' *> takeWhile1P Nothing isAlphaNumOrSeparator)
     <?> "an enum constructor\nfor example: #true, #false"
 
--- | Parses an integer with an optional sign (with no space).
-signedInteger :: (Num a) => Parser a
-signedInteger =
-  flip Lexer.signed Lexer.decimal $
-    takeWhileP Nothing isHSpace $> ()
-
--- | Parses a float/double with an optional sign (with no space).
-signedFloat :: Parser Double
-signedFloat =
-  flip Lexer.signed Lexer.float $
-    takeWhileP Nothing isHSpace $> ()
-
 enumE :: (SourcePos -> () -> Scoped ModuleName -> Ident -> f) -> Parser f
 enumE f = lexeme . withSourcePos $ \pos ->
   asum
@@ -496,9 +517,15 @@ signedIntE, signedDoubleE :: (SourcePos -> Lit -> f SourcePos) -> Parser (f Sour
 signedIntE f =
   label "a number\nfor example: 42, 3.1415, (-6)" . lexeme . withSourcePos $
     \pos -> f pos . LInt <$> signedInteger
+  where
+    signedInteger :: (Num a) => Parser a
+    signedInteger = flip Lexer.signed Lexer.decimal $ takeWhileP Nothing isHSpace $> ()
 signedDoubleE f =
   label "a number\nfor example: 42, 3.1415, (-6)" . lexeme . withSourcePos $
     \pos -> f pos . LDouble <$> signedFloat
+  where
+    signedFloat :: Parser Double
+    signedFloat = flip Lexer.signed Lexer.float $ takeWhileP Nothing isHSpace $> ()
 
 noneE :: (SourcePos -> a) -> Parser a
 noneE e =
@@ -667,17 +694,6 @@ record p =
             symbol ";" *> fmap (Separated fld (Just pos) :) argsE
         , pure [Separated fld Nothing]
         ]
-
-mkArray :: Delimited (Expr () SourcePos) -> Expr () SourcePos
-mkArray del = flip (Array del.open) del.close $ fmap ((.val) &&& (.sep)) del.items
-
-mkRecord :: Delimited (Field (Expr () SourcePos)) -> Expr () SourcePos
-mkRecord del = Record del.open (fmap toTriple del.items) del.close
-  where
-    toTriple ::
-      Separated (Field (Expr () SourcePos)) ->
-      (Ident, Expr () SourcePos, Maybe SourcePos)
-    toTriple s = (s.val.name, s.val.val, s.sep)
 
 funE :: Parser (Expr () SourcePos)
 funE = label "a function\nfor example: fun x y -> x + y" $ do
@@ -1081,6 +1097,17 @@ term =
     qualVar :: SourcePos -> Text -> Text -> Expr () SourcePos
     qualVar pos ns x = Var pos () (Scope $ ModuleName ns) . Expl . ExtIdent $ Right x
 
+    mkArray :: Delimited (Expr () SourcePos) -> Expr () SourcePos
+    mkArray del = flip (Array del.open) del.close $ fmap ((.val) &&& (.sep)) del.items
+
+    mkRecord :: Delimited (Field (Expr () SourcePos)) -> Expr () SourcePos
+    mkRecord del = Record del.open (fmap toTriple del.items) del.close
+      where
+        toTriple ::
+          Separated (Field (Expr () SourcePos)) ->
+          (Ident, Expr () SourcePos, Maybe SourcePos)
+        toTriple s = (s.val.name, s.val.val, s.sep)
+
 app :: Parser (Expr () SourcePos)
 app =
   term >>= \x ->
@@ -1091,39 +1118,6 @@ app =
 
 expr :: Parser (Expr () SourcePos)
 expr = join $ asks (.exprP)
-
-mkOperators :: OpsTable -> [[Operator Parser (Expr () SourcePos)]]
-mkOperators tbl =
-  IntMap.toDescList tbl <&> \(prec, grp) -> fmap (uncurry3 (mkOp prec)) grp
-  where
-    opStr :: Scoped ModuleName -> Text -> Text
-    opStr = \cases
-      LocalScope s -> s
-      (Scope (ModuleName ns)) s -> ns <> "." <> s
-
-    fixCtor :: InfixFixity -> Parser (a -> a -> a) -> Operator Parser a
-    fixCtor = \cases
-      NoFix -> InfixN
-      LeftFix -> InfixL
-      RightFix -> InfixR
-
-    mkOp ::
-      Int ->
-      Fixity ->
-      Scoped ModuleName ->
-      Text ->
-      Operator Parser (Expr () SourcePos)
-    mkOp = \cases
-      prec (InfixOp fix) ns o ->
-        fixCtor fix . label "an infix operator\nfor example: +, *, ==, >, <" $
-          opP ns o >>= \pos -> pure $ \e1 e2 ->
-            Op e1 pos () (prec, fix) ns (Ident o) e2
-      prec PrefixOp ns o ->
-        Prefix . label "a prefix operator\nfor example: -, !" $
-          opP ns o >>= \pos -> pure . PreOp pos () prec ns $ Ident o
-
-    opP :: Scoped ModuleName -> Text -> Parser SourcePos
-    opP ns o = lexeme $ getSourcePos <* string (opStr ns o)
 
 parseExpr ::
   OpsTable ->
@@ -1524,15 +1518,15 @@ sigsParser = go id
     isOpChar :: Char -> Bool
     isOpChar = (&&) <$> (/= ';') <*> not . isSpace
 
-insertIntoOpsTable :: OpsTable -> Fixity -> Int -> Text -> OpsTable
-insertIntoOpsTable tbl f lvl op = IntMap.alter go lvl tbl
-  where
-    go ::
-      Maybe [(Fixity, Scoped ModuleName, Text)] ->
-      Maybe [(Fixity, Scoped ModuleName, Text)]
-    go = \cases
-      Nothing -> Just [(f, LocalScope, op)]
-      (Just xs) -> Just $ (f, LocalScope, op) : xs
+    insertIntoOpsTable :: OpsTable -> Fixity -> Int -> Text -> OpsTable
+    insertIntoOpsTable tbl fix lvl op = IntMap.alter f lvl tbl
+      where
+        f ::
+          Maybe [(Fixity, Scoped ModuleName, Text)] ->
+          Maybe [(Fixity, Scoped ModuleName, Text)]
+        f =
+          flip maybe (Just . ((fix, LocalScope, op) :)) . Just $
+            pure (fix, LocalScope, op)
 
 modulesParser :: Parser [ParsedModule (Maybe TCScheme, QQDefinition)]
 modulesParser = do

--- a/inferno-core/src/Inferno/Parse.hs
+++ b/inferno-core/src/Inferno/Parse.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedRecordDot #-}
@@ -12,6 +13,7 @@ module Inferno.Parse
   ( Comment (..),
     OpsTable,
     TopLevelDefn (..),
+    ParsedModule (..),
     QQDefinition (..),
     InfernoParsingError (..),
     topLevel,
@@ -50,6 +52,7 @@ import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
+import Data.Tuple.Extra (second3)
 import Inferno.Parse.Error (prettyError)
 import Inferno.Types.Syntax
   ( Comment (BlockComment, LineComment),
@@ -88,7 +91,7 @@ import Inferno.Types.Syntax
     Pat (PArray, PEmpty, PEnum, PLit, POne, PRecord, PTuple, PVar),
     RestOfRecord,
     Scoped (LocalScope, Scope),
-    SigVar,
+    SigVar (SigOpVar, SigVar),
     TList (TNil),
     fromScoped,
     rws,
@@ -127,7 +130,7 @@ data InfernoParsingError
   | InfixOpNotFound ModuleName Ident
   | UnboundTyVar Text
   | ImplicitVarTypeAnnot
-  deriving (Eq, Show, Ord)
+  deriving stock (Eq, Show, Ord)
 
 instance ShowErrorComponent InfernoParsingError where
   showErrorComponent (ModuleNotFound (ModuleName modNm)) =
@@ -146,16 +149,18 @@ type ParserOver r = ReaderT r (StateT [Comment SourcePos] BaseParsec)
 type Parser = ParserOver ParseEnv
 
 data TopLevelDefn def
-  = -- FIXME Don't use record fields in sum types, damn it!
-    Signature
-      { documentation :: Maybe Text
-      , name :: SigVar
-      , def :: def
-      }
+  = Signature (Maybe Text) SigVar def
   | EnumDef (Maybe Text) Text [Ident]
   | TypeClassInstance TypeClass
   | Export ModuleName
-  deriving (Eq, Show, Data)
+  deriving stock (Eq, Show, Data)
+
+data ParsedModule a = ParsedModule
+  { name :: !ModuleName
+  , opsTable :: !OpsTable
+  , defs :: [TopLevelDefn a]
+  }
+  deriving stock (Eq, Show, Data)
 
 type OpsTable = IntMap.IntMap [(Fixity, Scoped ModuleName, Text)]
 
@@ -163,7 +168,7 @@ data QQDefinition
   = QQRawDef String
   | QQToValueDef String
   | InlineDef (Expr () SourcePos)
-  deriving (Data)
+  deriving stock (Data)
 
 type TyParser = ParserOver TyParseEnv
 
@@ -680,13 +685,13 @@ letE = label ("a 'let' expression" <> example "x") $ do
         , Impl . ExtIdent . Right <$> implicitVariable
         ]
   tPos <- getSourcePos
-  maybeTy <- optional $ symbol ":" *> withReaderT toTyEnv schemeParser
+  mTy <- optional $ symbol ":" *> withReaderT toTyEnv schemeParser
   eqPos <- getSourcePos
   void . label "'='" $ symbol "="
   e1 <- expr <?> (bindMsg . Text.unpack . renderPretty) x
   inPos <- getSourcePos
   e2 <- inExpr
-  (x, maybeTy) & \case
+  (x, mTy) & \case
     (Expl y, Just t) ->
       pure $ LetAnnot startPos varPos y tPos t eqPos e1 inPos e2
     (Impl _, Just _) -> customFailure ImplicitVarTypeAnnot
@@ -1041,7 +1046,15 @@ enumConstructors :: Parser [Ident]
 enumConstructors = undefined
 
 sigVariable :: Parser SigVar
-sigVariable = undefined
+sigVariable =
+  lexeme . asum $
+    [ tryMany infixOp =<< asks (.infixOps)
+    , tryMany (fmap SigVar . string) =<< asks (.prefixOps)
+    , SigVar <$> variable
+    ]
+  where
+    infixOp :: Text -> Parser SigVar
+    infixOp op = char '(' *> fmap SigOpVar (string op) <* char ')'
 
 exprOrBuiltin :: Parser QQDefinition
 exprOrBuiltin = undefined
@@ -1050,13 +1063,54 @@ sigParser :: Parser (TopLevelDefn (Maybe TCScheme, QQDefinition))
 sigParser = undefined
 
 fixityP :: Parser Fixity
-fixityP = undefined
+fixityP =
+  lexeme . asum $
+    [ try $ rword "infixr" $> InfixOp RightFix
+    , try $ rword "infixl" $> InfixOp LeftFix
+    , try $ rword "infix" $> InfixOp NoFix
+    , rword "prefix" $> PrefixOp
+    ]
 
 fixityLvl :: Parser Int
-fixityLvl = undefined
+fixityLvl = try $ lexeme Lexer.decimal >>= check
+  where
+    check :: Int -> Parser Int
+    check x =
+      bool
+        (fail "Fixity level annotation must be between 0 and 19 (inclusive)")
+        (pure x)
+        $ x >= 0 && x < 20
 
 sigsParser :: Parser (OpsTable, [TopLevelDefn (Maybe TCScheme, QQDefinition)])
-sigsParser = undefined
+sigsParser = go id
+  where
+    -- Avoids O(n) snoc (previously was `reverse acc`); now O(n) materialization,
+    -- O(1) snoc
+    go ::
+      ( [TopLevelDefn (Maybe TCScheme, QQDefinition)] ->
+        [TopLevelDefn (Maybe TCScheme, QQDefinition)]
+      ) ->
+      Parser (OpsTable, [TopLevelDefn (Maybe TCScheme, QQDefinition)])
+    go f =
+      asum
+        [ flip withReaderT (go f) . const =<< opDeclP
+        , go . (f .) . (:) =<< sigParser
+        , asks $ (,f mempty) . (.ops)
+        ]
+
+    opDeclP :: Parser ParseEnv
+    opDeclP = do
+      env <- ask
+      f <- fixityP
+      l <- fixityLvl
+      o <- operatorP <* symbol ";"
+      pure $ mkParseEnv (insertIntoOpsTable env.ops f l o) env.modOps env.customTypes
+
+    operatorP :: Parser Text
+    operatorP = lexeme $ takeWhile1P (Just "operator") isOpChar
+
+    isOpChar :: Char -> Bool
+    isOpChar = (&&) <$> (/= ';') <*> not . isSpace
 
 insertIntoOpsTable :: OpsTable -> Fixity -> Int -> Text -> OpsTable
 insertIntoOpsTable tbl f lvl op = IntMap.alter go lvl tbl
@@ -1068,9 +1122,27 @@ insertIntoOpsTable tbl f lvl op = IntMap.alter go lvl tbl
       Nothing -> Just [(f, LocalScope, op)]
       (Just xs) -> Just $ (f, LocalScope, op) : xs
 
-modulesParser ::
-  Parser [(ModuleName, OpsTable, [TopLevelDefn (Maybe TCScheme, QQDefinition)])]
-modulesParser = undefined
+modulesParser :: Parser [ParsedModule (Maybe TCScheme, QQDefinition)]
+modulesParser = do
+  void $ symbol "module"
+  nm <- ModuleName <$> lexeme variable
+  (ops, sigs) <- sigsParser
+
+  let qualOps :: OpsTable
+      qualOps = flip IntMap.map ops . fmap . second3 . const $ Scope nm
+
+  (ParsedModule nm ops sigs :)
+    <$> asum
+      [ flip withReaderT modulesParser . const =<< asks (mergedEnv qualOps nm ops)
+      , pure mempty
+      ]
+  where
+    mergedEnv :: OpsTable -> ModuleName -> OpsTable -> ParseEnv -> ParseEnv
+    mergedEnv qualOps nm modTbl env =
+      mkParseEnv
+        (IntMap.unionWith (<>) env.ops qualOps)
+        (Map.insert nm modTbl env.modOps)
+        env.customTypes
 
 topLevel :: ParserOver r a -> ParserOver r a
 topLevel = undefined

--- a/inferno-core/src/Inferno/Parse.hs
+++ b/inferno-core/src/Inferno/Parse.hs
@@ -16,8 +16,10 @@ module Inferno.Parse
     ParsedModule (..),
     QQDefinition (..),
     InfernoParsingError (..),
+    ParseEnv,
     topLevel,
     expr,
+    mkParseEnv,
     parseExpr,
     parseType,
     parseTCScheme,
@@ -309,9 +311,13 @@ mkParseEnv ops modOps cts = env
         { ops
         , modOps
         , customTypes = cts
-        , reserved = Set.fromList $ rws <> fmap (.name) allOps
-        , localOps = fmap (.name) . filter ((== LocalScope) . (.scope)) $ allOps
-        , qualOps = fmap ((.scope) &&& (.name)) . filter ((/= LocalScope) . (.scope)) $ allOps
+        , reserved =
+            Set.fromList $ rws <> fmap (.name) allOps
+        , localOps =
+            fmap (.name) . filter ((== LocalScope) . (.scope)) $ allOps
+        , qualOps =
+            fmap ((.scope) &&& (.name)) . filter ((/= LocalScope) . (.scope)) $
+              allOps
         , infixOps = mapMaybe infixName allOps
         , prefixOps = mapMaybe prefixName allOps
         , exprP = makeExprParser app $ mkOperators ops

--- a/inferno-core/src/Inferno/Parse.hs
+++ b/inferno-core/src/Inferno/Parse.hs
@@ -46,15 +46,17 @@ import Data.Foldable (foldl') -- foldl': DO NOT REMOVE; needed for older GHC com
 import Data.Function ((&))
 import Data.Functor (($>), (<&>))
 import qualified Data.IntMap.Strict as IntMap
+import Data.List (sortOn)
 import Data.List.NonEmpty (NonEmpty ((:|)))
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (mapMaybe)
+import Data.Ord (Down (Down))
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
-import Data.Tuple.Extra (second3, snd3)
+import Data.Tuple.Extra (second3, snd3, thd3)
 import Inferno.Infer.Env (closeOver)
 import Inferno.Parse.Error (prettyError)
 import Inferno.Types.Syntax
@@ -336,9 +338,12 @@ mkParseEnv ops modOps cts = env
       PrefixOp -> Just e.name
       _ -> Nothing
 
+    -- Sort operators longest-first at each precedence level so that e.g.
+    -- `<=` is tried before `<` (avoiding a partial match via `string`)
     mkOperators :: OpsTable -> [[Operator Parser (Expr () SourcePos)]]
     mkOperators tbl =
-      IntMap.toDescList tbl <&> \(prec, grp) -> fmap (uncurry3 (mkOp prec)) grp
+      IntMap.toDescList tbl <&> \(prec, grp) ->
+        fmap (uncurry3 (mkOp prec)) . sortOn (Down . Text.length . thd3) $ grp
       where
         opStr :: Scoped ModuleName -> Text -> Text
         opStr = \cases

--- a/inferno-core/src/Inferno/Utils/QQ/Module.hs
+++ b/inferno-core/src/Inferno/Utils/QQ/Module.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 
+{-# OPTIONS_GHC -Wno-unused-imports #-} -- FIXME Parser rewrite
+
 module Inferno.Utils.QQ.Module where
 
 import Control.Monad.Reader (ReaderT (..))
@@ -57,21 +59,22 @@ infernoModules = moduleQuoter []
 moduleQuoter :: [CustomType] -> QuasiQuoter
 moduleQuoter customTypes =
   QuasiQuoter
-    { quoteExp = \str -> do
-        l <- location'
-        let (_, res) =
-              runParser' (runWriterT $ flip runReaderT (mempty, mempty, customTypes) $ topLevel modulesParser) $
-                State
-                  (pack str)
-                  0
-                  (PosState (pack str) 0 l defaultTabWidth "")
-                  []
-        case res of
-          Left (ParseErrorBundle errs pos) ->
-            let errs' = map mkParseErrorStr $ NEList.toList $ fst $ attachSourcePos errorOffset errs pos
-             in fail $ intercalate "\n\n" errs'
-          Right (modules, _comments) ->
-            [|buildPinnedQQModules $(dataToExpQ ((fmap liftText . cast) `extQ` metaToValue) modules)|]
+    { quoteExp = undefined -- FIXME parser rewrite
+      -- \str -> do
+      --   l <- location'
+      --   let (_, res) =
+      --         runParser' (runWriterT $ flip runReaderT (mempty, mempty, customTypes) $ topLevel modulesParser) $
+      --           State
+      --             (pack str)
+      --             0
+      --             (PosState (pack str) 0 l defaultTabWidth "")
+      --             []
+      --   case res of
+      --     Left (ParseErrorBundle errs pos) ->
+      --       let errs' = map mkParseErrorStr $ NEList.toList $ fst $ attachSourcePos errorOffset errs pos
+      --        in fail $ intercalate "\n\n" errs'
+      --     Right (modules, _comments) ->
+      --       [|buildPinnedQQModules $(dataToExpQ ((fmap liftText . cast) `extQ` metaToValue) modules)|]
     , quotePat = error "moduleQuoter: Invalid use of this quasi-quoter in pattern context."
     , quoteType = error "moduleQuoter: Invalid use of this quasi-quoter in type context."
     , quoteDec = error "moduleQuoter: Invalid use of this quasi-quoter in top-level declaration context."

--- a/inferno-core/src/Inferno/Utils/QQ/Module.hs
+++ b/inferno-core/src/Inferno/Utils/QQ/Module.hs
@@ -8,7 +8,7 @@ import Control.Monad.State.Strict (runStateT)
 import Data.Data (Proxy (..), cast)
 import Data.Generics.Aliases (extQ)
 import Data.List (intercalate)
-import qualified Data.List.NonEmpty as NEList
+import qualified Data.List.NonEmpty as NonEmpty
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Inferno.Infer (closeOverType)
@@ -94,7 +94,7 @@ moduleQuoter customTypes =
       fail
         . intercalate "\n\n"
         . fmap mkParseErrorStr
-        . NEList.toList
+        . NonEmpty.toList
         . fst
         $ attachSourcePos errorOffset errs pos
 

--- a/inferno-core/src/Inferno/Utils/QQ/Module.hs
+++ b/inferno-core/src/Inferno/Utils/QQ/Module.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE TemplateHaskell #-}
-
-{-# OPTIONS_GHC -Wno-unused-imports #-} -- FIXME Parser rewrite
+-- FIXME Parser rewrite
+{-# OPTIONS_GHC -Wno-unused-imports #-}
 
 module Inferno.Utils.QQ.Module where
 
@@ -60,21 +60,21 @@ moduleQuoter :: [CustomType] -> QuasiQuoter
 moduleQuoter customTypes =
   QuasiQuoter
     { quoteExp = undefined -- FIXME parser rewrite
-      -- \str -> do
-      --   l <- location'
-      --   let (_, res) =
-      --         runParser' (runWriterT $ flip runReaderT (mempty, mempty, customTypes) $ topLevel modulesParser) $
-      --           State
-      --             (pack str)
-      --             0
-      --             (PosState (pack str) 0 l defaultTabWidth "")
-      --             []
-      --   case res of
-      --     Left (ParseErrorBundle errs pos) ->
-      --       let errs' = map mkParseErrorStr $ NEList.toList $ fst $ attachSourcePos errorOffset errs pos
-      --        in fail $ intercalate "\n\n" errs'
-      --     Right (modules, _comments) ->
-      --       [|buildPinnedQQModules $(dataToExpQ ((fmap liftText . cast) `extQ` metaToValue) modules)|]
+    -- \str -> do
+    --   l <- location'
+    --   let (_, res) =
+    --         runParser' (runWriterT $ flip runReaderT (mempty, mempty, customTypes) $ topLevel modulesParser) $
+    --           State
+    --             (pack str)
+    --             0
+    --             (PosState (pack str) 0 l defaultTabWidth "")
+    --             []
+    --   case res of
+    --     Left (ParseErrorBundle errs pos) ->
+    --       let errs' = map mkParseErrorStr $ NEList.toList $ fst $ attachSourcePos errorOffset errs pos
+    --        in fail $ intercalate "\n\n" errs'
+    --     Right (modules, _comments) ->
+    --       [|buildPinnedQQModules $(dataToExpQ ((fmap liftText . cast) `extQ` metaToValue) modules)|]
     , quotePat = error "moduleQuoter: Invalid use of this quasi-quoter in pattern context."
     , quoteType = error "moduleQuoter: Invalid use of this quasi-quoter in type context."
     , quoteDec = error "moduleQuoter: Invalid use of this quasi-quoter in top-level declaration context."

--- a/inferno-core/src/Inferno/Utils/QQ/Module.hs
+++ b/inferno-core/src/Inferno/Utils/QQ/Module.hs
@@ -1,25 +1,28 @@
 {-# LANGUAGE TemplateHaskell #-}
--- FIXME Parser rewrite
-{-# OPTIONS_GHC -Wno-unused-imports #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module Inferno.Utils.QQ.Module where
 
-import Control.Monad.Reader (ReaderT (..))
-import Control.Monad.Writer (WriterT (..))
+import Control.Monad.Reader (runReaderT)
+import Control.Monad.State.Strict (runStateT)
 import Data.Data (Proxy (..), cast)
 import Data.Generics.Aliases (extQ)
 import Data.List (intercalate)
 import qualified Data.List.NonEmpty as NEList
-import Data.Text (pack)
+import Data.Text (Text)
+import qualified Data.Text as Text
 import Inferno.Infer (closeOverType)
 import Inferno.Module (buildPinnedQQModules)
 import Inferno.Parse
-  ( QQDefinition (..),
+  ( InfernoParsingError,
+    ParseEnv,
+    ParsedModule,
+    QQDefinition (..),
+    mkParseEnv,
     modulesParser,
     topLevel,
   )
-import Inferno.Types.Syntax (CustomType)
-import qualified Inferno.Types.Type as Type
+import Inferno.Types.Syntax (Comment, CustomType, TCScheme)
 import Inferno.Utils.QQ.Common
   ( liftText,
     location',
@@ -27,10 +30,12 @@ import Inferno.Utils.QQ.Common
   )
 import qualified Language.Haskell.TH.Lib as TH
 import Language.Haskell.TH.Quote (QuasiQuoter (..), dataToExpQ)
-import Language.Haskell.TH.Syntax (mkName)
+import Language.Haskell.TH.Syntax (Exp, Q, mkName)
 import Text.Megaparsec
   ( ParseErrorBundle (ParseErrorBundle),
+    Parsec,
     PosState (PosState),
+    SourcePos,
     State (State),
     attachSourcePos,
     defaultTabWidth,
@@ -41,7 +46,7 @@ import Text.Megaparsec
 mkProxy :: a -> Proxy a
 mkProxy _ = Proxy
 
-metaToValue :: (Maybe Type.TCScheme, QQDefinition) -> Maybe TH.ExpQ
+metaToValue :: (Maybe TCScheme, QQDefinition) -> Maybe TH.ExpQ
 metaToValue = \case
   (Just sch, QQToValueDef x) -> Just [|Left ($(dataToExpQ (fmap liftText . cast) sch), toValue $(TH.varE (mkName x)))|]
   (Nothing, QQToValueDef x) ->
@@ -59,23 +64,40 @@ infernoModules = moduleQuoter []
 moduleQuoter :: [CustomType] -> QuasiQuoter
 moduleQuoter customTypes =
   QuasiQuoter
-    { quoteExp = undefined -- FIXME parser rewrite
-    -- \str -> do
-    --   l <- location'
-    --   let (_, res) =
-    --         runParser' (runWriterT $ flip runReaderT (mempty, mempty, customTypes) $ topLevel modulesParser) $
-    --           State
-    --             (pack str)
-    --             0
-    --             (PosState (pack str) 0 l defaultTabWidth "")
-    --             []
-    --   case res of
-    --     Left (ParseErrorBundle errs pos) ->
-    --       let errs' = map mkParseErrorStr $ NEList.toList $ fst $ attachSourcePos errorOffset errs pos
-    --        in fail $ intercalate "\n\n" errs'
-    --     Right (modules, _comments) ->
-    --       [|buildPinnedQQModules $(dataToExpQ ((fmap liftText . cast) `extQ` metaToValue) modules)|]
+    { quoteExp = \(Text.pack -> str) -> do
+        location' >>= \l ->
+          let env :: ParseEnv
+              env = mkParseEnv mempty mempty customTypes
+
+              run ::
+                Parsec
+                  InfernoParsingError
+                  Text
+                  ([ParsedModule (Maybe TCScheme, QQDefinition)], [Comment SourcePos])
+              run = flip runStateT mempty . flip runReaderT env $ topLevel modulesParser
+
+              res ::
+                Either
+                  (ParseErrorBundle Text InfernoParsingError)
+                  ([ParsedModule (Maybe TCScheme, QQDefinition)], [Comment SourcePos])
+              (_, res) =
+                runParser' run $
+                  State str 0 (PosState str 0 l defaultTabWidth mempty) mempty
+          in either parseFail liftModules res
     , quotePat = error "moduleQuoter: Invalid use of this quasi-quoter in pattern context."
     , quoteType = error "moduleQuoter: Invalid use of this quasi-quoter in type context."
     , quoteDec = error "moduleQuoter: Invalid use of this quasi-quoter in top-level declaration context."
     }
+  where
+    parseFail :: ParseErrorBundle Text InfernoParsingError -> Q Exp
+    parseFail (ParseErrorBundle errs pos) =
+      fail
+        . intercalate "\n\n"
+        . fmap mkParseErrorStr
+        . NEList.toList
+        . fst
+        $ attachSourcePos errorOffset errs pos
+
+    liftModules :: ([ParsedModule (Maybe TCScheme, QQDefinition)], [Comment SourcePos]) -> Q Exp
+    liftModules (modules, _) =
+      [|buildPinnedQQModules $(dataToExpQ ((fmap liftText . cast) `extQ` metaToValue) modules)|]

--- a/inferno-core/src/Inferno/Utils/QQ/Module.hs
+++ b/inferno-core/src/Inferno/Utils/QQ/Module.hs
@@ -83,7 +83,7 @@ moduleQuoter customTypes =
               (_, res) =
                 runParser' run $
                   State str 0 (PosState str 0 l defaultTabWidth mempty) mempty
-          in either parseFail liftModules res
+           in either parseFail liftModules res
     , quotePat = error "moduleQuoter: Invalid use of this quasi-quoter in pattern context."
     , quoteType = error "moduleQuoter: Invalid use of this quasi-quoter in type context."
     , quoteDec = error "moduleQuoter: Invalid use of this quasi-quoter in top-level declaration context."

--- a/inferno-core/src/Inferno/Utils/QQ/Script.hs
+++ b/inferno-core/src/Inferno/Utils/QQ/Script.hs
@@ -3,6 +3,8 @@
 {-# LANGUAGE TemplateHaskellQuotes #-}
 {-# LANGUAGE TypeApplications #-}
 
+{-# OPTIONS_GHC -Wno-unused-imports #-} -- FIXME Parser rewrite
+
 module Inferno.Utils.QQ.Script where
 
 import Control.Monad.Catch (MonadCatch (..), MonadThrow (..))
@@ -46,28 +48,29 @@ import Text.Megaparsec
 inferno :: forall m c. (MonadIO m, MonadThrow m, MonadCatch m, Pretty c, Eq c) => QuasiQuoter
 inferno =
   QuasiQuoter
-    { quoteExp = \str -> do
-        l <- location'
-        let (_, res) =
-              runParser' (runWriterT $ flip runReaderT (baseOpsTable @_ @c builtins, builtinModulesOpsTable @_ @c builtins, []) $ topLevel expr) $
-                State
-                  (pack str)
-                  0
-                  (PosState (pack str) 0 l defaultTabWidth "")
-                  []
-        case res of
-          Left (ParseErrorBundle errs pos) ->
-            let errs' = map mkParseErrorStr $ NEList.toList $ fst $ attachSourcePos errorOffset errs pos
-             in fail $ intercalate "\n\n" errs'
-          Right (ast, comments) ->
-            case pinExpr (builtinModulesPinMap @_ @c builtins) ast of
-              Left err -> fail $ "Pinning expression failed:\n" <> show err
-              Right pinnedAST ->
-                case inferExpr builtins pinnedAST of
-                  Left err -> fail $ "Inference failed:\n" <> show err
-                  Right (pinnedAST', t, _tyMap) -> do
-                    let final = insertCommentsIntoExpr (appEndo comments []) pinnedAST'
-                    dataToExpQ ((fmap liftText . cast) `extQ` vcObjectHashToValue) (final, t)
+    { quoteExp = undefined -- FIXME Parser rewrite
+      -- \str -> do
+      --   l <- location'
+      --   let (_, res) =
+      --         runParser' (runWriterT $ flip runReaderT (baseOpsTable @_ @c builtins, builtinModulesOpsTable @_ @c builtins, []) $ topLevel expr) $
+      --           State
+      --             (pack str)
+      --             0
+      --             (PosState (pack str) 0 l defaultTabWidth "")
+      --             []
+      --   case res of
+      --     Left (ParseErrorBundle errs pos) ->
+      --       let errs' = map mkParseErrorStr $ NEList.toList $ fst $ attachSourcePos errorOffset errs pos
+      --        in fail $ intercalate "\n\n" errs'
+      --     Right (ast, comments) ->
+      --       case pinExpr (builtinModulesPinMap @_ @c builtins) ast of
+      --         Left err -> fail $ "Pinning expression failed:\n" <> show err
+      --         Right pinnedAST ->
+      --           case inferExpr builtins pinnedAST of
+      --             Left err -> fail $ "Inference failed:\n" <> show err
+      --             Right (pinnedAST', t, _tyMap) -> do
+      --               let final = insertCommentsIntoExpr (appEndo comments []) pinnedAST'
+      --               dataToExpQ ((fmap liftText . cast) `extQ` vcObjectHashToValue) (final, t)
     , quotePat = error "inferno: Invalid use of this quasi-quoter in pattern context."
     , quoteType = error "inferno: Invalid use of this quasi-quoter in type context."
     , quoteDec = error "inferno: Invalid use of this quasi-quoter in top-level declaration context."

--- a/inferno-core/src/Inferno/Utils/QQ/Script.hs
+++ b/inferno-core/src/Inferno/Utils/QQ/Script.hs
@@ -2,30 +2,37 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
 {-# LANGUAGE TypeApplications #-}
--- FIXME Parser rewrite
-{-# OPTIONS_GHC -Wno-unused-imports #-}
 
 module Inferno.Utils.QQ.Script where
 
+import Control.Monad ((>=>))
 import Control.Monad.Catch (MonadCatch (..), MonadThrow (..))
 import Control.Monad.IO.Class (MonadIO)
-import Control.Monad.Reader (ReaderT (..))
-import Control.Monad.Writer (WriterT (..))
+import Control.Monad.Reader (runReaderT)
+import Control.Monad.State.Strict (runStateT)
 import qualified Crypto.Hash as Crypto
 import Data.ByteArray (convert)
-import Data.ByteString (ByteString, unpack)
+import qualified Data.ByteString as ByteString
 import Data.Data (cast)
 import Data.Generics.Aliases (extQ)
 import Data.List (intercalate)
 import qualified Data.List.NonEmpty as NEList
 import qualified Data.Maybe as Maybe
-import Data.Monoid (appEndo)
-import Data.Text (pack)
+import Data.Text (Text)
+import qualified Data.Text as Text
 import Inferno.Infer (inferExpr)
 import Inferno.Infer.Pinned (pinExpr)
-import Inferno.Module.Prelude (baseOpsTable, builtinModules, builtinModulesOpsTable, builtinModulesPinMap)
-import Inferno.Parse (expr, topLevel)
+import Inferno.Module.Prelude
+  ( ModuleMap,
+    baseOpsTable,
+    builtinModules,
+    builtinModulesOpsTable,
+    builtinModulesPinMap,
+  )
+import Inferno.Parse (InfernoParsingError, ParseEnv, expr, mkParseEnv, topLevel)
 import Inferno.Parse.Commented (insertCommentsIntoExpr)
+import Inferno.Types.Syntax (Comment, Expr, TCScheme)
+import Inferno.Types.VersionControl (Pinned, VCObjectHash)
 import Inferno.Utils.QQ.Common
   ( liftText,
     location',
@@ -33,11 +40,13 @@ import Inferno.Utils.QQ.Common
   )
 import qualified Language.Haskell.TH.Lib as TH
 import Language.Haskell.TH.Quote (QuasiQuoter (..), dataToExpQ)
-import Language.Haskell.TH.Syntax (Exp (AppE, VarE), Lift (lift))
+import Language.Haskell.TH.Syntax (Exp (AppE, VarE), Lift (lift), Q)
 import Prettyprinter (Pretty)
 import Text.Megaparsec
   ( ParseErrorBundle (ParseErrorBundle),
+    Parsec,
     PosState (PosState),
+    SourcePos,
     State (State),
     attachSourcePos,
     defaultTabWidth,
@@ -45,43 +54,70 @@ import Text.Megaparsec
     runParser',
   )
 
-inferno :: forall m c. (MonadIO m, MonadThrow m, MonadCatch m, Pretty c, Eq c) => QuasiQuoter
+inferno ::
+  forall m c.
+  (MonadIO m, MonadThrow m, MonadCatch m, Pretty c, Eq c) =>
+  QuasiQuoter
 inferno =
   QuasiQuoter
-    { quoteExp = undefined -- FIXME Parser rewrite
-    -- \str -> do
-    --   l <- location'
-    --   let (_, res) =
-    --         runParser' (runWriterT $ flip runReaderT (baseOpsTable @_ @c builtins, builtinModulesOpsTable @_ @c builtins, []) $ topLevel expr) $
-    --           State
-    --             (pack str)
-    --             0
-    --             (PosState (pack str) 0 l defaultTabWidth "")
-    --             []
-    --   case res of
-    --     Left (ParseErrorBundle errs pos) ->
-    --       let errs' = map mkParseErrorStr $ NEList.toList $ fst $ attachSourcePos errorOffset errs pos
-    --        in fail $ intercalate "\n\n" errs'
-    --     Right (ast, comments) ->
-    --       case pinExpr (builtinModulesPinMap @_ @c builtins) ast of
-    --         Left err -> fail $ "Pinning expression failed:\n" <> show err
-    --         Right pinnedAST ->
-    --           case inferExpr builtins pinnedAST of
-    --             Left err -> fail $ "Inference failed:\n" <> show err
-    --             Right (pinnedAST', t, _tyMap) -> do
-    --               let final = insertCommentsIntoExpr (appEndo comments []) pinnedAST'
-    --               dataToExpQ ((fmap liftText . cast) `extQ` vcObjectHashToValue) (final, t)
+    { quoteExp = \str ->
+        location' >>= \l ->
+          let env :: ParseEnv
+              env =
+                mkParseEnv
+                  (baseOpsTable @_ @c builtins)
+                  (builtinModulesOpsTable @_ @c builtins)
+                  mempty
+
+              run :: Parsec InfernoParsingError Text (Expr () SourcePos, [Comment SourcePos])
+              run = flip runStateT mempty . flip runReaderT env $ topLevel expr
+
+              res ::
+                Either
+                  (ParseErrorBundle Text InfernoParsingError)
+                  (Expr () SourcePos, [Comment SourcePos])
+              (_, res) =
+                runParser' run $
+                  State
+                    (Text.pack str)
+                    0
+                    (PosState (Text.pack str) 0 l defaultTabWidth mempty)
+                    mempty
+           in either parseFail (pinAndInfer >=> liftToTH) res
     , quotePat = error "inferno: Invalid use of this quasi-quoter in pattern context."
     , quoteType = error "inferno: Invalid use of this quasi-quoter in type context."
     , quoteDec = error "inferno: Invalid use of this quasi-quoter in top-level declaration context."
     }
   where
+    builtins :: ModuleMap m c
     builtins = builtinModules @m @c
+
+    parseFail :: ParseErrorBundle Text InfernoParsingError -> Q Exp
+    parseFail (ParseErrorBundle errs pos) =
+      fail
+        . intercalate "\n\n"
+        . fmap mkParseErrorStr
+        . NEList.toList
+        . fst
+        $ attachSourcePos errorOffset errs pos
+
+    pinAndInfer ::
+      (Expr () SourcePos, [Comment SourcePos]) -> Q (Expr (Pinned VCObjectHash) SourcePos, TCScheme)
+    pinAndInfer (ast, comments) = do
+      pinned <-
+        either (fail . ("Pinning expression failed:\n" <>) . show) pure $
+          pinExpr (builtinModulesPinMap @_ @c builtins) ast
+      (pinnedAST, t, _) <-
+        either (fail . ("Inference failed:\n" <>) . show) pure $
+          inferExpr builtins pinned
+      pure (insertCommentsIntoExpr (reverse comments) pinnedAST, t)
+
+    liftToTH :: (Expr (Pinned VCObjectHash) SourcePos, TCScheme) -> Q Exp
+    liftToTH = dataToExpQ ((fmap liftText . cast) `extQ` vcObjectHashToValue)
+
     vcObjectHashToValue :: Crypto.Digest Crypto.SHA256 -> Maybe TH.ExpQ
     vcObjectHashToValue h =
-      let str = convert h :: ByteString
-       in Just
-            ( AppE (VarE 'Maybe.fromJust)
-                . AppE (VarE 'Crypto.digestFromByteString)
-                <$> lift (unpack str)
-            )
+      Just $
+        AppE (VarE 'Maybe.fromJust)
+          . AppE (VarE 'Crypto.digestFromByteString)
+          <$> lift (ByteString.unpack (convert h))

--- a/inferno-core/src/Inferno/Utils/QQ/Script.hs
+++ b/inferno-core/src/Inferno/Utils/QQ/Script.hs
@@ -17,7 +17,7 @@ import qualified Data.ByteString as ByteString
 import Data.Data (cast)
 import Data.Generics.Aliases (extQ)
 import Data.List (intercalate)
-import qualified Data.List.NonEmpty as NEList
+import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Maybe as Maybe
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -94,7 +94,7 @@ inferno =
       fail
         . intercalate "\n\n"
         . fmap mkParseErrorStr
-        . NEList.toList
+        . NonEmpty.toList
         . fst
         $ attachSourcePos errorOffset errs pos
 

--- a/inferno-core/src/Inferno/Utils/QQ/Script.hs
+++ b/inferno-core/src/Inferno/Utils/QQ/Script.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module Inferno.Utils.QQ.Script where
 
@@ -60,7 +61,7 @@ inferno ::
   QuasiQuoter
 inferno =
   QuasiQuoter
-    { quoteExp = \str ->
+    { quoteExp = \(Text.pack -> str) ->
         location' >>= \l ->
           let env :: ParseEnv
               env =
@@ -78,11 +79,7 @@ inferno =
                   (Expr () SourcePos, [Comment SourcePos])
               (_, res) =
                 runParser' run $
-                  State
-                    (Text.pack str)
-                    0
-                    (PosState (Text.pack str) 0 l defaultTabWidth mempty)
-                    mempty
+                  State str 0 (PosState str 0 l defaultTabWidth mempty) mempty
            in either parseFail (pinAndInfer >=> liftToTH) res
     , quotePat = error "inferno: Invalid use of this quasi-quoter in pattern context."
     , quoteType = error "inferno: Invalid use of this quasi-quoter in type context."

--- a/inferno-core/src/Inferno/Utils/QQ/Script.hs
+++ b/inferno-core/src/Inferno/Utils/QQ/Script.hs
@@ -2,8 +2,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
 {-# LANGUAGE TypeApplications #-}
-
-{-# OPTIONS_GHC -Wno-unused-imports #-} -- FIXME Parser rewrite
+-- FIXME Parser rewrite
+{-# OPTIONS_GHC -Wno-unused-imports #-}
 
 module Inferno.Utils.QQ.Script where
 
@@ -49,28 +49,28 @@ inferno :: forall m c. (MonadIO m, MonadThrow m, MonadCatch m, Pretty c, Eq c) =
 inferno =
   QuasiQuoter
     { quoteExp = undefined -- FIXME Parser rewrite
-      -- \str -> do
-      --   l <- location'
-      --   let (_, res) =
-      --         runParser' (runWriterT $ flip runReaderT (baseOpsTable @_ @c builtins, builtinModulesOpsTable @_ @c builtins, []) $ topLevel expr) $
-      --           State
-      --             (pack str)
-      --             0
-      --             (PosState (pack str) 0 l defaultTabWidth "")
-      --             []
-      --   case res of
-      --     Left (ParseErrorBundle errs pos) ->
-      --       let errs' = map mkParseErrorStr $ NEList.toList $ fst $ attachSourcePos errorOffset errs pos
-      --        in fail $ intercalate "\n\n" errs'
-      --     Right (ast, comments) ->
-      --       case pinExpr (builtinModulesPinMap @_ @c builtins) ast of
-      --         Left err -> fail $ "Pinning expression failed:\n" <> show err
-      --         Right pinnedAST ->
-      --           case inferExpr builtins pinnedAST of
-      --             Left err -> fail $ "Inference failed:\n" <> show err
-      --             Right (pinnedAST', t, _tyMap) -> do
-      --               let final = insertCommentsIntoExpr (appEndo comments []) pinnedAST'
-      --               dataToExpQ ((fmap liftText . cast) `extQ` vcObjectHashToValue) (final, t)
+    -- \str -> do
+    --   l <- location'
+    --   let (_, res) =
+    --         runParser' (runWriterT $ flip runReaderT (baseOpsTable @_ @c builtins, builtinModulesOpsTable @_ @c builtins, []) $ topLevel expr) $
+    --           State
+    --             (pack str)
+    --             0
+    --             (PosState (pack str) 0 l defaultTabWidth "")
+    --             []
+    --   case res of
+    --     Left (ParseErrorBundle errs pos) ->
+    --       let errs' = map mkParseErrorStr $ NEList.toList $ fst $ attachSourcePos errorOffset errs pos
+    --        in fail $ intercalate "\n\n" errs'
+    --     Right (ast, comments) ->
+    --       case pinExpr (builtinModulesPinMap @_ @c builtins) ast of
+    --         Left err -> fail $ "Pinning expression failed:\n" <> show err
+    --         Right pinnedAST ->
+    --           case inferExpr builtins pinnedAST of
+    --             Left err -> fail $ "Inference failed:\n" <> show err
+    --             Right (pinnedAST', t, _tyMap) -> do
+    --               let final = insertCommentsIntoExpr (appEndo comments []) pinnedAST'
+    --               dataToExpQ ((fmap liftText . cast) `extQ` vcObjectHashToValue) (final, t)
     , quotePat = error "inferno: Invalid use of this quasi-quoter in pattern context."
     , quoteType = error "inferno: Invalid use of this quasi-quoter in type context."
     , quoteDec = error "inferno: Invalid use of this quasi-quoter in top-level declaration context."


### PR DESCRIPTION
This rewrites the parser to avoid pervasive laziness, recomputing the same information on literally every pass (I mean actually recreating the entire expression parser on every parse), and avoiding intermediate allocations (e.g. accumulating directly into strict `Map`s, rather than `[(a, b)]` then into a lazy `Map` when parsing is done). Also added some helper records and types to help clarify intent of parser code, which I honestly found difficult to follow at times.

For more specific information on decisions made, see #213, #214, #215, #216, and #217. 

All tests in `inferno` pass. The new parsers are semantically equivalent to the old ones.

At any rate, the changes have certainly paid off, as the benchmarks demonstrate. The `deep/*` benchmarks in particular show a huge improvement (this exercise longer parser chains than `wide/*`, so this makes sense). I won't paste the raw stats but a summary:

### Performance improvements

#### Wall-clock improvements

| Benchmark | Old   | New   | Speedup  |
| --------- | ----- | ----- | -------- |
| wide/100  | 304ms | 181ms | **1.7x** |
| wide/1000 | 3.93s | 2.88s | **1.4x** |
| deep/25   | 1.44s | 549ms | **2.6x** |
| deep/50   | 2.90s | 1.13s | **2.6x** |
| deep/100  | 6.08s | 2.43s | **2.5x** |

#### Runtime statistics 

##### `wide/*` benchmark suite

| Metric              | Old      | New     | Change   |
| ------------------- | -------- | ------- | -------- |
| Total elapsed       | 85.1s    | 50.9s   | -40%     |
| Mutator time        | 38.1s    | 32.2s   | -16%     |
| GC time             | 47.0s    | 18.6s   | **-60%** |
| Productivity        | 44.9%    | 63.4%   | +18pp    |
| Heap allocated      | 314 GB   | 251 GB  | -20%     |
| Bytes copied (GC)   | 88.7 GB  | 37.2 GB | **-58%** |
| Max residency       | 501 MB   | 246 MB  | **-51%** |
| Total memory in use | 1210 MiB | 629 MiB | -48%     |
| Gen 1 max pause     | 388ms    | 173ms   | -55%     |

##### `deep/*` benchmark suite

| Metric              | Old     | New     | Change   |
| ------------------- | ------- | ------- | -------- |
| Total elapsed       | 167.2s  | 66.0s   | -60%     |
| Mutator time        | 78.0s   | 47.4s   | **-39%** |
| GC time             | 89.2s   | 18.6s   | **-79%** |
| Productivity        | 46.7%   | 71.9%   | +25pp    |
| Heap allocated      | 710 GB  | 403 GB  | -43%     |
| Bytes copied (GC)   | 177 GB  | 38.7 GB | **-78%** |
| Max residency       | 310 MB  | 78 MB   | **-75%** |
| Total memory in use | 750 MiB | 203 MiB | -73%     |
| Gen 1 max pause     | 206ms   | 56ms    | -73%     |

#### Specific changes from the old parser

- **The old parser spent more time in GC than doing work** (53% GC on deep inputs, 55% on wide). The new parser is **72% productive**.
- The old `makeExprParser` **was rebuilt on every `expr` invocation**
  - This means that _every single subexpression_ rebuilt the **ENTIRE** expression parser
  - The parser is now pre-computed once per environment and read from a lazy field (i.e. knot-tying approach)
- The old lazy `WriterT` accumulated thunk chains for comments; this has been replaced with a strict `StateT` (now GC can reclaim immediately)
- In the old apprach, `foldl` built `App` thunks in function application; this has been replaced with `foldl'`.
- the `variable` parser performed O(m) linear keyword scan _per identifier_; now O(log m) via `Set.member` on precomputed reserved keywords
- Collections (arrays, records) double-parsed their last element via `try` backtracking; this has been restructured to parse-then-decide
- Operator lists were extracted and filtered on every prefix-op parse; this is now also pre-computed in the environment