### PR TITLE
[inferno][lsp] Add parsing, inference, and completion modules

### DIFF
--- a/inferno-lsp/inferno-lsp.cabal
+++ b/inferno-lsp/inferno-lsp.cabal
@@ -45,10 +45,10 @@ library
     , inferno-types
     , inferno-vc
     , IntervalMap
+    , lens
     , lsp
     , lsp-types
     , megaparsec
-    , microlens
     , plow-log
     , plow-log-async
     , prettyprinter

--- a/inferno-lsp/src/Inferno/LSP/Completion.hs
+++ b/inferno-lsp/src/Inferno/LSP/Completion.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NoFieldSelectors #-}
+
 module Inferno.LSP.Completion () where
 
 import Data.Bool (bool)
@@ -8,24 +10,27 @@ import qualified Data.Map.Strict as Map
 import Data.Set (Set)
 import Data.Text (Text)
 import qualified Data.Text as Text
+import Inferno.LSP.Hover (metadataDocsText, mkPrettyTy)
 import Inferno.Types.Syntax
   ( Ident (Ident),
     ModuleName (ModuleName),
     Namespace (EnumNamespace, FunNamespace, ModuleNamespace, OpNamespace, TypeNamespace),
+    TypeClass,
   )
 import qualified Inferno.Types.Syntax
 import Inferno.Types.Type (TCScheme, TypeMetadata)
-import Language.LSP.Types (Position (Position))
+import Inferno.Utils.Prettyprinter (renderDoc, renderPretty)
+import qualified Language.LSP.Types as LSP
 
 -- | Given a cursor @Position@, split the document text into a
 -- @(leadup, prefix)@ pair where @prefix@ is the token fragment being
 -- completed (everything back to the nearest break character) and @leadup@
 -- is the text preceding it.
-completionQueryAt :: Text -> Position -> (Text, Text)
+completionQueryAt :: Text -> LSP.Position -> (Text, Text)
 completionQueryAt txt pos = (leadup, prefix)
   where
     truncated :: Text
-    truncated = Text.take (positionToOffset txt pos) txt
+    truncated = flip Text.take txt $ positionToOffset txt pos
 
     isBreak :: Char -> Bool
     isBreak =
@@ -86,11 +91,80 @@ findInPrelude prelude prefix = Map.filterWithKey matches prelude
           ModuleNamespace modName -> Text.toLower modName.unModuleName
           TypeNamespace _ -> mempty
 
+-- | Context shared across all completion items in a single response.
+data CompletionCtx = CompletionCtx
+  { classes :: !(Set TypeClass)
+  , prefix  :: !Text
+  }
+
+-- | Build a @CompletionItem@ from a prelude entry. Qualifies the label with
+-- the module name unless the completion prefix already includes it. Renders
+-- the type signature as detail and metadata docs as markdown documentation.
+mkCompletionItem ::
+  CompletionCtx ->
+  (Maybe ModuleName, Namespace) ->
+  TypeMetadata TCScheme ->
+  LSP.CompletionItem
+mkCompletionItem ctx (modNm, ns) meta =
+  LSP.CompletionItem
+    { LSP._label = qualifiedLabel
+    , LSP._kind = nsKind
+    , LSP._tags = Nothing
+    , LSP._detail = Just . renderDoc $ mkPrettyTy ctx.classes mempty meta.ty
+    , LSP._documentation =
+        LSP.CompletionDocMarkup . LSP.MarkupContent LSP.MkMarkdown
+          <$> metadataDocsText meta
+    , LSP._deprecated = Nothing
+    , LSP._preselect = Nothing
+    , LSP._sortText = Nothing
+    , LSP._filterText =
+        -- First checks if we are in enum namespace, which is faster than _always_
+        -- doing a text scan for `#` (only enum idents can start with `#`)
+        Just $ bool qualifiedLabel (Text.drop 1 qualifiedLabel) isEnum
+    , LSP._insertText =
+        ns & \case
+          EnumNamespace ident ->
+            bool Nothing (Just ident.unIdent) $ "#" `Text.isPrefixOf` ctx.prefix
+          _ -> Nothing
+    , LSP._insertTextMode = Nothing
+    , LSP._insertTextFormat = Nothing
+    , LSP._textEdit = Nothing
+    , LSP._additionalTextEdits = Nothing
+    , LSP._commitCharacters = Nothing
+    , LSP._command = Nothing
+    , LSP._xdata = Nothing
+    }
+  where
+    qualifiedLabel :: Text
+    qualifiedLabel =
+      modNm & \case
+        Nothing -> renderPretty ns
+        Just modName ->
+          bool (qual <> renderPretty ns) (renderPretty ns) $
+            qual `Text.isPrefixOf` ctx.prefix
+          where
+            qual :: Text
+            qual = modName.unModuleName <> "."
+
+    isEnum :: Bool
+    isEnum = case ns of
+      EnumNamespace _ -> True
+      _ -> False
+
+    nsKind :: Maybe LSP.CompletionItemKind
+    nsKind =
+      ns & \case
+        FunNamespace _ -> Just LSP.CiFunction
+        OpNamespace _ -> Just LSP.CiFunction
+        EnumNamespace _ -> Just LSP.CiEnum
+        ModuleNamespace _ -> Just LSP.CiModule
+        TypeNamespace _ -> Nothing
+
 -- | Convert an LSP @Position@ (0-based line and column) to a 0-based
 -- character offset into @txt@. Clamps to @Text.length txt@ if the position
 -- lies beyond the end of the document.
