### PR TITLE
[inferno-core] Don't mask errors in `unifyArgs`

### DIFF
--- a/inferno-core/src/Inferno/Infer.hs
+++ b/inferno-core/src/Inferno/Infer.hs
@@ -2594,8 +2594,8 @@ inferTypeReps allTyCls (ForallTC tvs tyCls impl) inputTys outputTy =
     -- Peel `TArr` layers from the signature and unify with concrete types
     unifyArgs :: InfernoType -> [InfernoType] -> Infer s ()
     unifyArgs = \cases
-      (TArr a rest) (x : xs) -> unify mempty a x *> unifyArgs rest xs
-      t [] -> unify mempty t outputTy
+      (TArr a rest) (x : xs) -> unify [UnificationFail mempty a x dummyLoc] a x *> unifyArgs rest xs
+      t [] -> unify [UnificationFail mempty t outputTy dummyLoc] t outputTy
       _ _ -> throwError [UnificationFail mempty impl.body outputTy dummyLoc]
 
 inferPossibleTypes ::


### PR DESCRIPTION
In #212 I accidentally masked type errors in `unifyArgs`, meaning in some cases programs that don't typecheck will be reported with a `[]` error list. This fixes that. Note that the use of `dummyLoc` is the same behavior as the older, substitution-map-based typechecker