### PR TITLE
[inferno-lsp] Add document state and hover modules

### DIFF
--- a/inferno-core/src/Inferno/Infer.hs
+++ b/inferno-core/src/Inferno/Infer.hs
@@ -47,7 +47,6 @@ import Data.Traversable (for)
 import Data.Tuple.Extra (dupe, fst3, snd3, thd3)
 import Data.Vector (Vector, (!?))
 import qualified Data.Vector as Vector
-import GHC.Records (HasField (getField))
 import Inferno.Infer.Env
   ( Env,
     Namespace (EnumNamespace, OpNamespace),
@@ -463,13 +462,6 @@ data OpenModuleBinding = OpenModuleBinding
   , inPos :: !SourcePos
   , body :: !(Expr (Pinned VCObjectHash) SourcePos)
   }
-
--- | Virtual record fields for @ImplType@
-instance HasField "impl" ImplType (Map ExtIdent InfernoType) where
-  getField (ImplType m _) = m
-
-instance HasField "body" ImplType InfernoType where
-  getField (ImplType _ t) = t
 
 -------------------------------------------------------------------------------
 -- Type Map and Environment Helpers

--- a/inferno-core/src/Inferno/Module.hs
+++ b/inferno-core/src/Inferno/Module.hs
@@ -30,7 +30,7 @@ import Inferno.Infer.Env (Namespace (..), TypeMetadata (..))
 import Inferno.Infer.Pinned (pinExpr)
 import qualified Inferno.Infer.Pinned as Pinned
 import Inferno.Module.Cast (ToValue (..))