-positionToOffset :: Text -> Position -> Int
-positionToOffset txt (Position line col) =
+positionToOffset :: Text -> LSP.Position -> Int
+positionToOffset txt (LSP.Position line col) =
   min (lineStart + fromIntegral col) $ Text.length txt
   where
     lineStart :: Int

--- a/inferno-lsp/src/Inferno/LSP/Completion.hs
+++ b/inferno-lsp/src/Inferno/LSP/Completion.hs
@@ -1,1 +1,106 @@
-module Inferno.LSP.Completion where
+module Inferno.LSP.Completion () where
+
+import Data.Bool (bool)
+import Data.Function ((&))
+import Data.List (scanl')
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Set (Set)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Inferno.Types.Syntax
+  ( Ident (Ident),
+    ModuleName (ModuleName),
+    Namespace (EnumNamespace, FunNamespace, ModuleNamespace, OpNamespace, TypeNamespace),
+  )
+import qualified Inferno.Types.Syntax
+import Inferno.Types.Type (TCScheme, TypeMetadata)
+import Language.LSP.Types (Position (Position))
+
+-- | Given a cursor @Position@, split the document text into a
+-- @(leadup, prefix)@ pair where @prefix@ is the token fragment being
+-- completed (everything back to the nearest break character) and @leadup@
+-- is the text preceding it.
+completionQueryAt :: Text -> Position -> (Text, Text)
+completionQueryAt txt pos = (leadup, prefix)
+  where
+    truncated :: Text
+    truncated = Text.take (positionToOffset txt pos) txt
+
+    isBreak :: Char -> Bool
+    isBreak =
+      (`elem` [' ', '\t', '\n', '[', '(', ',', '=', '+', '*', '&', '|', '}', '?', '>'])
+
+    prefix :: Text
+    prefix = Text.takeWhileEnd (not . isBreak) truncated
+
+    leadup :: Text
+    leadup = Text.dropEnd (Text.length prefix) truncated
+
+-- | Filter the prelude map to entries matching a completion @prefix@. If the
+-- prefix starts with @#@, only enum constructors are considered. Otherwise
+-- matches against unqualified names, module names, and qualified @Module.name@
+-- forms.
+--
+-- Returns a filtered sub-map; callers needing an association list should apply
+-- @Map.toList@ at the call site.
+findInPrelude ::
+  Map (Maybe ModuleName, Namespace) (TypeMetadata TCScheme) ->
+  Text ->
+  Map (Maybe ModuleName, Namespace) (TypeMetadata TCScheme)
+findInPrelude prelude prefix = Map.filterWithKey matches prelude
+  where
+    matches :: (Maybe ModuleName, Namespace) -> TypeMetadata TCScheme -> Bool
+    matches (mMod, ns) _ =
+      ns & \case
+        TypeNamespace _ -> False
+        EnumNamespace ident
+          | prefixIsEnum -> lcPrefix `Text.isPrefixOf` Text.toLower ident.unIdent
+        _ | prefixIsEnum -> False
+        _ -> any (lcPrefix `Text.isPrefixOf`) searchTexts
+      where
+        lcPrefix :: Text
+        lcPrefix =
+          Text.dropWhileEnd (== '.')
+            . bool id (Text.drop 1) prefixIsEnum
+            $ Text.toLower prefix
+
+        prefixIsEnum :: Bool
+        prefixIsEnum = "#" `Text.isPrefixOf` prefix
+
+        searchTexts :: [Text]
+        searchTexts =
+          mMod & \case
+            Nothing -> [renderNameSpace ns]
+            Just modName ->
+              [ Text.toLower modName.unModuleName
+              , renderNameSpace ns
+              , Text.toLower modName.unModuleName <> "." <> renderNameSpace ns
+              ]
+
+        renderNameSpace :: Namespace -> Text
+        renderNameSpace = \case
+          FunNamespace ident -> Text.toLower ident.unIdent
+          OpNamespace ident -> Text.toLower ident.unIdent
+          EnumNamespace ident -> Text.toLower ident.unIdent
+          ModuleNamespace modName -> Text.toLower modName.unModuleName
+          TypeNamespace _ -> mempty
+
+-- | Convert an LSP @Position@ (0-based line and column) to a 0-based
+-- character offset into @txt@. Clamps to @Text.length txt@ if the position
+-- lies beyond the end of the document.
+positionToOffset :: Text -> Position -> Int
+positionToOffset txt (Position line col) =
+  min (lineStart + fromIntegral col) $ Text.length txt
+  where
+    lineStart :: Int
+    lineStart =
+      starts & drop (fromIntegral line) & \case
+        (s : _) -> s
+        [] -> Text.length txt
+
+    starts :: [Int]
+    starts = scanl' addLine 0 $ Text.splitOn "\n" txt
+
+    addLine :: Int -> Text -> Int
+    addLine acc l = acc + Text.length l + 1

--- a/inferno-lsp/src/Inferno/LSP/Completion.hs
+++ b/inferno-lsp/src/Inferno/LSP/Completion.hs
@@ -1,21 +1,37 @@
 {-# LANGUAGE NoFieldSelectors #-}
 
-module Inferno.LSP.Completion () where
+module Inferno.LSP.Completion
+  ( CompletionCtx (CompletionCtx, classes, prefix),
+    completionQueryAt,
+    findInPrelude,
+    mkCompletionItem,
+    identifierCompletionItems,
+    rwsCompletionItems,
+    filterModuleNameCompletionItems,
+  ) where
 
 import Data.Bool (bool)
 import Data.Function ((&))
 import Data.List (scanl')
+import Data.List.Extra (nubOrd)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import Data.Maybe (mapMaybe)
 import Data.Set (Set)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Inferno.LSP.Hover (metadataDocsText, mkPrettyTy)
 import Inferno.Types.Syntax
-  ( Ident (Ident),
-    ModuleName (ModuleName),
-    Namespace (EnumNamespace, FunNamespace, ModuleNamespace, OpNamespace, TypeNamespace),
+  ( ModuleName,
+    Namespace
+      ( EnumNamespace,
+        FunNamespace,
+        ModuleNamespace,
+        OpNamespace,
+        TypeNamespace
+      ),
     TypeClass,
+    rws,
   )
 import qualified Inferno.Types.Syntax
 import Inferno.Types.Type (TCScheme, TypeMetadata)
@@ -94,7 +110,7 @@ findInPrelude prelude prefix = Map.filterWithKey matches prelude
 -- | Context shared across all completion items in a single response.
 data CompletionCtx = CompletionCtx
   { classes :: !(Set TypeClass)
-  , prefix  :: !Text
+  , prefix :: !Text
   }
 
 -- | Build a @CompletionItem@ from a prelude entry. Qualifies the label with
@@ -159,6 +175,101 @@ mkCompletionItem ctx (modNm, ns) meta =
         EnumNamespace _ -> Just LSP.CiEnum
         ModuleNamespace _ -> Just LSP.CiModule
         TypeNamespace _ -> Nothing
+
+-- | Create completion items for user-provided identifiers (e.g. @input0@).
+-- Returns empty if the prefix ends with @.@ since identifiers have no module
+-- qualification.
+identifierCompletionItems :: [Text] -> Text -> [LSP.CompletionItem]
+identifierCompletionItems idents prefix
+  | "." `Text.isSuffixOf` prefix = mempty
+  | otherwise = mkItem <$> filter (prefix `Text.isPrefixOf`) idents
+  where
+    mkItem :: Text -> LSP.CompletionItem
+    mkItem ident =
+      LSP.CompletionItem
+        { LSP._label = ident
+        , LSP._kind = Just LSP.CiVariable
+        , LSP._tags = Nothing
+        , LSP._detail = Nothing
+        , LSP._documentation = Nothing
+        , LSP._deprecated = Nothing
+        , LSP._preselect = Nothing
+        , LSP._sortText = Nothing
+        , LSP._filterText = Just ident
+        , LSP._insertText = Nothing
+        , LSP._insertTextMode = Nothing
+        , LSP._insertTextFormat = Nothing
+        , LSP._textEdit = Nothing
+        , LSP._additionalTextEdits = Nothing
+        , LSP._commitCharacters = Nothing
+        , LSP._command = Nothing
+        , LSP._xdata = Nothing
+        }
+
+-- | Create completion items for reserved words. Excludes @Some@ and @None@
+-- which are provided via the enum namespace. Returns empty if the prefix
+-- ends with @.@ since keywords have no module qualification.
+rwsCompletionItems :: Text -> [LSP.CompletionItem]
+rwsCompletionItems prefix
+  | "." `Text.isSuffixOf` prefix = mempty
+  | otherwise = mkItem <$> filter (prefix `Text.isPrefixOf`) filteredRws
+  where
+    filteredRws :: [Text]
+    filteredRws = filter (`notElem` ["Some", "None"]) rws
+
+    mkItem :: Text -> LSP.CompletionItem
+    mkItem rw =
+      LSP.CompletionItem
+        { LSP._label = rw
+        , LSP._kind = Just LSP.CiKeyword
+        , LSP._tags = Nothing
+        , LSP._detail = Nothing
+        , LSP._documentation = Nothing
+        , LSP._deprecated = Nothing
+        , LSP._preselect = Nothing
+        , LSP._sortText = Nothing
+        , LSP._filterText = Nothing
+        , LSP._insertText = Nothing
+        , LSP._insertTextMode = Nothing
+        , LSP._insertTextFormat = Nothing
+        , LSP._textEdit = Nothing
+        , LSP._additionalTextEdits = Nothing
+        , LSP._commitCharacters = Nothing
+        , LSP._command = Nothing
+        , LSP._xdata = Nothing
+        }
+
+-- | Create completion items for module names found in the prelude map,
+-- filtered by @prefix@. Extracts distinct module names from the map keys.
+filterModuleNameCompletionItems ::
+  Map (Maybe ModuleName, Namespace) (TypeMetadata TCScheme) -> Text -> [LSP.CompletionItem]
+filterModuleNameCompletionItems prelude prefix =
+  mkItem <$> filter (prefix `Text.isPrefixOf`) modules
+  where
+    modules :: [Text]
+    modules = nubOrd . mapMaybe (fmap (.unModuleName) . fst) $ Map.keys prelude
+
+    mkItem :: Text -> LSP.CompletionItem
+    mkItem m =
+      LSP.CompletionItem
+        { LSP._label = m
+        , LSP._kind = Just LSP.CiModule
+        , LSP._tags = Nothing
+        , LSP._detail = Nothing
+        , LSP._documentation = Nothing
+        , LSP._deprecated = Nothing
+        , LSP._preselect = Nothing
+        , LSP._sortText = Nothing
+        , LSP._filterText = Just m
+        , LSP._insertText = Just m
+        , LSP._insertTextMode = Nothing
+        , LSP._insertTextFormat = Nothing
+        , LSP._textEdit = Nothing
+        , LSP._additionalTextEdits = Nothing
+        , LSP._commitCharacters = Nothing
+        , LSP._command = Nothing
+        , LSP._xdata = Nothing
+        }
 
 -- | Convert an LSP @Position@ (0-based line and column) to a 0-based
 -- character offset into @txt@. Clamps to @Text.length txt@ if the position

--- a/inferno-lsp/src/Inferno/LSP/Hover.hs
+++ b/inferno-lsp/src/Inferno/LSP/Hover.hs
@@ -9,6 +9,8 @@ module Inferno.LSP.Hover
     buildHoverIndex,
     queryHover,
     renderHoverContent,
+    metadataDocsText,
+    mkPrettyTy,
   ) where
 
 import Data.IntervalMap.Generic.Strict (IntervalMap)

--- a/inferno-lsp/src/Inferno/LSP/ParseInfer.hs
+++ b/inferno-lsp/src/Inferno/LSP/ParseInfer.hs
@@ -1,1 +1,388 @@
-module Inferno.LSP.ParseInfer where
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE NoFieldSelectors #-}
+
+module Inferno.LSP.ParseInfer
+  ( parseErrorDiagnostic,
+    inferErrorDiagnostic,
+    mkDiagnostic,
+  ) where
+
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Inferno.Infer.Env (closeOverType)
+import Inferno.Infer.Error (Location, TypeError)
+import qualified Inferno.Infer.Error as Error
+import Inferno.Parse.Error (prettyError)
+import Inferno.Types.Syntax
+  ( ExtIdent (ExtIdent),
+    Ident (Ident),
+    InfernoType,
+    ModuleName (ModuleName),
+    Namespace
+      ( EnumNamespace,
+        FunNamespace,
+        ModuleNamespace,
+        OpNamespace,
+        TypeNamespace
+      ),
+    Scoped (LocalScope, Scope),
+    TypeClass,
+    TypeClassShape (TypeClassShape),
+  )
+import Inferno.Types.VersionControl (VCObjectHash)
+import Inferno.Utils.Prettyprinter (renderDoc)
+import Language.LSP.Types
+  ( Diagnostic (Diagnostic),
+    DiagnosticSeverity (DsError, DsWarning),
+    Range,
+    mkRange,
+  )
+import Prettyprinter
+  ( Doc,
+    Pretty (pretty),
+    align,
+    hsep,
+    indent,
+    squotes,
+    vsep,
+    (<+>),
+  )
+import Text.Megaparsec.Error (ParseError, ShowErrorComponent)
+import Text.Megaparsec.Pos (SourcePos)
+import qualified Text.Megaparsec.Pos as Pos
+
+-- | Build a 'Diagnostic' from a source span, severity, source tag, and message.
+-- The @- 2@ on lines accounts for the 2-line @fun ... ->@ prefix prepended
+-- before parsing.
+parseErrorDiagnostic :: (ShowErrorComponent e) => (ParseError Text e, SourcePos) -> Diagnostic
+parseErrorDiagnostic (err, pos) =
+  mkDiagnostic DsError (Just "inferno.parser") (pos, pos) . Text.pack $ prettyError err
+
+inferErrorDiagnostic :: TypeError SourcePos -> [Diagnostic]
+inferErrorDiagnostic = \case
+  Error.UnificationFail _ t1 t2 loc ->
+    [ inferDiag loc . renderDoc $
+        vsep
+          [ "Could not match the type"
+          , prettyClosedIndented t1
+          , "with"
+          , prettyClosedIndented t2
+          ]
+    ]
+  Error.AnnotationUnificationFail _ t1 t2 loc ->
+    [ inferDiag loc . renderDoc $
+        vsep
+          [ "The type of this expression"
+          , prettyClosedIndented t1
+          , "does not match with the annotated type"
+          , prettyClosedIndented t2
+          ]
+    ]
+  Error.ExpectedFunction _ t1 t2 loc ->
+    [ inferDiag loc . renderDoc $
+        vsep
+          [ "Expected a function here of type"
+          , prettyClosedIndented t1
+          , "but instead found"
+          , prettyClosedIndented t2
+          ]
+    ]
+  Error.InfiniteType tv t loc ->
+    [ inferDiag loc . renderDoc $
+        "Could not unify"
+          <+> pretty tv
+          <+> "~"
+          <+> (pretty . closeOverType) t
+    ]
+  Error.UnboundExtIdent modNm v loc ->
+    [ inferDiag loc . renderDoc $
+        mconcat
+          [ "Unbound variable '"
+          , scopePrefix modNm
+          , pretty v
+          , "'"
+          ]
+    ]
+  Error.UnboundNameInNamespace modNm (Right n) loc ->
+    [ inferDiag loc . renderDoc $ case n of
+        FunNamespace (Ident v) ->
+          hsep
+            [ "Unbound variable"
+            , squotes . pretty $ scopePrefixText modNm <> v
+            ]
+        OpNamespace (Ident v) ->
+          hsep
+            [ "Unbound operator"
+            , squotes . pretty $ scopePrefixText modNm <> v
+            ]
+        ModuleNamespace (ModuleName v) ->
+          hsep
+            [ "Module"
+            , squotes . pretty $ scopePrefixText modNm <> v
+            , "could not be found."
+            ]
+        TypeNamespace (Ident v) ->
+          hsep
+            [ "Type"
+            , squotes . pretty $ scopePrefixText modNm <> v
+            , "could not be found."
+            ]
+        EnumNamespace (Ident c) ->
+          vsep
+            [ mconcat
+                [ "Could not find the enum constructor '#"
+                , scopePrefix modNm
+                , pretty c
+                , "'."
+                ]
+            , "Make sure the enum you are trying to use has been imported"
+            ]
+    ]
+  Error.UnboundNameInNamespace _ (Left h) loc ->
+    [ inferDiag loc . renderDoc $
+        hsep
+          [ "Object with hash"
+          , squotes . pretty $ show h
+          , "could not be found."
+          ]
+    ]
+  Error.ImplicitVarTypeOverlap _ (ExtIdent ident) t1 t2 loc ->
+    [ inferDiag loc . renderDoc $
+        vsep
+          [ hsep
+              [ "The implicit variable"
+              , squotes $ either (("var$" <>) . pretty) pretty ident
+              , "has multiple types:"
+              ]
+          , prettyClosedIndented t1
+          , "and"
+          , prettyClosedIndented t2
+          ]
+    ]
+  Error.VarMultipleOccurrence (Ident x) loc2 loc1 ->
+    [inferDiag loc1 msg, inferDiag loc2 msg]
+    where
+      msg :: Text
+      msg =
+        renderDoc $
+          vsep
+            [ hsep
+                [ "Duplicate declarations of"
+                , squotes $ pretty x
+                , "in the pattern match"
+                ]
+            , hsep
+                [ "at line"
+                , pretty (Pos.unPos (fst loc1).sourceLine) <> ","
+                , "column"
+                , pretty $ Pos.unPos (fst loc1).sourceColumn
+                ]
+            , hsep
+                [ "and line"
+                , pretty (Pos.unPos (fst loc2).sourceLine) <> ","
+                , "column"
+                , pretty $ Pos.unPos (fst loc2).sourceColumn
+                ]
+            ]
+  Error.IfConditionMustBeBool _ t loc ->
+    [ inferDiag loc . renderDoc $
+        vsep
+          [ "The type of the if condition was expected to be a bool, instead I found"
+          , prettyClosedIndented t
+          ]
+    ]
+  Error.AssertConditionMustBeBool _ t loc ->
+    [ inferDiag loc . renderDoc $
+        vsep
+          [ "The type of the assert condition was expected to be a bool, instead I found"
+          , prettyClosedIndented t
+          ]
+    ]
+  Error.IfBranchesMustBeEqType _ t1 t2 loc1 loc2 ->
+    [inferDiag loc1 msg, inferDiag loc2 msg]
+    where
+      msg :: Text
+      msg =
+        renderDoc $
+          vsep
+            [ "The type of both branches of the if statement must be the same, however I found two different types:"
+            , prettyClosedIndented t1
+            , "and"
+            , prettyClosedIndented t2
+            ]
+  Error.CaseBranchesMustBeEqType _ t1 t2 loc1 loc2 ->
+    [inferDiag loc1 msg, inferDiag loc2 msg]
+    where
+      msg :: Text
+      msg =
+        renderDoc $
+          vsep
+            [ "The type of all case branches must be the same, but I found two different types:"
+            , prettyClosedIndented t1
+            , "and"
+            , prettyClosedIndented t2
+            ]
+  Error.PatternUnificationFail tPat tE p loc ->
+    [ inferDiag loc $
+        renderDoc $
+          vsep
+            [ "The type of the pattern does not match the case expression"
+            , "expected"
+            , prettyClosedIndented tE
+            , "but instead found"
+            , indent2 $
+                hsep
+                  [ pretty p
+                  , ":"
+                  , align . pretty $ closeOverType tPat
+                  ]
+            ]
+    ]
+  Error.PatternsMustBeEqType _ t1 t2 p1 p2 loc1 loc2 ->
+    [inferDiag loc1 msg, inferDiag loc2 msg]
+    where
+      msg :: Text
+      msg =
+        renderDoc $
+          vsep
+            [ "The type of all case patterns must be the same, but I found two different types:"
+            , indent2 $
+                hsep
+                  [ pretty p1
+                  , ":"
+                  , align . pretty $ closeOverType t1
+                  ]
+            , "and"
+            , indent2 $
+                hsep
+                  [ pretty p2
+                  , ":"
+                  , align . pretty $ closeOverType t2
+                  ]
+            ]
+  Error.TypeClassNotFoundError _ tcls loc ->
+    [ inferDiag loc . renderDoc $
+        vsep
+          [ "Could not find any definitions for"
+          , indent2Pretty $ TypeClassShape tcls
+          ]
+    ]
+  Error.TypeClassNoPartialMatch tcls loc ->
+    [ inferDiag loc . renderDoc $
+        vsep
+          [ "Could not find any matching definitions for"
+          , indent2Pretty $ TypeClassShape tcls
+          ]
+    ]
+  Error.CouldNotFindTypeclassWitness (Set.toList -> tyCls) loc ->
+    [ inferDiag loc . renderDoc $
+        vsep $
+          prefix : fmap indent2Pretty tyCls
+    ]
+    where
+      prefix :: Doc ann
+      prefix =
+        "Could not find any matching assignment of types which satisfies the type class constraints:"
+  Error.NonExhaustivePatternMatch pat loc ->
+    [ inferDiag loc . renderDoc $
+        vsep
+          [ "The patterns in this case expression are non-exhaustive."
+          , "For example, the following pattern is missing:"
+          , indent2Pretty pat
+          ]
+    ]
+  Error.UselessPattern (Just pat) loc ->
+    [ inferDiag loc . renderDoc $
+        vsep
+          [ "This case is unreachable, since it is subsumed by the previous pattern"
+          , indent2Pretty pat
+          ]
+    ]
+  Error.UselessPattern Nothing loc ->
+    [ inferDiag
+        loc
+        "This case is unreachable, since it is subsumed by the previous patterns"
+    ]
+  Error.ModuleNameTaken (ModuleName m) loc ->
+    [ inferDiag loc . renderDoc $
+        vsep
+          [ "The chosen module name already exists:"
+          , indent2Pretty m
+          ]
+    ]
+  Error.ModuleDoesNotExist (ModuleName m) loc ->
+    [ inferDiag loc . renderDoc $
+        vsep
+          [ "The following module does not exist:"
+          , indent2Pretty m
+          , "make sure you have imported the module"
+          ]
+    ]
+  Error.NameInModuleDoesNotExist (ModuleName m) (Ident i) loc ->
+    [ inferDiag loc . renderDoc $
+        vsep
+          [ "The module"
+          , indent2Pretty m
+          , "does not contain:"
+          , indent2Pretty i
+          ]
+    ]
+  Error.AmbiguousName (ModuleName m) n loc ->
+    [ inferDiag loc . renderDoc $
+        vsep
+          [ "The name"
+          , indent2Pretty n
+          , "you are trying to import from"
+          , indent2Pretty m
+          , "already exists in local scope and would be overshadowed. Consider using:"
+          , mconcat
+              [ indent2Pretty m
+              , "."
+              , pretty n
+              ]
+          ]
+    ]
+  Error.DuplicateRecordField (Ident f) loc ->
+    [ inferDiag loc . renderDoc $
+        vsep
+          [ "Duplicate record field name:"
+          , indent2Pretty f
+          ]
+    ]
+  where
+    inferDiag :: Location SourcePos -> Text -> Diagnostic
+    inferDiag = mkDiagnostic DsError (Just "inferno.infer")
+
+    scopePrefix :: Scoped ModuleName -> Doc ann
+    scopePrefix = \case
+      LocalScope -> mempty
+      Scope (ModuleName nm) -> pretty nm <> "."
+
+    scopePrefixText :: Scoped ModuleName -> Text
+    scopePrefixText = \case
+      LocalScope -> ""
+      Scope (ModuleName nm) -> nm <> "."
+
+    indent2 :: Doc ann -> Doc ann
+    indent2 = indent 2
+
+    prettyClosedIndented :: InfernoType -> Doc ann
+    prettyClosedIndented = indent2Pretty . closeOverType
+
+    indent2Pretty :: (Pretty a) => a -> Doc ann
+    indent2Pretty = indent 2 . pretty
+
+mkDiagnostic :: DiagnosticSeverity -> Maybe Text -> (SourcePos, SourcePos) -> Text -> Diagnostic
+mkDiagnostic sev src (s, e) msg = Diagnostic range (Just sev) Nothing src msg Nothing Nothing
+  where
+    range :: Range
+    range =
+      mkRange
+        (fromIntegral (Pos.unPos s.sourceLine) - 2)
+        (fromIntegral (Pos.unPos s.sourceColumn) - 1)
+        (fromIntegral (Pos.unPos e.sourceLine) - 2)
+        $ fromIntegral (Pos.unPos e.sourceColumn) - 1

--- a/inferno-lsp/src/Inferno/LSP/ParseInfer.hs
+++ b/inferno-lsp/src/Inferno/LSP/ParseInfer.hs
@@ -190,9 +190,6 @@ parseAndInferDiagnostics interp idents txt =
           mkDiagnostic DsWarning (Just "inferno.lsp") (s, e) $
             "Unused variable: " <> x
 
--- | Build a 'Diagnostic' from a source span, severity, source tag, and message.
--- The @- 2@ on lines accounts for the 2-line @fun ... ->@ prefix prepended
--- before parsing.
 parseErrorDiagnostic :: (ShowErrorComponent e) => (ParseError Text e, SourcePos) -> Diagnostic
 parseErrorDiagnostic (err, pos) =
   mkDiagnostic DsError (Just "inferno.parser") (pos, pos) . Text.pack $ prettyError err
@@ -511,7 +508,11 @@ inferErrorDiagnostic = \case
     indent2Pretty :: (Pretty a) => a -> Doc ann
     indent2Pretty = indent 2 . pretty
 
-mkDiagnostic :: DiagnosticSeverity -> Maybe Text -> (SourcePos, SourcePos) -> Text -> Diagnostic
+-- | Build a 'Diagnostic' from a source span, severity, source tag, and message.
+-- The @- 2@ on lines accounts for the 2-line @fun ... ->@ prefix prepended
+-- before parsing.
+mkDiagnostic ::
+  DiagnosticSeverity -> Maybe Text -> (SourcePos, SourcePos) -> Text -> Diagnostic
 mkDiagnostic sev src (s, e) msg = Diagnostic range (Just sev) Nothing src msg Nothing Nothing
   where
     range :: Range

--- a/inferno-lsp/src/Inferno/LSP/ParseInfer.hs
+++ b/inferno-lsp/src/Inferno/LSP/ParseInfer.hs
@@ -1,24 +1,58 @@
 {-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE NoFieldSelectors #-}
 
+-- | Parse\/infer pipeline and diagnostic generation.
+--
+-- This module is concerned with language-level operations only: parsing,
+-- type inference, comment insertion, and unused-variable detection. It does
+-- NOT handle:
+--
+--   * Input type validation (@validateInput@); this is domain policy and
+--     belongs in the Server layer.
+--   * 'Inferno.LSP.Hover.HoverIndex' construction; the Server builds it from
+--     'InferSuccess.typeMap'.
+--   * Backwards-compat @ParsedResult@ translation (the @(Expr, TCScheme,
+--     [Diagnostic], [(Range, MarkupContent)])@ tuple expected by @afterParse@
+--     callbacks); the Server is responsible for assembling it from
+--     'InferSuccess' and the hover rendering functions in "Inferno.LSP.Hover".
 module Inferno.LSP.ParseInfer
-  ( parseErrorDiagnostic,
+  ( InferSuccess
+      ( InferSuccess,
+        ast,
+        scheme,
+        typeMap,
+        classes,
+        warnings
+      ),
+    parseAndInferDiagnostics,
+    parseErrorDiagnostic,
     inferErrorDiagnostic,
     mkDiagnostic,
   ) where
 
+import Control.Monad (void)
+import Data.Foldable (foldl') -- NOTE: Do NOT remove, needed for GHC version compat
+import Data.List.Extra (nubOrd)
+import Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NonEmpty
+import Data.Map.Strict (Map)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
+import Inferno.Core (Interpreter)
+import qualified Inferno.Core as Core
 import Inferno.Infer.Env (closeOverType)
 import Inferno.Infer.Error (Location, TypeError)
 import qualified Inferno.Infer.Error as Error
+import Inferno.Parse.Commented (insertCommentsIntoExpr)
 import Inferno.Parse.Error (prettyError)
 import Inferno.Types.Syntax
-  ( ExtIdent (ExtIdent),
+  ( Expr (Lam),
+    ExtIdent (ExtIdent),
     Ident (Ident),
     InfernoType,
     ModuleName (ModuleName),
@@ -30,10 +64,15 @@ import Inferno.Types.Syntax
         TypeNamespace
       ),
     Scoped (LocalScope, Scope),
+    TCScheme,
     TypeClass,
     TypeClassShape (TypeClassShape),
+    TypeMetadata,
+    collectArrs,
+    unusedVars,
   )
-import Inferno.Types.VersionControl (VCObjectHash)
+import qualified Inferno.Types.Syntax
+import Inferno.Types.VersionControl (Pinned, VCObjectHash)
 import Inferno.Utils.Prettyprinter (renderDoc)
 import Language.LSP.Types
   ( Diagnostic (Diagnostic),
@@ -54,6 +93,102 @@ import Prettyprinter
 import Text.Megaparsec.Error (ParseError, ShowErrorComponent)
 import Text.Megaparsec.Pos (SourcePos)
 import qualified Text.Megaparsec.Pos as Pos
+
+-- | The result of a successful parse\/infer cycle.
+data InferSuccess = InferSuccess
+  { ast :: !(Expr (Pinned VCObjectHash) ())
+  , scheme :: !TCScheme
+  , typeMap :: !(Map (SourcePos, SourcePos) (TypeMetadata TCScheme))
+  , classes :: !(Set TypeClass)
+  , warnings :: ![Diagnostic]
+  }
+
+-- | Run the parse\/infer pipeline on script text, producing either error
+-- diagnostics or a successful result. Handles the @fun args ->@ prefix
+-- construction, comment insertion, and unused-variable warnings.
+parseAndInferDiagnostics ::
+  (Pretty c, Eq c) =>
+  Interpreter IO c ->
+  [Maybe Ident] ->
+  Text ->
+  Either [Diagnostic] InferSuccess
+parseAndInferDiagnostics interp idents txt =
+  case interp.parseAndInfer input of
+    Left (Core.ParseError errs) ->
+      Left . fmap parseErrorDiagnostic $ NonEmpty.toList errs
+    Left (Core.PinError errs) ->
+      Left . foldMap inferErrorDiagnostic $ nubOrd errs
+    Left (Core.InferenceError errs) ->
+      Left . foldMap inferErrorDiagnostic $ nubOrd errs
+    Right (pinnedAst, scheme, typeMap, comments)
+      | length (collectArrs scheme.impl.body) > length idents + 1 ->
+          Left [scriptIsFunctionErr]
+      | otherwise ->
+          Right
+            InferSuccess
+              { ast =
+                  putBackLams lams . void $
+                    insertCommentsIntoExpr comments body
+              , classes = scheme.classes
+              , warnings = unusedVarWarnings body
+              , scheme
+              , typeMap
+              }
+      where
+        lams :: [NonEmpty (Maybe ExtIdent)]
+        body :: Expr (Pinned VCObjectHash) SourcePos
+        (lams, body) = extractLams mempty pinnedAst
+  where
+    input :: Text
+    input = case idents of
+      [] -> "\n" <> txt
+      ids ->
+        mconcat
+          [ "fun "
+          , Text.intercalate " " $ fmap (maybe "_" (.unIdent)) ids
+          , " -> \n"
+          , txt
+          ]
+
+    extractLams ::
+      [NonEmpty (Maybe ExtIdent)] ->
+      Expr (Pinned VCObjectHash) SourcePos ->
+      ([NonEmpty (Maybe ExtIdent)], Expr (Pinned VCObjectHash) SourcePos)
+    extractLams acc = \case
+      Lam _ xs _ e -> extractLams (fmap snd xs : acc) e
+      e -> (acc, e)
+
+    putBackLams ::
+      [NonEmpty (Maybe ExtIdent)] ->
+      Expr (Pinned VCObjectHash) () ->
+      Expr (Pinned VCObjectHash) ()
+    putBackLams acc e = foldl' wrapLam e acc
+      where
+        wrapLam ::
+          Expr (Pinned VCObjectHash) () ->
+          NonEmpty (Maybe ExtIdent) ->
+          Expr (Pinned VCObjectHash) ()
+        wrapLam l xs = Lam () (fmap ((),) xs) () l
+
+    scriptIsFunctionErr :: Diagnostic
+    scriptIsFunctionErr =
+      mkDiagnostic
+        DsError
+        (Just "inferno.infer")
+        (startPos, startPos)
+        "This script evaluates to a function. Did you mean to add input parameters instead?"
+
+    startPos :: SourcePos
+    startPos = Pos.initialPos mempty
+
+    unusedVarWarnings :: Expr (Pinned VCObjectHash) SourcePos -> [Diagnostic]
+    unusedVarWarnings =
+      fmap mkWarn . Set.toList . unusedVars
+      where
+        mkWarn :: (Text, SourcePos, SourcePos) -> Diagnostic
+        mkWarn (x, s, e) =
+          mkDiagnostic DsWarning (Just "inferno.lsp") (s, e) $
+            "Unused variable: " <> x
 
 -- | Build a 'Diagnostic' from a source span, severity, source tag, and message.
 -- The @- 2@ on lines accounts for the 2-line @fun ... ->@ prefix prepended


### PR DESCRIPTION
These largely resemble the old modules but with some fixes/improvements:

- Strict `InferSuccess` record replaces the 4-tuple mess (`(Expr, TCScheme, [Diagnostic], [(Range, MarkupContent)])`) as the internal representation; `Server.hs` will handle backwards-compat translation
- `findTypeClassWitnesses` no longer called eagerly per-AST-node at parse time; deferred to hover-request time
- Unused-variable warnings computed via `unusedVars` and returned as structured data rather than being conflated with hover rendering
- Better separation of concerns; no more input validation or hover index construction
- `positionToOffset` rewritten to avoid `!!` list indexing; now uses `scanl'` and `drop` with pattern match for safe O(line) offset computation
- `completionQueryAt` uses `Text.takeWhileEnd` / `Text.dropEnd` instead of splitting into lines and indexing
- Completion logic factored into composable pieces (`findInPrelude`, `identifierCompletionItems`, `rwsCompletionItems`, `filterModuleNameCompletionItems`) rather than one monolithic function
- `CompletionCtx` record shares computed state (type classes, prefix) across items without recomputing per-entry