### PR TITLE
[inferno-lsp] Write new LSP handlers

### DIFF
--- a/inferno-lsp/src/Inferno/LSP/Completion.hs
+++ b/inferno-lsp/src/Inferno/LSP/Completion.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DisambiguateRecordFields #-}
 {-# LANGUAGE NoFieldSelectors #-}
 
 module Inferno.LSP.Completion
@@ -123,32 +124,32 @@ mkCompletionItem ::
   LSP.CompletionItem
 mkCompletionItem ctx (modNm, ns) meta =
   LSP.CompletionItem
-    { LSP._label = qualifiedLabel
-    , LSP._kind = nsKind
-    , LSP._tags = Nothing
-    , LSP._detail = Just . renderDoc $ mkPrettyTy ctx.classes mempty meta.ty
-    , LSP._documentation =
+    { _label = qualifiedLabel
+    , _kind = nsKind
+    , _tags = Nothing
+    , _detail = Just . renderDoc $ mkPrettyTy ctx.classes mempty meta.ty
+    , _documentation =
         LSP.CompletionDocMarkup . LSP.MarkupContent LSP.MkMarkdown
           <$> metadataDocsText meta
-    , LSP._deprecated = Nothing
-    , LSP._preselect = Nothing
-    , LSP._sortText = Nothing
-    , LSP._filterText =
+    , _deprecated = Nothing
+    , _preselect = Nothing
+    , _sortText = Nothing
+    , _filterText =
         -- First checks if we are in enum namespace, which is faster than _always_
         -- doing a text scan for `#` (only enum idents can start with `#`)
         Just $ bool qualifiedLabel (Text.drop 1 qualifiedLabel) isEnum
-    , LSP._insertText =
+    , _insertText =
         ns & \case
           EnumNamespace ident ->
             bool Nothing (Just ident.unIdent) $ "#" `Text.isPrefixOf` ctx.prefix
           _ -> Nothing
-    , LSP._insertTextMode = Nothing
-    , LSP._insertTextFormat = Nothing
-    , LSP._textEdit = Nothing
-    , LSP._additionalTextEdits = Nothing
-    , LSP._commitCharacters = Nothing
-    , LSP._command = Nothing
-    , LSP._xdata = Nothing
+    , _insertTextMode = Nothing
+    , _insertTextFormat = Nothing
+    , _textEdit = Nothing
+    , _additionalTextEdits = Nothing
+    , _commitCharacters = Nothing
+    , _command = Nothing
+    , _xdata = Nothing
     }
   where
     qualifiedLabel :: Text
@@ -187,23 +188,23 @@ identifierCompletionItems idents prefix
     mkItem :: Text -> LSP.CompletionItem
     mkItem ident =
       LSP.CompletionItem
-        { LSP._label = ident
-        , LSP._kind = Just LSP.CiVariable
-        , LSP._tags = Nothing
-        , LSP._detail = Nothing
-        , LSP._documentation = Nothing
-        , LSP._deprecated = Nothing
-        , LSP._preselect = Nothing
-        , LSP._sortText = Nothing
-        , LSP._filterText = Just ident
-        , LSP._insertText = Nothing
-        , LSP._insertTextMode = Nothing
-        , LSP._insertTextFormat = Nothing
-        , LSP._textEdit = Nothing
-        , LSP._additionalTextEdits = Nothing
-        , LSP._commitCharacters = Nothing
-        , LSP._command = Nothing
-        , LSP._xdata = Nothing
+        { _label = ident
+        , _kind = Just LSP.CiVariable
+        , _tags = Nothing
+        , _detail = Nothing
+        , _documentation = Nothing
+        , _deprecated = Nothing
+        , _preselect = Nothing
+        , _sortText = Nothing
+        , _filterText = Just ident
+        , _insertText = Nothing
+        , _insertTextMode = Nothing
+        , _insertTextFormat = Nothing
+        , _textEdit = Nothing
+        , _additionalTextEdits = Nothing
+        , _commitCharacters = Nothing
+        , _command = Nothing
+        , _xdata = Nothing
         }
 
 -- | Create completion items for reserved words. Excludes @Some@ and @None@
@@ -220,23 +221,23 @@ rwsCompletionItems prefix
     mkItem :: Text -> LSP.CompletionItem
     mkItem rw =
       LSP.CompletionItem
-        { LSP._label = rw
-        , LSP._kind = Just LSP.CiKeyword
-        , LSP._tags = Nothing
-        , LSP._detail = Nothing
-        , LSP._documentation = Nothing
-        , LSP._deprecated = Nothing
-        , LSP._preselect = Nothing
-        , LSP._sortText = Nothing
-        , LSP._filterText = Nothing
-        , LSP._insertText = Nothing
-        , LSP._insertTextMode = Nothing
-        , LSP._insertTextFormat = Nothing
-        , LSP._textEdit = Nothing
-        , LSP._additionalTextEdits = Nothing
-        , LSP._commitCharacters = Nothing
-        , LSP._command = Nothing
-        , LSP._xdata = Nothing
+        { _label = rw
+        , _kind = Just LSP.CiKeyword
+        , _tags = Nothing
+        , _detail = Nothing
+        , _documentation = Nothing
+        , _deprecated = Nothing
+        , _preselect = Nothing
+        , _sortText = Nothing
+        , _filterText = Nothing
+        , _insertText = Nothing
+        , _insertTextMode = Nothing
+        , _insertTextFormat = Nothing
+        , _textEdit = Nothing
+        , _additionalTextEdits = Nothing
+        , _commitCharacters = Nothing
+        , _command = Nothing
+        , _xdata = Nothing
         }
 
 -- | Create completion items for module names found in the prelude map,
@@ -252,23 +253,23 @@ filterModuleNameCompletionItems prelude prefix =
     mkItem :: Text -> LSP.CompletionItem
     mkItem m =
       LSP.CompletionItem
-        { LSP._label = m
-        , LSP._kind = Just LSP.CiModule
-        , LSP._tags = Nothing
-        , LSP._detail = Nothing
-        , LSP._documentation = Nothing
-        , LSP._deprecated = Nothing
-        , LSP._preselect = Nothing
-        , LSP._sortText = Nothing
-        , LSP._filterText = Just m
-        , LSP._insertText = Just m
-        , LSP._insertTextMode = Nothing
-        , LSP._insertTextFormat = Nothing
-        , LSP._textEdit = Nothing
-        , LSP._additionalTextEdits = Nothing
-        , LSP._commitCharacters = Nothing
-        , LSP._command = Nothing
-        , LSP._xdata = Nothing
+        { _label = m
+        , _kind = Just LSP.CiModule
+        , _tags = Nothing
+        , _detail = Nothing
+        , _documentation = Nothing
+        , _deprecated = Nothing
+        , _preselect = Nothing
+        , _sortText = Nothing
+        , _filterText = Just m
+        , _insertText = Just m
+        , _insertTextMode = Nothing
+        , _insertTextFormat = Nothing
+        , _textEdit = Nothing
+        , _additionalTextEdits = Nothing
+        , _commitCharacters = Nothing
+        , _command = Nothing
+        , _xdata = Nothing
         }
 
 -- | Convert an LSP @Position@ (0-based line and column) to a 0-based

--- a/inferno-lsp/src/Inferno/LSP/DocState.hs
+++ b/inferno-lsp/src/Inferno/LSP/DocState.hs
@@ -12,7 +12,11 @@ module Inferno.LSP.DocState
         hoverCache
       ),
     AnalysisResult
-      ( AnalysisResult
+      ( AnalysisResult,
+        version,
+        hoverIdx,
+        typeMap,
+        classes
       ),
     DocStore,
     lookupDoc,

--- a/inferno-lsp/src/Inferno/LSP/DocState.hs
+++ b/inferno-lsp/src/Inferno/LSP/DocState.hs
@@ -120,11 +120,14 @@ setAnalysis :: Async () -> TVar DocState -> STM ()
 setAnalysis a tvar = modifyTVar' tvar $ \ds -> ds{analysis = Just a}
 
 -- | Handle @DidOpen@: create a fresh empty 'DocState' and insert it into the
--- store. Returns the 'TVar' for subsequent updates.
-openDoc :: NormalizedUri -> DocStore -> STM (TVar DocState)
-openDoc uri store =
-  newDoc >>= \doc ->
-    doc <$ insertDoc uri doc store
+-- store. Returns the new 'TVar' for subsequent updates, plus the previous one
+-- (if any) so the caller can cancel its in-flight analysis in IO. This prevents
+-- orphaned asyncs when a misbehaving client sends DidOpen twice without DidClose.
+openDoc :: NormalizedUri -> DocStore -> STM (TVar DocState, Maybe (TVar DocState))
+openDoc uri store = do
+  old <- lookupDoc uri store
+  doc <- newDoc
+  (doc, old) <$ insertDoc uri doc store
 
 newDoc :: STM (TVar DocState)
 newDoc =

--- a/inferno-lsp/src/Inferno/LSP/Server.hs
+++ b/inferno-lsp/src/Inferno/LSP/Server.hs
@@ -35,7 +35,7 @@ import Control.Exception
     fromException,
   )
 import Control.Lens
-import Control.Monad (guard)
+import Control.Monad (guard, join)
 import Control.Monad.Extra (whenJustM)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Class (lift)
@@ -48,15 +48,16 @@ import qualified Data.ByteString.Lazy as ByteString.Lazy
 import Data.Foldable (for_, traverse_) -- NOTE: Do NOT remove, needed for GHC version compat
 import Data.Functor (($>))
 import Data.Int (Int32)
+import qualified Data.IntMap.Strict as IntMap
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, catMaybes)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
-import qualified Data.Text.Utf16.Rope as Rope
 import Data.Time.Clock (UTCTime, getCurrentTime)
+import Data.Tuple (swap)
 import Data.UUID (UUID)
 import qualified Data.UUID.V4 as UUID.V4
 import Inferno.Core (Interpreter, mkInferno)
@@ -70,9 +71,10 @@ import Inferno.LSP.Completion
     mkCompletionItem,
     rwsCompletionItems,
   )
+import qualified Inferno.LSP.Completion
 import Inferno.LSP.DocState
   ( AnalysisResult (AnalysisResult),
-    DocState,
+    DocState (hoverCache),
     DocStore,
     cancelAnalysis,
     closeDoc,
@@ -105,10 +107,11 @@ import Inferno.Types.Syntax
     TypeClass,
     TypeMetadata,
   )
+import qualified Inferno.Types.Syntax
 import Inferno.Types.VersionControl (Pinned, VCObjectHash)
 import Language.LSP.Diagnostics (partitionBySource)
 import qualified Language.LSP.Server as LSP.Server
-import qualified Language.LSP.Types as LSP
+import qualified Language.LSP.Types as LSP hiding (line)
 import qualified Language.LSP.Types.Lens as LSP
 import qualified Language.LSP.VFS as LSP.VFS
 import Plow.Logging (IOTracer, traceWith)
@@ -386,10 +389,96 @@ runLspWithConfig mods ctys cfg =
         uri = msg ^. LSP.params . LSP.textDocument . LSP.uri . to LSP.toNormalizedUri
 
     handleHover :: LSP.Server.Handler (InfernoLspM c) LSP.TextDocumentHover
-    handleHover = undefined
+    handleHover req respond = do
+      env <- lift ask
+      result <-
+        liftIO . atomically $
+          traverse (lookupHover env) =<< lookupDoc uri env.docStore
+      respond . Right $
+        uncurry LSP.Hover . bimap LSP.HoverContents Just . swap <$> join result
+      where
+        uri :: LSP.NormalizedUri
+        uri = req ^. LSP.params . LSP.textDocument . LSP.uri . to LSP.toNormalizedUri
+
+        line :: LSP.UInt
+        line = req ^. LSP.params . LSP.position . LSP.line
+
+        col :: LSP.UInt
+        col = req ^. LSP.params . LSP.position . LSP.character
+
+        -- Matches the encoding used by `Hover.linearize`: LSP positions are
+        -- 0-indexed, `SourcePos` is 1-indexed with `- 1` applied in `linearize`,
+        -- yielding the same `line * 10000 + col` value. This is also the key
+        -- used in `DocState.hoverCache` (`IntMap`).
+        pt :: Int
+        pt = fromIntegral line * 1_0000 + fromIntegral col
+
+        lookupHover :: Env c -> TVar DocState -> STM (Maybe (LSP.Range, LSP.MarkupContent))
+        lookupHover env tvar =
+          readTVar tvar >>= \ds ->
+            case IntMap.lookup pt ds.hoverCache of
+              hit@(Just _) -> pure hit
+              Nothing -> do
+                let computed :: Maybe (LSP.Range, LSP.MarkupContent)
+                    computed =
+                      renderHoverContent env.allClasses ds.classes
+                        <$> queryHover (line, col) ds.hoverIdx
+                for_ computed $ \r ->
+                  writeTVar tvar ds{hoverCache = IntMap.insert pt r ds.hoverCache}
+                pure computed
 
     handleCompletion :: LSP.Server.Handler (InfernoLspM c) LSP.TextDocumentCompletion
-    handleCompletion = undefined
+    handleCompletion req respond =
+      LSP.Server.getVirtualFile uri >>= \case
+        Nothing -> respond . Right . LSP.InL $ LSP.List mempty
+        Just vf -> do
+          env <- lift ask
+          idents <- liftIO env.getIdents
+
+          let
+              txt :: Text
+              txt = LSP.VFS.virtualFileText vf
+
+              prefix :: Text
+              (_, prefix) = completionQueryAt txt pos
+
+              ctx :: CompletionCtx
+              ctx = CompletionCtx{classes = env.allClasses, prefix}
+
+              preludeItems :: [LSP.CompletionItem]
+              preludeItems =
+                fmap (uncurry (mkCompletionItem ctx))
+                  . Map.toList
+                  $ findInPrelude env.interpreter.nameToTypeMap prefix
+
+              identItems :: [LSP.CompletionItem]
+              identItems =
+                flip identifierCompletionItems prefix
+                  . fmap (.unIdent)
+                  . catMaybes
+                  $ idents
+
+              moduleItems :: [LSP.CompletionItem]
+              moduleItems =
+                filterModuleNameCompletionItems env.interpreter.nameToTypeMap prefix
+
+              rwsItems :: [LSP.CompletionItem]
+              rwsItems = rwsCompletionItems prefix
+
+          respond . Right . LSP.InL . LSP.List $
+            mconcat
+              [ rwsItems
+              , moduleItems
+              , identItems
+              , preludeItems
+              ]
+
+      where
+        uri :: LSP.NormalizedUri
+        uri = req ^. LSP.params . LSP.textDocument . LSP.uri . to LSP.toNormalizedUri
+
+        pos :: LSP.Position
+        pos = req ^. LSP.params . LSP.position
 
 lspOptions :: LSP.Server.Options
 lspOptions =

--- a/inferno-lsp/src/Inferno/LSP/Server.hs
+++ b/inferno-lsp/src/Inferno/LSP/Server.hs
@@ -1,1 +1,203 @@
-module Inferno.LSP.Server () where
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE ExplicitNamespaces #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NoFieldSelectors #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Inferno.LSP.Server
+  ( LspConfig
+      ( LspConfig,
+        tracer,
+        clientIn,
+        clientOut,
+        getIdents,
+        validateIn,
+        beforeParse,
+        afterParse,
+        debounceMs
+      ),
+    ParsedResult,
+    runLsp,
+  ) where
+
+import Colog.Core.Action (LogAction (LogAction))
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Trans.Reader (ReaderT (ReaderT), ask, runReaderT)
+import qualified Control.Exception as Exception
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as ByteString
+import Data.ByteString.Builder.Extra (defaultChunkSize)
+import qualified Data.ByteString.Lazy as ByteString.Lazy
+import Data.Int (Int32)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Utf16.Rope as Rope
+import Data.Time.Clock (UTCTime, getCurrentTime)
+import Data.UUID (UUID)
+import qualified Data.UUID.V4 as UUID.V4
+import Inferno.Core (Interpreter, mkInferno)
+import Inferno.LSP.Completion
+  ( CompletionCtx (CompletionCtx),
+    completionQueryAt,
+    filterModuleNameCompletionItems,
+    findInPrelude,
+    identifierCompletionItems,
+    mkCompletionItem,
+    rwsCompletionItems,
+  )
+import Inferno.LSP.DocState
+  ( AnalysisResult (AnalysisResult),
+    DocState,
+    DocStore,
+    cancelAnalysis,
+    closeDoc,
+    lookupDoc,
+    openDoc,
+    setAnalysis,
+    updateDoc,
+  )
+import Inferno.LSP.Hover
+  ( buildHoverIndex,
+    linearize,
+    queryHover,
+    renderHoverContent,
+  )
+import Inferno.LSP.ParseInfer
+  ( InferSuccess (InferSuccess),
+    parseAndInferDiagnostics,
+  )
+import Inferno.Module.Prelude (ModuleMap)
+import Inferno.Types.Syntax
+  ( CustomType,
+    Expr,
+    Ident (Ident),
+    InfernoType,
+    TCScheme,
+    TypeClass,
+    TypeMetadata,
+  )
+import Inferno.Types.VersionControl (Pinned, VCObjectHash)
+import Language.LSP.Diagnostics (partitionBySource)
+import qualified Language.LSP.Server as LSP.Server
+import qualified Language.LSP.Types as LSP
+import qualified Language.LSP.Types.Lens as LSP
+import qualified Language.LSP.VFS as LSP.VFS
+import Control.Lens
+import Plow.Logging (IOTracer, traceWith)
+import Plow.Logging.Async (withAsyncHandleTracer)
+import Prettyprinter (Pretty)
+import qualified StmContainers.Map
+import System.IO
+  ( BufferMode (NoBuffering),
+    hFlush,
+    hSetBuffering,
+    hSetEncoding,
+    stderr,
+    stdin,
+    stdout,
+    utf8,
+  )
+import System.Timeout (timeout)
+import Text.Megaparsec.Pos (SourcePos)
+import UnliftIO.Async (Async, async, cancel)
+import UnliftIO.STM
+  ( STM,
+    TVar,
+    atomically,
+    modifyTVar',
+    newTVarIO,
+    readTVar,
+    readTVarIO,
+    writeTVar,
+  )
+
+-- | The monad stack for LSP handlers. @LspT@ provides access to LSP operations
+-- (publish diagnostics, get virtual file, etc.) and @ReaderT (Env c) IO@
+-- provides access to our own state via @lift ask@.
+type InfernoLspM c = LSP.Server.LspT () (ReaderT (Env c) IO)
+
+-- | Backwards-compatible result type for the @afterParse@ callback.
+type ParsedResult =
+  Either
+    [LSP.Diagnostic]
+    ( Expr (Pinned VCObjectHash) ()
+    , TCScheme
+    , [LSP.Diagnostic]
+    , [(LSP.Range, LSP.MarkupContent)]
+    )
+
+-- | Configuration record for the LSP server. Built internally with sensible
+-- defaults (stdio, stderr tracer, no-op callbacks, 150ms debounce); callers
+-- supply a @LspConfig c -> LspConfig c@ to override what they need.
+data LspConfig c = LspConfig
+  { tracer :: !(IOTracer Text)
+  , clientIn :: !(IO ByteString)
+  , clientOut :: !(ByteString.Lazy.ByteString -> IO ())
+  , getIdents :: !(IO [Maybe Ident])
+  , validateIn :: !(InfernoType -> Either Text ())
+  , beforeParse :: !((UUID, UTCTime) -> IO ())
+  , afterParse :: !((UUID, UTCTime) -> ParsedResult -> IO ParsedResult)
+  , debounceMs :: {-# UNPACK #-} !Int
+  }
+
+-- | Server environment, built once at startup from 'LspConfig' and threaded
+-- through all handlers via 'ReaderT'.
+data Env c = Env
+  { docStore :: !DocStore
+  , interpreter :: !(Interpreter IO c)
+  , allClasses :: !(Set TypeClass)
+  , tracer :: !(IOTracer Text)
+  , getIdents :: !(IO [Maybe Ident])
+  , beforeParse :: !((UUID, UTCTime) -> IO ())
+  , afterParse :: !((UUID, UTCTime) -> ParsedResult -> IO ParsedResult)
+  , validateIn :: !(InfernoType -> Either Text ())
+  , debounceMs :: {-# UNPACK #-} !Int
+  }
+
+-- | Run the Inferno LSP server. Accepts a @ModuleMap@, @[CustomType]@, and a
+-- config modifier. The modifier receives a default 'LspConfig' (stdio,
+-- stderr tracer, no-op callbacks, 150ms debounce) and can override any field.
+--
+-- @
+-- runLsp modules mempty id             -- uses defaults
+-- runLsp modules mempty $ \\cfg -> cfg { debounceMs = 300 }
+-- @
+runLsp ::
+  forall c.
+  (Pretty c, Eq c) =>
+  ModuleMap IO c ->
+  [CustomType] ->
+  (LspConfig c -> LspConfig c) ->
+  IO Int
+runLsp mods ctys f = do
+  hSetBuffering stdin NoBuffering
+  hSetEncoding stdin utf8
+  hSetBuffering stdout NoBuffering
+  hSetEncoding stdout utf8
+  withAsyncHandleTracer stderr 100 $ \tracer ->
+    runLspWithConfig @c mods ctys $ f $ mkDefaultConfig tracer
+  where
+    mkDefaultConfig :: IOTracer Text -> LspConfig c
+    mkDefaultConfig tracer =
+      LspConfig
+        { tracer
+        , clientIn = ByteString.hGetSome stdin defaultChunkSize
+        , clientOut = \bs -> ByteString.Lazy.hPut stdout bs *> hFlush stdout
+        , getIdents = pure mempty
+        , validateIn = const $ Right ()
+        , beforeParse = const $ pure ()
+        , afterParse = const pure
+        , debounceMs = 150
+        }
+
+-- | Internal: run the server with a fully resolved config.
+runLspWithConfig ::
+  forall c. (Pretty c, Eq c) => ModuleMap IO c -> [CustomType] -> LspConfig c -> IO Int
+runLspWithConfig mods ctys cfg = undefined

--- a/inferno-lsp/src/Inferno/LSP/Server.hs
+++ b/inferno-lsp/src/Inferno/LSP/Server.hs
@@ -2,12 +2,11 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE ExplicitNamespaces #-}
 {-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE NoFieldSelectors #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-
+{-# LANGUAGE NoFieldSelectors #-}
 {-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
 
 module Inferno.LSP.Server
@@ -28,19 +27,30 @@ module Inferno.LSP.Server
 
 import Colog.Core.Action (LogAction (LogAction))
 import Colog.Core.Severity (WithSeverity)
-import Control.Exception (SomeException)
+import Control.Concurrent (threadDelay)
+import Control.Exception
+  ( SomeException,
+    displayException,
+    evaluate,
+    fromException,
+  )
 import Control.Lens
+import Control.Monad (guard)
+import Control.Monad.Extra (whenJustM)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Reader (ReaderT (ReaderT), ask, runReaderT)
+import Data.Bifunctor (first)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as ByteString
 import Data.ByteString.Builder.Extra (defaultChunkSize)
 import qualified Data.ByteString.Lazy as ByteString.Lazy
+import Data.Foldable (for_, traverse_) -- NOTE: Do NOT remove, needed for GHC version compat
+import Data.Functor (($>))
 import Data.Int (Int32)
-import Data.Maybe (fromMaybe)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import Data.Maybe (fromMaybe)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text)
@@ -60,7 +70,6 @@ import Inferno.LSP.Completion
     mkCompletionItem,
     rwsCompletionItems,
   )
-import qualified Inferno.LSP.DocState
 import Inferno.LSP.DocState
   ( AnalysisResult (AnalysisResult),
     DocState,
@@ -72,6 +81,7 @@ import Inferno.LSP.DocState
     setAnalysis,
     updateDoc,
   )
+import qualified Inferno.LSP.DocState
 import Inferno.LSP.Hover
   ( HoverEntry (HoverEntry),
     buildHoverIndex,
@@ -80,11 +90,11 @@ import Inferno.LSP.Hover
     renderHoverContent,
   )
 import qualified Inferno.LSP.Hover
-import qualified Inferno.LSP.ParseInfer
 import Inferno.LSP.ParseInfer
   ( InferSuccess (InferSuccess),
     parseAndInferDiagnostics,
   )
+import qualified Inferno.LSP.ParseInfer
 import Inferno.Module.Prelude (ModuleMap)
 import Inferno.Types.Syntax
   ( CustomType,
@@ -117,8 +127,9 @@ import System.IO
   )
 import System.Timeout (timeout)
 import Text.Megaparsec.Pos (SourcePos)
-import UnliftIO.Async (Async, async, cancel)
-import UnliftIO.Exception (catchAny)
+import qualified Text.Megaparsec.Pos as Pos
+import UnliftIO.Async (Async, AsyncCancelled, async, cancel)
+import UnliftIO.Exception (catchAny, handleJust)
 import UnliftIO.STM
   ( STM,
     TVar,
@@ -203,7 +214,7 @@ runLsp mods ctys f = do
   hSetBuffering stdout NoBuffering
   hSetEncoding stdout utf8
   withAsyncHandleTracer stderr 100 $ \tracer ->
-    runLspWithConfig @c mods ctys $ f $ mkDefaultConfig tracer
+    runLspWithConfig @c mods ctys . f $ mkDefaultConfig tracer
   where
     mkDefaultConfig :: IOTracer Text -> LspConfig c
     mkDefaultConfig tracer =
@@ -225,6 +236,7 @@ runLspWithConfig mods ctys cfg =
   flip catchAny onErr $ do
     interpreter <- mkInferno mods ctys
     docStore <- StmContainers.Map.newIO
+
     let env :: Env c
         env =
           Env
@@ -257,10 +269,10 @@ runLspWithConfig mods ctys cfg =
         lspLog :: LogAction (LSP.Server.LspM ()) (WithSeverity LSP.Server.LspServerLog)
         lspLog = LogAction $ liftIO . traceWith cfg.tracer . Text.pack . show
 
-    i <- LSP.Server.runServerWith ioLog lspLog cfg.clientIn cfg.clientOut serverDef
-    traceWith cfg.tracer "shutting down..."
-    pure i
+    LSP.Server.runServerWith ioLog lspLog cfg.clientIn cfg.clientOut serverDef
+      >>= \i -> i <$ traceWith cfg.tracer "shutting down..."
   where
+    -- Same handler for any synchronous (caught via `catchAny`) exception
     onErr :: SomeException -> IO Int
     onErr = (1 <$) . traceWith cfg.tracer . Text.pack . show
 
@@ -276,30 +288,95 @@ runLspWithConfig mods ctys cfg =
 
     handleDidOpen :: LSP.Server.Handler (InfernoLspM c) LSP.TextDocumentDidOpen
     handleDidOpen msg = do
-      let uri :: LSP.NormalizedUri
-          uri = msg ^. LSP.params . LSP.textDocument . LSP.uri . to LSP.toNormalizedUri
-
-          txt :: Text
-          txt = msg ^. LSP.params . LSP.textDocument . LSP.text
-
       env <- lift ask
-      tvar <- atomically $ openDoc uri env.docStore
-      a <- liftIO . async $ do
+      (tvar, old) <- atomically $ openDoc uri env.docStore
+      liftIO $ traverse_ cancelAnalysis old
+      a <- liftIO . async . swallowCancelled $ do
         idents <- env.getIdents
         ts <- getCurrentTime
         uuid <- UUID.V4.nextRandom
         env.beforeParse (uuid, ts)
-        parsed <- fromMaybe (Left [timeoutDiagnostic])
-          <$> timeout 120_000_000 (pure (parseAndInferDiagnostics env.interpreter idents txt))
-        atomically . updateDoc (either (const (emptyAnalysisResult 0)) (mkAnalysisResult 0) parsed) $ tvar
-        let raw :: ParsedResult
-            raw = toParsedResult . toInferResult env.allClasses =<< parsed
-        diags <- either id (.warnings) . fromParsedResult <$> env.afterParse (uuid, ts) raw
-        sendDiags env uri (Just 0) diags
+        parsed <- runPipeline env idents txt
+
+        let validated :: Either [LSP.Diagnostic] InferSuccess
+            validated = validateInputs env.validateIn =<< parsed
+
+            raw :: ParsedResult
+            raw = toParsedResult . toInferResult env.allClasses =<< validated
+
+        atomically
+          . updateDoc
+            ( either
+                (const (emptyAnalysisResult ver))
+                (mkAnalysisResult ver)
+                validated
+            )
+          $ tvar
+
+        -- Guard: only publish if no newer edit has superseded this cycle.
+        -- After `updateDoc` sets `analysis = Nothing`, a racing `DidChange`
+        -- cannot cancel us (it sees `Nothing`). Without this check, both the
+        -- stale and fresh asyncs would call `sendDiags`, potentially
+        -- overwriting current diagnostics with outdated ones.
+        whenCurrentVersion tvar ver $
+          publishAfterParse env uri ver (uuid, ts) raw
       atomically $ setAnalysis a tvar
+      where
+        uri :: LSP.NormalizedUri
+        uri = msg ^. LSP.params . LSP.textDocument . LSP.uri . to LSP.toNormalizedUri
+
+        ver :: Int32
+        ver = msg ^. LSP.params . LSP.textDocument . LSP.version
+
+        txt :: Text
+        txt = msg ^. LSP.params . LSP.textDocument . LSP.text
 
     handleDidChange :: LSP.Server.Handler (InfernoLspM c) LSP.TextDocumentDidChange
-    handleDidChange = undefined
+    handleDidChange msg =
+      whenJustM (LSP.Server.getVirtualFile uri) $ \vf ->
+        lift ask >>= \env ->
+          traverse_ (onChange env vf) =<< atomically (lookupDoc uri env.docStore)
+      where
+        uri :: LSP.NormalizedUri
+        uri = msg ^. LSP.params . LSP.textDocument . LSP.uri . to LSP.toNormalizedUri
+
+        onChange :: Env c -> LSP.VFS.VirtualFile -> TVar DocState -> InfernoLspM c ()
+        onChange env vf tvar = do
+          liftIO $ cancelAnalysis tvar
+          a <- liftIO . async . swallowCancelled $ do
+            threadDelay $ env.debounceMs * 1000
+            idents <- env.getIdents
+            ts <- getCurrentTime
+            uuid <- UUID.V4.nextRandom
+            env.beforeParse (uuid, ts)
+            parsed <- runPipeline env idents txt
+
+            let validated :: Either [LSP.Diagnostic] InferSuccess
+                validated = validateInputs env.validateIn =<< parsed
+
+            atomically
+              . updateDoc
+                ( either
+                    (const (emptyAnalysisResult ver))
+                    (mkAnalysisResult ver)
+                    validated
+                )
+              $ tvar
+
+            -- See version guard comment in `handleDidOpen`
+            let raw :: ParsedResult
+                raw = toParsedResult . toInferResult env.allClasses =<< validated
+
+            whenCurrentVersion tvar ver $
+              publishAfterParse env uri ver (uuid, ts) raw
+
+          atomically $ setAnalysis a tvar
+          where
+            ver :: Int32
+            ver = LSP.VFS.virtualFileVersion vf
+
+            txt :: Text
+            txt = LSP.VFS.virtualFileText vf
 
     handleDidClose :: LSP.Server.Handler (InfernoLspM c) LSP.TextDocumentDidClose
     handleDidClose = undefined
@@ -336,9 +413,12 @@ toInferResult allClasses success =
     , hovers = fmap toHover . Map.toList $ success.typeMap
     }
   where
-    toHover :: ((SourcePos, SourcePos), TypeMetadata TCScheme) -> (LSP.Range, LSP.MarkupContent)
+    toHover ::
+      ((SourcePos, SourcePos), TypeMetadata TCScheme) -> (LSP.Range, LSP.MarkupContent)
     toHover ((s, e), meta) =
-      renderHoverContent allClasses success.classes
+      renderHoverContent
+        allClasses
+        success.classes
         Inferno.LSP.Hover.HoverEntry{meta, start = s, end = e}
 
 toParsedResult :: InferResult -> ParsedResult
@@ -351,24 +431,104 @@ fromParsedResult = \case
     Right InferResult{ast, scheme, warnings, hovers}
 
 mkAnalysisResult :: Int32 -> InferSuccess -> AnalysisResult
-mkAnalysisResult ver success =
+mkAnalysisResult version success =
   AnalysisResult
-    { version = ver
+    { version
     , hoverIdx = buildHoverIndex success.typeMap
     , typeMap = success.typeMap
     , classes = success.classes
     }
 
 emptyAnalysisResult :: Int32 -> AnalysisResult
-emptyAnalysisResult ver =
+emptyAnalysisResult version =
   AnalysisResult
-    { version = ver
+    { version
     , hoverIdx = mempty
     , typeMap = mempty
     , classes = mempty
     }
 
-sendDiags :: Env c -> LSP.NormalizedUri -> LSP.TextDocumentVersion -> [LSP.Diagnostic] -> IO ()
+-- | Wrap an IO action so that 'AsyncCancelled' is caught and silently
+-- discarded. Used in analysis async bodies to ensure partial state updates
+-- do not occur when a newer edit supersedes an in-flight pipeline.
+swallowCancelled :: IO () -> IO ()
+swallowCancelled = handleJust (fromException @AsyncCancelled) . const $ pure ()
+
+-- | Execute an action only if the document version in the 'TVar' still matches
+-- @ver@. This closes a race window: after 'updateDoc' sets @analysis = Nothing@,
+-- a new @DidChange@ can arrive and spawn a fresh async (since 'cancelAnalysis' sees
+-- Nothing and no-ops). Without this guard, both the old (stale) and new async
+-- would publish diagnostics, potentially overwriting current results with
+-- outdated ones. Reading the version via 'readTVarIO' is safe here because we
+-- only need a point-in-time snapshot; the worst case is a harmless skip.
+whenCurrentVersion :: TVar DocState -> Int32 -> IO () -> IO ()
+whenCurrentVersion tvar ver f =
+  readTVarIO tvar >>= \ds ->
+    for_ @Maybe (guard (ds.version == ver)) . const $ f
+
+-- | Run the parse\/infer pipeline with a 2-minute timeout. We force the
+-- result to NF of the outer 'Either' AND the 'InferSuccess' constructor (whose
+-- fields are all strict) inside the timeout window. Without the inner
+-- 'evaluate', the 'Right' case would remain a thunk; the real inference work
+-- would then execute later (during 'updateDoc') outside the timeout, defeating
+-- its purpose.
+runPipeline ::
+  (Pretty c, Eq c) =>
+  Env c ->
+  [Maybe Ident] ->
+  Text ->
+  IO (Either [LSP.Diagnostic] InferSuccess)
+runPipeline env idents txt =
+  fmap (fromMaybe (Left [timeoutDiagnostic]))
+    . timeout 120_000_000
+    $ case parseAndInferDiagnostics env.interpreter idents txt of
+      l@(Left _) -> evaluate l
+      r@(Right s) -> evaluate s *> evaluate r
+
+-- | Apply domain-level input type validation to a successful infer result.
+-- If 'validateIn' rejects the input type, returns a single error diagnostic
+-- at the start of the document.
+validateInputs ::
+  (InfernoType -> Either Text ()) ->
+  InferSuccess ->
+  Either [LSP.Diagnostic] InferSuccess
+validateInputs validate success =
+  first (pure . mkDiag) $ validate success.scheme.impl.body $> success
+  where
+    mkDiag :: Text -> LSP.Diagnostic
+    mkDiag =
+      Inferno.LSP.ParseInfer.mkDiagnostic
+        LSP.DsError
+        (Just "inferno.validate")
+        (startPos, startPos)
+
+    startPos :: SourcePos
+    startPos = Pos.initialPos mempty
+
+-- | Run the @afterParse@ callback and publish the resulting diagnostics,
+-- catching any exception thrown by the callback. If @afterParse@ throws, we log
+-- the error and skip publishing rather than letting the async die silently
+-- (which would leave the user with no diagnostics until the next edit).
+publishAfterParse ::
+  Env c -> LSP.NormalizedUri -> Int32 -> (UUID, UTCTime) -> ParsedResult -> IO ()
+publishAfterParse env uri ver key raw =
+  catchAny publish $
+    traceWith env.tracer
+      . ("afterParse callback threw: " <>)
+      . Text.pack
+      . displayException
+  where
+    publish :: IO ()
+    publish =
+      sendDiags env uri (Just ver) . either id (.warnings) . fromParsedResult
+        =<< env.afterParse key raw
+
+sendDiags ::
+  Env c ->
+  LSP.NormalizedUri ->
+  LSP.TextDocumentVersion ->
+  [LSP.Diagnostic] ->
+  IO ()
 sendDiags = undefined
 
 timeoutDiagnostic :: LSP.Diagnostic

--- a/inferno-lsp/src/Inferno/LSP/Server.hs
+++ b/inferno-lsp/src/Inferno/LSP/Server.hs
@@ -1,11 +1,11 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE ExplicitNamespaces #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedRecordDot #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE NoFieldSelectors #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE NoFieldSelectors #-}
 
 module Inferno.LSP.Server
   ( LspConfig
@@ -24,9 +24,11 @@ module Inferno.LSP.Server
   ) where
 
 import Colog.Core.Action (LogAction (LogAction))
+import Colog.Core.Severity (WithSeverity)
+import Control.Exception (SomeException)
+import Control.Lens
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Reader (ReaderT (ReaderT), ask, runReaderT)
-import qualified Control.Exception as Exception
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as ByteString
 import Data.ByteString.Builder.Extra (defaultChunkSize)
@@ -43,6 +45,7 @@ import Data.Time.Clock (UTCTime, getCurrentTime)
 import Data.UUID (UUID)
 import qualified Data.UUID.V4 as UUID.V4
 import Inferno.Core (Interpreter, mkInferno)
+import qualified Inferno.Core
 import Inferno.LSP.Completion
   ( CompletionCtx (CompletionCtx),
     completionQueryAt,
@@ -89,7 +92,6 @@ import qualified Language.LSP.Server as LSP.Server
 import qualified Language.LSP.Types as LSP
 import qualified Language.LSP.Types.Lens as LSP
 import qualified Language.LSP.VFS as LSP.VFS
-import Control.Lens
 import Plow.Logging (IOTracer, traceWith)
 import Plow.Logging.Async (withAsyncHandleTracer)
 import Prettyprinter (Pretty)
@@ -107,6 +109,7 @@ import System.IO
 import System.Timeout (timeout)
 import Text.Megaparsec.Pos (SourcePos)
 import UnliftIO.Async (Async, async, cancel)
+import UnliftIO.Exception (catchAny)
 import UnliftIO.STM
   ( STM,
     TVar,
@@ -200,4 +203,65 @@ runLsp mods ctys f = do
 -- | Internal: run the server with a fully resolved config.
 runLspWithConfig ::
   forall c. (Pretty c, Eq c) => ModuleMap IO c -> [CustomType] -> LspConfig c -> IO Int
-runLspWithConfig mods ctys cfg = undefined
+runLspWithConfig mods ctys cfg =
+  flip catchAny onErr $ do
+    interpreter <- mkInferno mods ctys
+    docStore <- StmContainers.Map.newIO
+    let env :: Env c
+        env =
+          Env
+            { docStore
+            , interpreter
+            , allClasses = interpreter.typeClasses
+            , tracer = cfg.tracer
+            , getIdents = cfg.getIdents
+            , beforeParse = cfg.beforeParse
+            , afterParse = cfg.afterParse
+            , validateIn = cfg.validateIn
+            , debounceMs = cfg.debounceMs
+            }
+
+        serverDef :: LSP.Server.ServerDefinition ()
+        serverDef =
+          LSP.Server.ServerDefinition
+            { LSP.Server.defaultConfig = ()
+            , LSP.Server.onConfigurationChange = \old _ -> Right old
+            , LSP.Server.doInitialize = \lspEnv _ -> pure $ Right lspEnv
+            , LSP.Server.staticHandlers = lspHandlers
+            , LSP.Server.interpretHandler = \lspEnv ->
+                LSP.Server.Iso (flip runReaderT env . LSP.Server.runLspT lspEnv) liftIO
+            , LSP.Server.options = lspOptions
+            }
+
+        ioLog :: LogAction IO (WithSeverity LSP.Server.LspServerLog)
+        ioLog = LogAction $ traceWith cfg.tracer . Text.pack . show
+
+        lspLog :: LogAction (LSP.Server.LspM ()) (WithSeverity LSP.Server.LspServerLog)
+        lspLog = LogAction $ liftIO . traceWith cfg.tracer . Text.pack . show
+
+    i <- LSP.Server.runServerWith ioLog lspLog cfg.clientIn cfg.clientOut serverDef
+    traceWith cfg.tracer "shutting down..."
+    pure i
+  where
+    onErr :: SomeException -> IO Int
+    onErr = (1 <$) . traceWith cfg.tracer . Text.pack . show
+
+    lspHandlers :: LSP.Server.Handlers (InfernoLspM c)
+    lspHandlers = undefined
+
+lspOptions :: LSP.Server.Options
+lspOptions =
+  LSP.Server.defaultOptions
+    { LSP.Server.textDocumentSync = Just syncOptions
+    , LSP.Server.executeCommandCommands = Nothing
+    }
+
+syncOptions :: LSP.TextDocumentSyncOptions
+syncOptions =
+  LSP.TextDocumentSyncOptions
+    { LSP._openClose = Just True
+    , LSP._change = Just LSP.TdSyncIncremental
+    , LSP._willSave = Just False
+    , LSP._willSaveWaitUntil = Just False
+    , LSP._save = Just . LSP.InR $ LSP.SaveOptions (Just False)
+    }

--- a/inferno-lsp/src/Inferno/LSP/Server.hs
+++ b/inferno-lsp/src/Inferno/LSP/Server.hs
@@ -1,11 +1,14 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE ExplicitNamespaces #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NoFieldSelectors #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE NoFieldSelectors #-}
+
+{-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
 
 module Inferno.LSP.Server
   ( LspConfig
@@ -28,12 +31,14 @@ import Colog.Core.Severity (WithSeverity)
 import Control.Exception (SomeException)
 import Control.Lens
 import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Reader (ReaderT (ReaderT), ask, runReaderT)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as ByteString
 import Data.ByteString.Builder.Extra (defaultChunkSize)
 import qualified Data.ByteString.Lazy as ByteString.Lazy
 import Data.Int (Int32)
+import Data.Maybe (fromMaybe)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Set (Set)
@@ -55,6 +60,7 @@ import Inferno.LSP.Completion
     mkCompletionItem,
     rwsCompletionItems,
   )
+import qualified Inferno.LSP.DocState
 import Inferno.LSP.DocState
   ( AnalysisResult (AnalysisResult),
     DocState,
@@ -67,11 +73,14 @@ import Inferno.LSP.DocState
     updateDoc,
   )
 import Inferno.LSP.Hover
-  ( buildHoverIndex,
+  ( HoverEntry (HoverEntry),
+    buildHoverIndex,
     linearize,
     queryHover,
     renderHoverContent,
   )
+import qualified Inferno.LSP.Hover
+import qualified Inferno.LSP.ParseInfer
 import Inferno.LSP.ParseInfer
   ( InferSuccess (InferSuccess),
     parseAndInferDiagnostics,
@@ -135,6 +144,15 @@ type ParsedResult =
     , [LSP.Diagnostic]
     , [(LSP.Range, LSP.MarkupContent)]
     )
+
+-- | Internal success record; avoids working with the 4-tuple directly.
+-- Converted to\/from 'ParsedResult' only at the @afterParse@ callback boundary.
+data InferResult = InferResult
+  { ast :: !(Expr (Pinned VCObjectHash) ())
+  , scheme :: !TCScheme
+  , warnings :: ![LSP.Diagnostic]
+  , hovers :: ![(LSP.Range, LSP.MarkupContent)]
+  }
 
 -- | Configuration record for the LSP server. Built internally with sensible
 -- defaults (stdio, stderr tracer, no-op callbacks, 150ms debounce); callers
@@ -247,7 +265,50 @@ runLspWithConfig mods ctys cfg =
     onErr = (1 <$) . traceWith cfg.tracer . Text.pack . show
 
     lspHandlers :: LSP.Server.Handlers (InfernoLspM c)
-    lspHandlers = undefined
+    lspHandlers =
+      mconcat
+        [ LSP.Server.notificationHandler LSP.STextDocumentDidOpen handleDidOpen
+        , LSP.Server.notificationHandler LSP.STextDocumentDidChange handleDidChange
+        , LSP.Server.notificationHandler LSP.STextDocumentDidClose handleDidClose
+        , LSP.Server.requestHandler LSP.STextDocumentHover handleHover
+        , LSP.Server.requestHandler LSP.STextDocumentCompletion handleCompletion
+        ]
+
+    handleDidOpen :: LSP.Server.Handler (InfernoLspM c) LSP.TextDocumentDidOpen
+    handleDidOpen msg = do
+      let uri :: LSP.NormalizedUri
+          uri = msg ^. LSP.params . LSP.textDocument . LSP.uri . to LSP.toNormalizedUri
+
+          txt :: Text
+          txt = msg ^. LSP.params . LSP.textDocument . LSP.text
+
+      env <- lift ask
+      tvar <- atomically $ openDoc uri env.docStore
+      a <- liftIO . async $ do
+        idents <- env.getIdents
+        ts <- getCurrentTime
+        uuid <- UUID.V4.nextRandom
+        env.beforeParse (uuid, ts)
+        parsed <- fromMaybe (Left [timeoutDiagnostic])
+          <$> timeout 120_000_000 (pure (parseAndInferDiagnostics env.interpreter idents txt))
+        atomically . updateDoc (either (const (emptyAnalysisResult 0)) (mkAnalysisResult 0) parsed) $ tvar
+        let raw :: ParsedResult
+            raw = toParsedResult . toInferResult env.allClasses =<< parsed
+        diags <- either id (.warnings) . fromParsedResult <$> env.afterParse (uuid, ts) raw
+        sendDiags env uri (Just 0) diags
+      atomically $ setAnalysis a tvar
+
+    handleDidChange :: LSP.Server.Handler (InfernoLspM c) LSP.TextDocumentDidChange
+    handleDidChange = undefined
+
+    handleDidClose :: LSP.Server.Handler (InfernoLspM c) LSP.TextDocumentDidClose
+    handleDidClose = undefined
+
+    handleHover :: LSP.Server.Handler (InfernoLspM c) LSP.TextDocumentHover
+    handleHover = undefined
+
+    handleCompletion :: LSP.Server.Handler (InfernoLspM c) LSP.TextDocumentCompletion
+    handleCompletion = undefined
 
 lspOptions :: LSP.Server.Options
 lspOptions =
@@ -265,3 +326,50 @@ syncOptions =
     , LSP._willSaveWaitUntil = Just False
     , LSP._save = Just . LSP.InR $ LSP.SaveOptions (Just False)
     }
+
+toInferResult :: Set TypeClass -> InferSuccess -> InferResult
+toInferResult allClasses success =
+  InferResult
+    { ast = success.ast
+    , scheme = success.scheme
+    , warnings = success.warnings
+    , hovers = fmap toHover . Map.toList $ success.typeMap
+    }
+  where
+    toHover :: ((SourcePos, SourcePos), TypeMetadata TCScheme) -> (LSP.Range, LSP.MarkupContent)
+    toHover ((s, e), meta) =
+      renderHoverContent allClasses success.classes
+        Inferno.LSP.Hover.HoverEntry{meta, start = s, end = e}
+
+toParsedResult :: InferResult -> ParsedResult
+toParsedResult r = Right (r.ast, r.scheme, r.warnings, r.hovers)
+
+fromParsedResult :: ParsedResult -> Either [LSP.Diagnostic] InferResult
+fromParsedResult = \case
+  Left diags -> Left diags
+  Right (ast, scheme, warnings, hovers) ->
+    Right InferResult{ast, scheme, warnings, hovers}
+
+mkAnalysisResult :: Int32 -> InferSuccess -> AnalysisResult
+mkAnalysisResult ver success =
+  AnalysisResult
+    { version = ver
+    , hoverIdx = buildHoverIndex success.typeMap
+    , typeMap = success.typeMap
+    , classes = success.classes
+    }
+
+emptyAnalysisResult :: Int32 -> AnalysisResult
+emptyAnalysisResult ver =
+  AnalysisResult
+    { version = ver
+    , hoverIdx = mempty
+    , typeMap = mempty
+    , classes = mempty
+    }
+
+sendDiags :: Env c -> LSP.NormalizedUri -> LSP.TextDocumentVersion -> [LSP.Diagnostic] -> IO ()
+sendDiags = undefined
+
+timeoutDiagnostic :: LSP.Diagnostic
+timeoutDiagnostic = undefined

--- a/inferno-lsp/src/Inferno/LSP/Server.hs
+++ b/inferno-lsp/src/Inferno/LSP/Server.hs
@@ -379,7 +379,11 @@ runLspWithConfig mods ctys cfg =
             txt = LSP.VFS.virtualFileText vf
 
     handleDidClose :: LSP.Server.Handler (InfernoLspM c) LSP.TextDocumentDidClose
-    handleDidClose = undefined
+    handleDidClose msg =
+      liftIO . closeDoc uri . (.docStore) =<< lift ask
+      where
+        uri :: LSP.NormalizedUri
+        uri = msg ^. LSP.params . LSP.textDocument . LSP.uri . to LSP.toNormalizedUri
 
     handleHover :: LSP.Server.Handler (InfernoLspM c) LSP.TextDocumentHover
     handleHover = undefined


### PR DESCRIPTION
**NOTE** Server is _not_ done yet. But these changes along with the earlier work address the major structural issues with `inferno-lsp`

All of the handlers (opening, closing, editing, etc...) are now implemented and address the **major** structural problems we've identified:

| Problem                               | Fix                                                    | Details                                                                    |
|-------------------------------------|--------------------------------------------------------|----------------------------------------------------------------------------|
| Unbounded hover map                 | `DocStore` per-doc; replace on change, delete on close | `updateDoc` replaces state and clears `hoverCache`, `closeDoc` removes entry entirely                        |
| No debounce                         | `threadDelay` + `cancel` pattern                       | `handleDidChange` includes debounce inside the async                       |
| Eager `findTypeClassWitnesses`      | Deferred to hover-request time; only for queried node  | `mkPrettyTy` calls it lazily in `renderHoverContent`, invoked only inside `lookupHover` STM transaction for the single queried node         |
| No cancellation                     | Per-doc `Async` handle; `cancel` on new edit           | `cancelAnalysis` on every DidChange; async handle stored via `setAnalysis` |
| `!!` list indexing for current line | Rewrite `positionToOffset`                             | Part of `Completion` module rewrite (existing)                             |
| O(n) hover scan                     | `IntervalMap.containing` for O(log n) point query      | `queryHover` uses `IntervalMap.containing` with `smallestContaining` fold  |
| 11 positional arg entrypoint        | `LspConfig c` record                                   | `LspConfig` record with modifier pattern in `runLsp`                       |
|                                     |                                                        |                                                                            |

Additionally:
- **Reactor removal**: There's no more unnecessary `TChan`/reactor. Handlers now run directly in `LspT`, per-doc asyncs handle concurrency. The `TChan` stuff probably (?) comes from pre-v1 `haskell-lsp`. The issue is that:
  - A slow parse on doc A blocks hover responses for doc B (i.e. everything is serialized)
  - You can't cancel stale work because it's already in the queue
  - The queue grows without bound under rapid typing (no backpressure)
  - No per-document parallelism at all
- **DidClose handler**: Exists now (old code lacked it entirely). This cancels analysis and deletes it from from `DocStore`
- **`hoverCache` bounded by design**: Cleared on every analysis update; keyed per-position within a single doc and evicted on close