-import Inferno.Parse (OpsTable, ParsedModule, TopLevelDefn (..))
+import Inferno.Parse (ParsedModule, TopLevelDefn (..))
 import qualified Inferno.Parse
 import Inferno.Types.Module
   ( BuiltinEnumHash (..),

--- a/inferno-lsp/inferno-lsp.cabal
+++ b/inferno-lsp/inferno-lsp.cabal
@@ -58,6 +58,7 @@ library
     , text-rope
     , time
     , transformers
+    , unliftio
     , uuid
 
   default-language:   Haskell2010

--- a/inferno-lsp/inferno-lsp.cabal
+++ b/inferno-lsp/inferno-lsp.cabal
@@ -24,6 +24,8 @@ library
   exposed-modules:    Inferno.LSP.Server
   other-modules:
     Inferno.LSP.Completion
+    Inferno.LSP.DocState
+    Inferno.LSP.Hover
     Inferno.LSP.ParseInfer
 
   hs-source-dirs:     src
@@ -33,13 +35,16 @@ library
 
   build-depends:
       base
+    , async
     , bytestring
     , co-log-core
     , containers
     , extra
+    , focus
     , inferno-core
     , inferno-types
     , inferno-vc
+    , IntervalMap
     , lsp
     , lsp-types
     , megaparsec
@@ -47,9 +52,8 @@ library
     , plow-log
     , plow-log-async
     , prettyprinter
-    , safe
-    , special-keys
     , stm
+    , stm-containers
     , text
     , text-rope
     , time
@@ -65,6 +69,7 @@ library
     FlexibleInstances
     LambdaCase
     MultiParamTypeClasses
+    OverloadedRecordDot
     OverloadedStrings
     TupleSections
 

--- a/inferno-lsp/src/Inferno/LSP/DocState.hs
+++ b/inferno-lsp/src/Inferno/LSP/DocState.hs
@@ -1,0 +1,1 @@
+module Inferno.LSP.DocState where

--- a/inferno-lsp/src/Inferno/LSP/DocState.hs
+++ b/inferno-lsp/src/Inferno/LSP/DocState.hs
@@ -1,1 +1,116 @@
-module Inferno.LSP.DocState where
+{-# LANGUAGE NoFieldSelectors #-}
+
+module Inferno.LSP.DocState
+  ( DocState
+      ( DocState,
+        version,
+        hoverIdx,
+        typeMap,
+        classes,
+        analysis,
+        hoverCache
+      ),
+    AnalysisResult
+      ( AnalysisResult
+      ),
+    DocStore,
+    lookupDoc,
+    insertDoc,
+    deleteDoc,
+    cancelAnalysis,
+    closeDoc,
+    updateDoc,
+    setAnalysis,
+    openDoc,
+    newDoc,
+  ) where
+
+import Data.Foldable (traverse_) -- NOTE: Do NOT remove, needed for GHC version compat
+import Data.Int (Int32)
+import Data.Map.Strict (Map)
+import Data.Set (Set)
+import Data.Word (Word32)
+import Inferno.LSP.Hover (HoverIndex)
+import Inferno.Types.Syntax (TCScheme, TypeClass, TypeMetadata)
+import Language.LSP.Types (MarkupContent, NormalizedUri, Range)
+import qualified StmContainers.Map
+import Text.Megaparsec.Pos (SourcePos)
+import UnliftIO.Async (Async, cancel)
+import UnliftIO.STM
+  ( STM,
+    TVar,
+    atomically,
+    modifyTVar',
+    newTVar,
+    readTVarIO,
+    writeTVar,
+  )
+
+data DocState = DocState
+  { version :: {-# UNPACK #-} !Int32
+  , hoverIdx :: !HoverIndex
+  , typeMap :: !(Map (SourcePos, SourcePos) (TypeMetadata TCScheme))
+  , classes :: !(Set TypeClass)
+  , analysis :: !(Maybe (Async ()))
+  , hoverCache :: !(Map (Word32, Word32) (Range, MarkupContent))
+  }
+
+type DocStore = StmContainers.Map.Map NormalizedUri (TVar DocState)
+
+lookupDoc :: NormalizedUri -> DocStore -> STM (Maybe (TVar DocState))
+lookupDoc = StmContainers.Map.lookup
+
+insertDoc :: NormalizedUri -> TVar DocState -> DocStore -> STM ()
+insertDoc uri tvar = StmContainers.Map.insert tvar uri
+
+deleteDoc :: NormalizedUri -> DocStore -> STM ()
+deleteDoc = StmContainers.Map.delete
+
+cancelAnalysis :: TVar DocState -> IO ()
+cancelAnalysis tvar = traverse_ cancel . (.analysis) =<< readTVarIO tvar
+
+closeDoc :: NormalizedUri -> DocStore -> IO ()
+closeDoc uri store =
+  traverse_ ((*> atomically (deleteDoc uri store)) . cancelAnalysis)
+    =<< atomically (lookupDoc uri store)
+
+data AnalysisResult = AnalysisResult
+  { version :: {-# UNPACK #-} !Int32
+  , hoverIdx :: !HoverIndex
+  , typeMap :: !(Map (SourcePos, SourcePos) (TypeMetadata TCScheme))
+  , classes :: !(Set TypeClass)
+  }
+
+updateDoc :: AnalysisResult -> TVar DocState -> STM ()
+updateDoc res tvar =
+  writeTVar
+    tvar
+    DocState
+      { version = res.version
+      , hoverIdx = res.hoverIdx
+      , typeMap = res.typeMap
+      , classes = res.classes
+      , analysis = Nothing
+      , hoverCache = mempty
+      }
+
+setAnalysis :: Async () -> TVar DocState -> STM ()
+setAnalysis a tvar = modifyTVar' tvar $ \ds -> ds{analysis = Just a}
+
+openDoc :: NormalizedUri -> DocStore -> STM (TVar DocState)
+openDoc uri store =
+  newDoc >>= \doc ->
+    doc <$ insertDoc uri doc store
+
+
+newDoc :: STM (TVar DocState)
+newDoc =
+  newTVar
+    DocState
+      { version = 0
+      , hoverIdx = mempty
+      , typeMap = mempty
+      , classes = mempty
+      , analysis = Nothing
+      , hoverCache = mempty
+      }

--- a/inferno-lsp/src/Inferno/LSP/DocState.hs
+++ b/inferno-lsp/src/Inferno/LSP/DocState.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE NoFieldSelectors #-}
 
 module Inferno.LSP.DocState
@@ -27,9 +28,9 @@ module Inferno.LSP.DocState
 
 import Data.Foldable (traverse_) -- NOTE: Do NOT remove, needed for GHC version compat
 import Data.Int (Int32)
+import Data.IntMap.Strict (IntMap)
 import Data.Map.Strict (Map)
 import Data.Set (Set)
-import Data.Word (Word32)
 import Inferno.LSP.Hover (HoverIndex)
 import Inferno.Types.Syntax (TCScheme, TypeClass, TypeMetadata)
 import Language.LSP.Types (MarkupContent, NormalizedUri, Range)
@@ -46,15 +47,22 @@ import UnliftIO.STM
     writeTVar,
   )
 
+-- | Per-document state, stored in a 'TVar' inside the 'DocStore'. Replaced
+-- atomically on each successful parse\/infer cycle.
 data DocState = DocState
   { version :: {-# UNPACK #-} !Int32
   , hoverIdx :: !HoverIndex
   , typeMap :: !(Map (SourcePos, SourcePos) (TypeMetadata TCScheme))
   , classes :: !(Set TypeClass)
   , analysis :: !(Maybe (Async ()))
-  , hoverCache :: !(Map (Word32, Word32) (Range, MarkupContent))
+  , hoverCache :: !(IntMap (Range, MarkupContent))
+  -- ^ Memoized hover results, keyed by linearized position (see
+  -- 'Inferno.LSP.Hover.linearize'). Invalidated (set to @mempty@) on every
+  -- analysis update since source positions shift.
   }
 
+-- | Concurrent map from document URIs to their per-document state. Uses
+-- @StmContainers.Map@ for lock-free concurrent access from LSP handlers.
 type DocStore = StmContainers.Map.Map NormalizedUri (TVar DocState)
 
 lookupDoc :: NormalizedUri -> DocStore -> STM (Maybe (TVar DocState))
@@ -66,14 +74,20 @@ insertDoc uri tvar = StmContainers.Map.insert tvar uri
 deleteDoc :: NormalizedUri -> DocStore -> STM ()
 deleteDoc = StmContainers.Map.delete
 
+-- | Cancel any in-flight analysis for a document. No-op if @analysis@ is
+-- 'Nothing' or the async has already completed.
 cancelAnalysis :: TVar DocState -> IO ()
 cancelAnalysis tvar = traverse_ cancel . (.analysis) =<< readTVarIO tvar
 
+-- | Handle @DidClose@: cancel in-flight analysis and remove the document
+-- from the store.
 closeDoc :: NormalizedUri -> DocStore -> IO ()
 closeDoc uri store =
   traverse_ ((*> atomically (deleteDoc uri store)) . cancelAnalysis)
     =<< atomically (lookupDoc uri store)
 
+-- | The output of a successful parse\/infer cycle, used to atomically replace
+-- the relevant fields of 'DocState' via 'updateDoc'.
 data AnalysisResult = AnalysisResult
   { version :: {-# UNPACK #-} !Int32
   , hoverIdx :: !HoverIndex
@@ -81,6 +95,8 @@ data AnalysisResult = AnalysisResult
   , classes :: !(Set TypeClass)
   }
 
+-- | Atomically replace document state with fresh analysis results. Clears the
+-- hover cache since source positions may have shifted.
 updateDoc :: AnalysisResult -> TVar DocState -> STM ()
 updateDoc res tvar =
   writeTVar
@@ -94,14 +110,17 @@ updateDoc res tvar =
       , hoverCache = mempty
       }
 
+-- | Record a newly spawned analysis async in the document state so it can be
+-- cancelled if superseded by a newer edit.
 setAnalysis :: Async () -> TVar DocState -> STM ()
 setAnalysis a tvar = modifyTVar' tvar $ \ds -> ds{analysis = Just a}
 
+-- | Handle @DidOpen@: create a fresh empty 'DocState' and insert it into the
+-- store. Returns the 'TVar' for subsequent updates.
 openDoc :: NormalizedUri -> DocStore -> STM (TVar DocState)
 openDoc uri store =
   newDoc >>= \doc ->
     doc <$ insertDoc uri doc store
-
 
 newDoc :: STM (TVar DocState)
 newDoc =

--- a/inferno-lsp/src/Inferno/LSP/Hover.hs
+++ b/inferno-lsp/src/Inferno/LSP/Hover.hs
@@ -1,20 +1,214 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE NoFieldSelectors #-}
+
 module Inferno.LSP.Hover
   ( HoverIndex,
+    HoverEntry (HoverEntry, meta, start, end),
     linearize,
+    buildHoverIndex,
+    queryHover,
+    renderHoverContent,
   ) where
 
-import Inferno.Types.Syntax (TCScheme, TypeMetadata)
-
 import Data.IntervalMap.Generic.Strict (IntervalMap)
+import qualified Data.IntervalMap.Generic.Strict as IntervalMap
 import Data.IntervalMap.Interval (Interval)
+import qualified Data.IntervalMap.Interval as Interval
+import Data.List.Extra (nubOrd)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Data.Text (Text)
+import Inferno.Infer (findTypeClassWitnesses)
+import Inferno.Types.Syntax
+  ( BaseType (TEnum),
+    Ident (unIdent),
+    ImplType (ImplType),
+    InfernoType (TBase, TRep),
+    Substitutable (ftv),
+    TCScheme,
+    TV,
+    TypeClass (TypeClass),
+    TypeMetadata,
+    punctuate',
+    substMap,
+  )
+import qualified Inferno.Types.Syntax
+import Inferno.Utils.Prettyprinter (renderDoc)
+import Language.LSP.Types
+  ( MarkupContent (MarkupContent),
+    MarkupKind (MkMarkdown),
+    Range,
+    UInt,
+    mkRange,
+  )
+import Prettyprinter (Doc, Pretty (pretty), align, hardline, sep, (<+>))
 import Text.Megaparsec.Pos (SourcePos)
 import qualified Text.Megaparsec.Pos as Pos
 
-type HoverIndex =
-  IntervalMap (Interval Int) (TypeMetadata TCScheme, SourcePos, SourcePos)
+-- | A single entry in the hover index, pairing type metadata with its
+-- source span.
+data HoverEntry = HoverEntry
+  { meta :: !(TypeMetadata TCScheme)
+  , start :: !SourcePos
+  , end :: !SourcePos
+  }
 
--- | Encode a `SourcePos` as a single `Int` for use as an `IntervalMap` key.
--- Uses a fixed column width of `10000`; safe for any realistic Inferno script.
-linearize :: Pos.SourcePos -> Int
+-- | Interval map from linearized source positions to hover entries. Supports
+-- O(log n) point queries via @IntervalMap.containing@. See 'linearize' for the
+-- encoding scheme.
+type HoverIndex = IntervalMap (Interval Int) HoverEntry
+
+-- | Encode a 'SourcePos' as a single @Int@ for use as an @IntervalMap@ key.
+-- Maps 2D @(line, col)@ to a single @Int@ via @line * 10000 + col@. This
+-- preserves containment: if span A contains span B, then
+-- @linearize A.start <= linearize B.start@ and
+-- @linearize A.end >= linearize B.end@. The fixed column width of @10000@ is
+-- safe for any realistic Inferno script.
+--
+-- Also used as the key for @DocState.hoverCache@ (@IntMap@), so hover cache
+-- lookups use the same encoding as index queries.
+linearize :: SourcePos -> Int
 linearize pos =
   (Pos.unPos pos.sourceLine - 1) * 10000 + (Pos.unPos pos.sourceColumn - 1)
+
+-- | Build an interval map from the type map produced by the inferencer. Each
+-- source span is linearized into a closed @Int@ interval.
+buildHoverIndex :: Map (SourcePos, SourcePos) (TypeMetadata TCScheme) -> HoverIndex
+buildHoverIndex = IntervalMap.fromList . fmap toEntry . Map.toList
+  where
+    toEntry :: ((SourcePos, SourcePos), TypeMetadata TCScheme) -> (Interval Int, HoverEntry)
+    toEntry ((s, e), m) = (Interval.ClosedInterval (linearize s) (linearize e), HoverEntry m s e)
+
+-- | Query the hover index at a given LSP @(line, col)@ position. Finds all
+-- intervals containing the linearized point, then picks the smallest
+-- (innermost) span. Returns 'Nothing' if the position has no type information.
+queryHover :: UInt -> UInt -> HoverIndex -> Maybe HoverEntry
+queryHover line col = smallestContaining . flip IntervalMap.containing pt
+  where
+    pt :: Int
+    pt = fromIntegral line * 10000 + fromIntegral col
+
+-- | Find the entry with the smallest enclosing interval (i.e. the most
+-- specific/innermost type). Folds the map directly; no intermediate list.
+smallestContaining :: IntervalMap (Interval Int) a -> Maybe a
+smallestContaining =
+  fmap snd . IntervalMap.foldlWithKey pick Nothing
+  where
+    pick :: Maybe (Interval Int, a) -> Interval Int -> a -> Maybe (Interval Int, a)
+    pick = \cases
+      Nothing k v -> Just (k, v)
+      (Just acc@(a, _)) k v
+        | ivSpan k < ivSpan a -> Just (k, v)
+        | otherwise -> Just acc
+
+    ivSpan :: Interval Int -> Int
+    ivSpan iv = Interval.upperBound iv - Interval.lowerBound iv
+
+-- | Render a hover entry into an LSP 'Range' and markdown 'MarkupContent'.
+-- The @- 2@ offset on source lines accounts for the 2-line @fun ... ->@ prefix
+-- prepended before parsing.
+renderHoverContent :: Set TypeClass -> Set TypeClass -> HoverEntry -> (Range, MarkupContent)
+renderHoverContent allClasses docClasses entry =
+  (range, MarkupContent MkMarkdown content)
+  where
+    prettyTy :: Doc ()
+    prettyTy = mkPrettyTy allClasses docClasses entry.meta.ty
+
+    range :: Range
+    range =
+      mkRange
+        (fromIntegral (Pos.unPos entry.start.sourceLine) - 2)
+        (fromIntegral (Pos.unPos entry.start.sourceColumn) - 1)
+        (fromIntegral (Pos.unPos entry.end.sourceLine) - 2)
+        $ fromIntegral (Pos.unPos entry.end.sourceColumn) - 1
+
+    content :: Text
+    content =
+      mconcat
+        [ "**Type**\n"
+        , "~~~inferno\n"
+        , renderDoc (pretty entry.meta.identExpr <+> align prettyTy)
+        , "\n~~~"
+        , maybe "" ("\n" <>) (metadataDocsText entry.meta)
+        ]
+
+-- | Pretty-print a type scheme as a union signature. If the scheme has free
+-- type variables, resolves typeclass witnesses (capped at @11@) to produce
+-- concrete instantiations. Displays up to @10@ variants; truncates with @...@.
+mkPrettyTy :: Set TypeClass -> Set TypeClass -> TCScheme -> Doc ann
+mkPrettyTy allClasses docClasses sch
+  | Set.null ftvTy = ":" <+> align (pretty sch.impl)
+  | null subs = ":" <+> align (pretty sch.impl)
+  | null (drop 10 prettyList) = sep $ unionTySig prettyList
+  | otherwise = sep . unionTySig $ take 10 prettyList <> ["..."]
+  where
+    ftvTy :: Set TV
+    ftvTy = ftv sch.impl
+
+    filteredCls :: Set TypeClass
+    filteredCls = Set.filter (not . isRepClass) $ Set.union sch.classes docClasses
+
+    subs :: [Map TV InfernoType]
+    subs = findTypeClassWitnesses allClasses (Just 11) filteredCls ftvTy
+
+    filtered :: ImplType
+    filtered = filterImplReps sch.impl
+
+    applyWit :: Map TV InfernoType -> ImplType
+    applyWit m =
+      ImplType (fmap (substMap m) filtered.impl) $ substMap m filtered.body
+
+    prettyList :: [Doc ann]
+    prettyList = fmap pretty . nubOrd $ fmap applyWit subs
+
+unionTySig :: [Doc ann] -> [Doc ann]
+unionTySig = \case
+  [] -> []
+  (t : ts) -> (":" <+> t) : fmap ("|" <+>) ts
+
+isRepClass :: TypeClass -> Bool
+isRepClass = \case
+  TypeClass "rep" _ -> True
+  _ -> False
+
+-- | Remove 'TRep' entries from an 'ImplType'\'s implicit context; these are
+-- runtime representation constraints that should not appear in hover output.
+filterImplReps :: ImplType -> ImplType
+filterImplReps (ImplType impls ty) =
+  flip ImplType ty $ Map.filter (not . isRep) impls
+  where
+    isRep :: InfernoType -> Bool
+    isRep = \case
+      TRep _ -> True
+      _ -> False
+
+-- | Extract documentation text from type metadata. For enum types, appends
+-- a fenced code block showing the enum definition.
+metadataDocsText :: TypeMetadata TCScheme -> Maybe Text
+metadataDocsText meta
+  | Nothing <- meta.docs = Nothing
+  | Just d <- meta.docs
+  , TBase (TEnum nm cs) <- meta.ty.impl.body =
+      Just . renderDoc $
+        mconcat
+          [ pretty d
+          , hardline
+          , "~~~inferno"
+          , hardline
+          , "enum"
+              <+> pretty nm
+              <+> align
+                ( sep
+                    ( "="
+                        : punctuate'
+                          "|"
+                          (("#" <>) . pretty . unIdent <$> Set.toList cs)
+                    )
+                )
+          , hardline
+          , "~~~"
+          ]
+  | otherwise = renderDoc . pretty <$> meta.docs

--- a/inferno-lsp/src/Inferno/LSP/Hover.hs
+++ b/inferno-lsp/src/Inferno/LSP/Hover.hs
@@ -56,16 +56,16 @@ data HoverEntry = HoverEntry
   , end :: !SourcePos
   }
 
--- | Interval map from linearized source positions to hover entries. Supports
+-- | Interval map from _linearized_ source positions to hover entries. Supports
 -- O(log n) point queries via @IntervalMap.containing@. See 'linearize' for the
 -- encoding scheme.
 type HoverIndex = IntervalMap (Interval Int) HoverEntry
 
 -- | Encode a 'SourcePos' as a single @Int@ for use as an @IntervalMap@ key.
 -- Maps 2D @(line, col)@ to a single @Int@ via @line * 10000 + col@. This
--- preserves containment: if span A contains span B, then
--- @linearize A.start <= linearize B.start@ and
--- @linearize A.end >= linearize B.end@. The fixed column width of @10000@ is
+-- preserves containment: if span @a@ contains span @b@, then
+-- @linearize a.start <= linearize b.start@ and
+-- @linearize a.end >= linearize b.end@. The fixed column width of @10000@ is
 -- safe for any realistic Inferno script.
 --
 -- Also used as the key for @DocState.hoverCache@ (@IntMap@), so hover cache
@@ -85,32 +85,34 @@ buildHoverIndex = IntervalMap.fromList . fmap toEntry . Map.toList
 -- | Query the hover index at a given LSP @(line, col)@ position. Finds all
 -- intervals containing the linearized point, then picks the smallest
 -- (innermost) span. Returns 'Nothing' if the position has no type information.
-queryHover :: UInt -> UInt -> HoverIndex -> Maybe HoverEntry
-queryHover line col = smallestContaining . flip IntervalMap.containing pt
+queryHover :: (UInt, UInt) -> HoverIndex -> Maybe HoverEntry
+queryHover (line, col) = smallestContaining . flip IntervalMap.containing pt
   where
     pt :: Int
     pt = fromIntegral line * 10000 + fromIntegral col
 
--- | Find the entry with the smallest enclosing interval (i.e. the most
--- specific/innermost type). Folds the map directly; no intermediate list.
-smallestContaining :: IntervalMap (Interval Int) a -> Maybe a
-smallestContaining =
-  fmap snd . IntervalMap.foldlWithKey pick Nothing
-  where
-    pick :: Maybe (Interval Int, a) -> Interval Int -> a -> Maybe (Interval Int, a)
-    pick = \cases
-      Nothing k v -> Just (k, v)
-      (Just acc@(a, _)) k v
-        | ivSpan k < ivSpan a -> Just (k, v)
-        | otherwise -> Just acc
+    -- Find the entry with the smallest enclosing interval (i.e. the most
+    -- specific/innermost type). Folds the map directly; no intermediate list.
+    smallestContaining :: IntervalMap (Interval Int) a -> Maybe a
+    smallestContaining =
+      fmap snd . IntervalMap.foldlWithKey pick Nothing
+      where
+        pick ::
+          Maybe (Interval Int, a) -> Interval Int -> a -> Maybe (Interval Int, a)
+        pick = \cases
+          Nothing k v -> Just (k, v)
+          (Just acc@(a, _)) k v
+            | ivSpan k < ivSpan a -> Just (k, v)
+            | otherwise -> Just acc
 
-    ivSpan :: Interval Int -> Int
-    ivSpan iv = Interval.upperBound iv - Interval.lowerBound iv
+        ivSpan :: Interval Int -> Int
+        ivSpan iv = Interval.upperBound iv - Interval.lowerBound iv
 
 -- | Render a hover entry into an LSP 'Range' and markdown 'MarkupContent'.
 -- The @- 2@ offset on source lines accounts for the 2-line @fun ... ->@ prefix
 -- prepended before parsing.
-renderHoverContent :: Set TypeClass -> Set TypeClass -> HoverEntry -> (Range, MarkupContent)
+renderHoverContent ::
+  Set TypeClass -> Set TypeClass -> HoverEntry -> (Range, MarkupContent)
 renderHoverContent allClasses docClasses entry =
   (range, MarkupContent MkMarkdown content)
   where
@@ -136,27 +138,28 @@ renderHoverContent allClasses docClasses entry =
         ]
 
 -- | Pretty-print a type scheme as a union signature. If the scheme has free
--- type variables, resolves typeclass witnesses (capped at @11@) to produce
--- concrete instantiations. Displays up to @10@ variants; truncates with @...@.
+-- type variables, resolves typeclass witnesses (capped at 11) to produce
+-- concrete instantiations. Displays up to 10 variants then truncates with @...@.
 --
 -- NOTE: this runs inside the hover STM transaction. The witness search space is
--- tiny (~15 classes, no real instances); `findTypeClassWitnesses` takes
+-- tiny (few classes, no real \"instances\"); @findTypeClassWitnesses@ takes
 -- microseconds. STM retry risk is near-zero because the only competing writer
 -- is the analysis async (fires at most once per debounce window). Moving this
--- outside STM (compute in IO, write cache in a separate versioned transaction)
+-- outside STM (compute in @IO@, write cache in a separate versioned transaction)
 -- would add significant complexity for negligible gain.
 mkPrettyTy :: Set TypeClass -> Set TypeClass -> TCScheme -> Doc ann
 mkPrettyTy allClasses docClasses sch
   | Set.null ftvTy = ":" <+> align (pretty sch.impl)
   | null subs = ":" <+> align (pretty sch.impl)
-  | null (drop 10 prettyList) = sep $ unionTySig prettyList
+  | null $ drop 10 prettyList = sep $ unionTySig prettyList
   | otherwise = sep . unionTySig $ take 10 prettyList <> ["..."]
   where
     ftvTy :: Set TV
     ftvTy = ftv sch.impl
 
     filteredCls :: Set TypeClass
-    filteredCls = Set.filter (not . isRepClass) $ Set.union sch.classes docClasses
+    filteredCls =
+      Set.filter (not . isRepClass) $ Set.union sch.classes docClasses
 
     subs :: [Map TV InfernoType]
     subs = findTypeClassWitnesses allClasses (Just 11) filteredCls ftvTy
@@ -171,26 +174,26 @@ mkPrettyTy allClasses docClasses sch
     prettyList :: [Doc ann]
     prettyList = fmap pretty . nubOrd $ fmap applyWit subs
 
-unionTySig :: [Doc ann] -> [Doc ann]
-unionTySig = \case
-  [] -> []
-  (t : ts) -> (":" <+> t) : fmap ("|" <+>) ts
+    unionTySig :: [Doc ann] -> [Doc ann]
+    unionTySig = \case
+      [] -> mempty
+      (t : ts) -> (":" <+> t) : fmap ("|" <+>) ts
 
-isRepClass :: TypeClass -> Bool
-isRepClass = \case
-  TypeClass "rep" _ -> True
-  _ -> False
-
--- | Remove 'TRep' entries from an 'ImplType'\'s implicit context; these are
--- runtime representation constraints that should not appear in hover output.
-filterImplReps :: ImplType -> ImplType
-filterImplReps (ImplType impls ty) =
-  flip ImplType ty $ Map.filter (not . isRep) impls
-  where
-    isRep :: InfernoType -> Bool
-    isRep = \case
-      TRep _ -> True
+    isRepClass :: TypeClass -> Bool
+    isRepClass = \case
+      TypeClass "rep" _ -> True
       _ -> False
+
+    -- Remove `TRep` entries from an `ImplType`'s implicit context; these are
+    -- runtime representation constraints that should not appear in hover output.
+    filterImplReps :: ImplType -> ImplType
+    filterImplReps (ImplType impls ty) =
+      flip ImplType ty $ Map.filter (not . isRep) impls
+      where
+        isRep :: InfernoType -> Bool
+        isRep = \case
+          TRep _ -> True
+          _ -> False
 
 -- | Extract documentation text from type metadata. For enum types, appends
 -- a fenced code block showing the enum definition.

--- a/inferno-lsp/src/Inferno/LSP/Hover.hs
+++ b/inferno-lsp/src/Inferno/LSP/Hover.hs
@@ -138,6 +138,13 @@ renderHoverContent allClasses docClasses entry =
 -- | Pretty-print a type scheme as a union signature. If the scheme has free
 -- type variables, resolves typeclass witnesses (capped at @11@) to produce
 -- concrete instantiations. Displays up to @10@ variants; truncates with @...@.
+--
+-- NOTE: this runs inside the hover STM transaction. The witness search space is
+-- tiny (~15 classes, no real instances); `findTypeClassWitnesses` takes
+-- microseconds. STM retry risk is near-zero because the only competing writer
+-- is the analysis async (fires at most once per debounce window). Moving this
+-- outside STM (compute in IO, write cache in a separate versioned transaction)
+-- would add significant complexity for negligible gain.
 mkPrettyTy :: Set TypeClass -> Set TypeClass -> TCScheme -> Doc ann
 mkPrettyTy allClasses docClasses sch
   | Set.null ftvTy = ":" <+> align (pretty sch.impl)

--- a/inferno-lsp/src/Inferno/LSP/Hover.hs
+++ b/inferno-lsp/src/Inferno/LSP/Hover.hs
@@ -1,0 +1,1 @@
+module Inferno.LSP.Hover where

--- a/inferno-lsp/src/Inferno/LSP/Hover.hs
+++ b/inferno-lsp/src/Inferno/LSP/Hover.hs
@@ -1,1 +1,20 @@
-module Inferno.LSP.Hover where
+module Inferno.LSP.Hover
+  ( HoverIndex,
+    linearize,
+  ) where
+
+import Inferno.Types.Syntax (TCScheme, TypeMetadata)
+
+import Data.IntervalMap.Generic.Strict (IntervalMap)
+import Data.IntervalMap.Interval (Interval)
+import Text.Megaparsec.Pos (SourcePos)
+import qualified Text.Megaparsec.Pos as Pos
+
+type HoverIndex =
+  IntervalMap (Interval Int) (TypeMetadata TCScheme, SourcePos, SourcePos)
+
+-- | Encode a `SourcePos` as a single `Int` for use as an `IntervalMap` key.
+-- Uses a fixed column width of `10000`; safe for any realistic Inferno script.
+linearize :: Pos.SourcePos -> Int
+linearize pos =
+  (Pos.unPos pos.sourceLine - 1) * 10000 + (Pos.unPos pos.sourceColumn - 1)

--- a/inferno-types/src/Inferno/Types/Syntax.hs
+++ b/inferno-types/src/Inferno/Types/Syntax.hs
@@ -140,11 +140,12 @@ import Data.Serialize (Serialize (..))
 import qualified Data.Serialize as Serialize
 import qualified Data.Set as Set
 import Data.String (IsString)
-import Data.Text (Text, unpack)
+import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import Data.Word (Word64)
 import GHC.Generics (Generic)
+import GHC.Records (HasField (getField))
 import Inferno.Utils.Prettyprinter (renderPretty)
 import Numeric (showHex)
 import Prettyprinter
@@ -387,6 +388,29 @@ data TypeClass = TypeClass
 
 data TCScheme = ForallTC [TV] (Set.Set TypeClass) ImplType
   deriving (Show, Eq, Ord, Data, Generic, ToJSON, FromJSON)
+
+-- Virtual record fields for positional types
+
+instance HasField "impl" ImplType (Map.Map ExtIdent InfernoType) where
+  getField (ImplType m _) = m
+
+instance HasField "body" ImplType InfernoType where
+  getField (ImplType _ t) = t
+
+instance HasField "tvs" Scheme [TV] where
+  getField (Forall vs _) = vs
+
+instance HasField "impl" Scheme ImplType where
+  getField (Forall _ i) = i
+
+instance HasField "tvs" TCScheme [TV] where
+  getField (ForallTC vs _ _) = vs
+
+instance HasField "classes" TCScheme (Set.Set TypeClass) where
+  getField (ForallTC _ cs _) = cs
+
+instance HasField "impl" TCScheme ImplType where
+  getField (ForallTC _ _ i) = i
 
 tySig :: [Doc ann] -> [Doc ann]
 tySig [] = []


### PR DESCRIPTION
This is the groundwork for the LSP rewrite. It adds the STM primitives, etc... that will be used for hovers (which is the most critical thing that needs to be fixed), document state, and so on. Split into smaller modules to avoid monolithic design

Also adds some helpful virtual record fields for key `inferno-core` types; these aren't defined as records (although they could have been), and pattern matching on them everywhere is tedious and difficult to read IMO. Removes previous orphan instances for this purpose from `Infer.hs`