### PR TITLE
[inferno-lsp] Finish `Server` module

### DIFF
--- a/inferno-core/CHANGELOG.md
+++ b/inferno-core/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Revision History for inferno-core
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.11.8.0 -- 2026-05-14
+* Rewrite signficant parts of parser for performance and correctness improvements; 
+significant reduction in memory usage and thunk accumulation
+
+## 0.11.7.0 -- 2026-04-30
+* Replace old unification with union-find and substantial rewrite of `Inferno.Infer` 
+for correctness and performance; significant (up to 140x) increase in parse/typecheck speeds
+
 ## 0.11.6.10 -- 2026-04-08
 * Add `criterion` benchmark suite for parse and type inference
 

--- a/inferno-core/inferno-core.cabal
+++ b/inferno-core/inferno-core.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               inferno-core
-version:            0.11.6.10
+version:            0.11.8.0
 synopsis:           A statically-typed functional scripting language
 description:
   Parser, type inference, and interpreter for a statically-typed functional scripting language

--- a/inferno-lsp/CHANGELOG.md
+++ b/inferno-lsp/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Revision History for inferno-lsp
 *Note*: we use https://pvp.haskell.org/ (MAJOR.MAJOR.MINOR.PATCH)
 
+## 0.3.0.0 -- 2026-05-28
+* Rewrite of LSP server to address critical memory leaks and
+  performance issues, including lack of DidClose handler, unbounded 
+  memory growth, lack of debounce and analysis cancellation, better
+  asymptotics on common operations (e.g. hovers). Refactor of main
+  entry point to use record instead of 11 positional arguments
+
 ## 0.2.6.3 -- 2026-04-06
 * Increase parse and typecheck timeout from 10s to 120s
 

--- a/inferno-lsp/inferno-lsp.cabal
+++ b/inferno-lsp/inferno-lsp.cabal
@@ -1,6 +1,6 @@
 cabal-version:      >=1.10
 name:               inferno-lsp
-version:            0.2.6.3
+version:            0.3.0.0
 synopsis:           LSP for Inferno
 description:
   A language server protocol implementation for the Inferno language
@@ -31,7 +31,8 @@ library
   hs-source-dirs:     src
   ghc-options:
     -Wall -Wunused-packages -Wincomplete-uni-patterns
-    -Wincomplete-record-updates
+    -Wincomplete-record-updates -Wmissing-deriving-strategies
+    -Wunused-packages
 
   build-depends:
       base
@@ -40,7 +41,6 @@ library
     , co-log-core
     , containers
     , extra
-    , focus
     , inferno-core
     , inferno-types
     , inferno-vc
@@ -52,10 +52,8 @@ library
     , plow-log
     , plow-log-async
     , prettyprinter
-    , stm
     , stm-containers
     , text
-    , text-rope
     , time
     , transformers
     , unliftio

--- a/inferno-lsp/inferno-lsp.cabal
+++ b/inferno-lsp/inferno-lsp.cabal
@@ -45,10 +45,10 @@ library
     , inferno-types
     , inferno-vc
     , IntervalMap
-    , lens
     , lsp
     , lsp-types
     , megaparsec
+    , microlens
     , plow-log
     , plow-log-async
     , prettyprinter

--- a/inferno-lsp/src/Inferno/LSP/DocState.hs
+++ b/inferno-lsp/src/Inferno/LSP/DocState.hs
@@ -51,6 +51,10 @@ import UnliftIO.STM
     writeTVar,
   )
 
+-- | Concurrent map from document URIs to their per-document state. Uses
+-- @StmContainers.Map@ for lock-free concurrent access from LSP handlers.
+type DocStore = StmContainers.Map.Map NormalizedUri (TVar DocState)
+
 -- | Per-document state, stored in a 'TVar' inside the 'DocStore'. Replaced
 -- atomically on each successful parse\/infer cycle.
 data DocState = DocState
@@ -65,9 +69,14 @@ data DocState = DocState
   -- analysis update since source positions shift.
   }
 
--- | Concurrent map from document URIs to their per-document state. Uses
--- @StmContainers.Map@ for lock-free concurrent access from LSP handlers.
-type DocStore = StmContainers.Map.Map NormalizedUri (TVar DocState)
+-- | The output of a successful parse\/infer cycle, used to atomically replace
+-- the relevant fields of 'DocState' via 'updateDoc'.
+data AnalysisResult = AnalysisResult
+  { version :: {-# UNPACK #-} !Int32
+  , hoverIdx :: !HoverIndex
+  , typeMap :: !(Map (SourcePos, SourcePos) (TypeMetadata TCScheme))
+  , classes :: !(Set TypeClass)
+  }
 
 lookupDoc :: NormalizedUri -> DocStore -> STM (Maybe (TVar DocState))
 lookupDoc = StmContainers.Map.lookup
@@ -89,15 +98,6 @@ closeDoc :: NormalizedUri -> DocStore -> IO ()
 closeDoc uri store =
   traverse_ ((*> atomically (deleteDoc uri store)) . cancelAnalysis)
     =<< atomically (lookupDoc uri store)
-
--- | The output of a successful parse\/infer cycle, used to atomically replace
--- the relevant fields of 'DocState' via 'updateDoc'.
-data AnalysisResult = AnalysisResult
-  { version :: {-# UNPACK #-} !Int32
-  , hoverIdx :: !HoverIndex
-  , typeMap :: !(Map (SourcePos, SourcePos) (TypeMetadata TCScheme))
-  , classes :: !(Set TypeClass)
-  }
 
 -- | Atomically replace document state with fresh analysis results. Clears the
 -- hover cache since source positions may have shifted.

--- a/inferno-lsp/src/Inferno/LSP/Server.hs
+++ b/inferno-lsp/src/Inferno/LSP/Server.hs
@@ -2,11 +2,11 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE ExplicitNamespaces #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NoFieldSelectors #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE NoFieldSelectors #-}
 {-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
 
 module Inferno.LSP.Server

--- a/inferno-lsp/src/Inferno/LSP/Server.hs
+++ b/inferno-lsp/src/Inferno/LSP/Server.hs
@@ -23,6 +23,7 @@ module Inferno.LSP.Server
       ),
     ParsedResult,
     runLsp,
+    runInfernoLspServer,
   ) where
 
 import Colog.Core.Action (LogAction (LogAction))
@@ -34,26 +35,25 @@ import Control.Exception
     evaluate,
     fromException,
   )
-import Control.Lens
 import Control.Monad (guard, join)
 import Control.Monad.Extra (whenJustM)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Class (lift)
-import Control.Monad.Trans.Reader (ReaderT (ReaderT), ask, runReaderT)
-import Data.Bifunctor (first)
+import Control.Monad.Trans.Reader (ReaderT, ask, asks, runReaderT)
+import Data.Bifunctor (bimap, first)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as ByteString
 import Data.ByteString.Builder.Extra (defaultChunkSize)
+import Data.ByteString.Lazy (LazyByteString)
 import qualified Data.ByteString.Lazy as ByteString.Lazy
 import Data.Foldable (for_, traverse_) -- NOTE: Do NOT remove, needed for GHC version compat
+import Data.Function ((&))
 import Data.Functor (($>))
 import Data.Int (Int32)
 import qualified Data.IntMap.Strict as IntMap
-import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import Data.Maybe (fromMaybe, catMaybes)
+import Data.Maybe (catMaybes, fromMaybe)
 import Data.Set (Set)
-import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time.Clock (UTCTime, getCurrentTime)
@@ -87,13 +87,12 @@ import qualified Inferno.LSP.DocState
 import Inferno.LSP.Hover
   ( HoverEntry (HoverEntry),
     buildHoverIndex,
-    linearize,
     queryHover,
     renderHoverContent,
   )
 import qualified Inferno.LSP.Hover
 import Inferno.LSP.ParseInfer
-  ( InferSuccess (InferSuccess),
+  ( InferSuccess,
     parseAndInferDiagnostics,
   )
 import qualified Inferno.LSP.ParseInfer
@@ -101,7 +100,7 @@ import Inferno.Module.Prelude (ModuleMap)
 import Inferno.Types.Syntax
   ( CustomType,
     Expr,
-    Ident (Ident),
+    Ident,
     InfernoType,
     TCScheme,
     TypeClass,
@@ -114,6 +113,7 @@ import qualified Language.LSP.Server as LSP.Server
 import qualified Language.LSP.Types as LSP hiding (line)
 import qualified Language.LSP.Types.Lens as LSP
 import qualified Language.LSP.VFS as LSP.VFS
+import Lens.Micro ((^.))
 import Plow.Logging (IOTracer, traceWith)
 import Plow.Logging.Async (withAsyncHandleTracer)
 import Prettyprinter (Pretty)
@@ -131,14 +131,12 @@ import System.IO
 import System.Timeout (timeout)
 import Text.Megaparsec.Pos (SourcePos)
 import qualified Text.Megaparsec.Pos as Pos
-import UnliftIO.Async (Async, AsyncCancelled, async, cancel)
+import UnliftIO.Async (AsyncCancelled, async)
 import UnliftIO.Exception (catchAny, handleJust)
 import UnliftIO.STM
   ( STM,
     TVar,
     atomically,
-    modifyTVar',
-    newTVarIO,
     readTVar,
     readTVarIO,
     writeTVar,
@@ -174,7 +172,7 @@ data InferResult = InferResult
 data LspConfig c = LspConfig
   { tracer :: !(IOTracer Text)
   , clientIn :: !(IO ByteString)
-  , clientOut :: !(ByteString.Lazy.ByteString -> IO ())
+  , clientOut :: !(LazyByteString -> IO ())
   , getIdents :: !(IO [Maybe Ident])
   , validateIn :: !(InfernoType -> Either Text ())
   , beforeParse :: !((UUID, UTCTime) -> IO ())
@@ -231,6 +229,10 @@ runLsp mods ctys f = do
         , afterParse = const pure
         , debounceMs = 150
         }
+
+-- | Backwards-compatible entry point. Equivalent to @runLsp mods ctys id@.
+runInfernoLspServer :: (Pretty c, Eq c) => ModuleMap IO c -> [CustomType] -> IO Int
+runInfernoLspServer mods ctys = runLsp mods ctys id
 
 -- | Internal: run the server with a fully resolved config.
 runLspWithConfig ::
@@ -291,42 +293,14 @@ runLspWithConfig mods ctys cfg =
 
     handleDidOpen :: LSP.Server.Handler (InfernoLspM c) LSP.TextDocumentDidOpen
     handleDidOpen msg = do
-      env <- lift ask
-      (tvar, old) <- atomically $ openDoc uri env.docStore
+      store <- lift $ asks (.docStore)
+      (tvar, old) <- atomically $ openDoc uri store
       liftIO $ traverse_ cancelAnalysis old
-      a <- liftIO . async . swallowCancelled $ do
-        idents <- env.getIdents
-        ts <- getCurrentTime
-        uuid <- UUID.V4.nextRandom
-        env.beforeParse (uuid, ts)
-        parsed <- runPipeline env idents txt
-
-        let validated :: Either [LSP.Diagnostic] InferSuccess
-            validated = validateInputs env.validateIn =<< parsed
-
-            raw :: ParsedResult
-            raw = toParsedResult . toInferResult env.allClasses =<< validated
-
-        atomically
-          . updateDoc
-            ( either
-                (const (emptyAnalysisResult ver))
-                (mkAnalysisResult ver)
-                validated
-            )
-          $ tvar
-
-        -- Guard: only publish if no newer edit has superseded this cycle.
-        -- After `updateDoc` sets `analysis = Nothing`, a racing `DidChange`
-        -- cannot cancel us (it sees `Nothing`). Without this check, both the
-        -- stale and fresh asyncs would call `sendDiags`, potentially
-        -- overwriting current diagnostics with outdated ones.
-        whenCurrentVersion tvar ver $
-          publishAfterParse env uri ver (uuid, ts) raw
+      a <- async . swallowCancelled $ analyzeAndPublish tvar uri ver txt
       atomically $ setAnalysis a tvar
       where
         uri :: LSP.NormalizedUri
-        uri = msg ^. LSP.params . LSP.textDocument . LSP.uri . to LSP.toNormalizedUri
+        uri = msg ^. LSP.params . LSP.textDocument . LSP.uri & LSP.toNormalizedUri
 
         ver :: Int32
         ver = msg ^. LSP.params . LSP.textDocument . LSP.version
@@ -337,42 +311,20 @@ runLspWithConfig mods ctys cfg =
     handleDidChange :: LSP.Server.Handler (InfernoLspM c) LSP.TextDocumentDidChange
     handleDidChange msg =
       whenJustM (LSP.Server.getVirtualFile uri) $ \vf ->
-        lift ask >>= \env ->
-          traverse_ (onChange env vf) =<< atomically (lookupDoc uri env.docStore)
+        traverse_ (onChange vf)
+          =<< atomically . lookupDoc uri
+          =<< lift (asks (.docStore))
       where
         uri :: LSP.NormalizedUri
-        uri = msg ^. LSP.params . LSP.textDocument . LSP.uri . to LSP.toNormalizedUri
+        uri = msg ^. LSP.params . LSP.textDocument . LSP.uri & LSP.toNormalizedUri
 
-        onChange :: Env c -> LSP.VFS.VirtualFile -> TVar DocState -> InfernoLspM c ()
-        onChange env vf tvar = do
+        onChange :: LSP.VFS.VirtualFile -> TVar DocState -> InfernoLspM c ()
+        onChange vf tvar = do
           liftIO $ cancelAnalysis tvar
-          a <- liftIO . async . swallowCancelled $ do
-            threadDelay $ env.debounceMs * 1000
-            idents <- env.getIdents
-            ts <- getCurrentTime
-            uuid <- UUID.V4.nextRandom
-            env.beforeParse (uuid, ts)
-            parsed <- runPipeline env idents txt
-
-            let validated :: Either [LSP.Diagnostic] InferSuccess
-                validated = validateInputs env.validateIn =<< parsed
-
-            atomically
-              . updateDoc
-                ( either
-                    (const (emptyAnalysisResult ver))
-                    (mkAnalysisResult ver)
-                    validated
-                )
-              $ tvar
-
-            -- See version guard comment in `handleDidOpen`
-            let raw :: ParsedResult
-                raw = toParsedResult . toInferResult env.allClasses =<< validated
-
-            whenCurrentVersion tvar ver $
-              publishAfterParse env uri ver (uuid, ts) raw
-
+          debounceMs <- lift $ asks (.debounceMs)
+          a <- async . swallowCancelled $ do
+            liftIO . threadDelay $ debounceMs * 1000
+            analyzeAndPublish tvar uri ver txt
           atomically $ setAnalysis a tvar
           where
             ver :: Int32
@@ -382,23 +334,23 @@ runLspWithConfig mods ctys cfg =
             txt = LSP.VFS.virtualFileText vf
 
     handleDidClose :: LSP.Server.Handler (InfernoLspM c) LSP.TextDocumentDidClose
-    handleDidClose msg =
-      liftIO . closeDoc uri . (.docStore) =<< lift ask
+    handleDidClose msg = liftIO . closeDoc uri =<< lift (asks (.docStore))
       where
         uri :: LSP.NormalizedUri
-        uri = msg ^. LSP.params . LSP.textDocument . LSP.uri . to LSP.toNormalizedUri
+        uri = msg ^. LSP.params . LSP.textDocument . LSP.uri & LSP.toNormalizedUri
 
     handleHover :: LSP.Server.Handler (InfernoLspM c) LSP.TextDocumentHover
     handleHover req respond = do
-      env <- lift ask
+      store <- lift $ asks (.docStore)
+      classes <- lift $ asks (.allClasses)
       result <-
         liftIO . atomically $
-          traverse (lookupHover env) =<< lookupDoc uri env.docStore
+          traverse (lookupHover classes) =<< lookupDoc uri store
       respond . Right $
         uncurry LSP.Hover . bimap LSP.HoverContents Just . swap <$> join result
       where
         uri :: LSP.NormalizedUri
-        uri = req ^. LSP.params . LSP.textDocument . LSP.uri . to LSP.toNormalizedUri
+        uri = req ^. LSP.params . LSP.textDocument . LSP.uri & LSP.toNormalizedUri
 
         line :: LSP.UInt
         line = req ^. LSP.params . LSP.position . LSP.line
@@ -413,15 +365,16 @@ runLspWithConfig mods ctys cfg =
         pt :: Int
         pt = fromIntegral line * 1_0000 + fromIntegral col
 
-        lookupHover :: Env c -> TVar DocState -> STM (Maybe (LSP.Range, LSP.MarkupContent))
-        lookupHover env tvar =
+        lookupHover ::
+          Set TypeClass -> TVar DocState -> STM (Maybe (LSP.Range, LSP.MarkupContent))
+        lookupHover classes tvar =
           readTVar tvar >>= \ds ->
-            case IntMap.lookup pt ds.hoverCache of
+            IntMap.lookup pt ds.hoverCache & \case
               hit@(Just _) -> pure hit
               Nothing -> do
                 let computed :: Maybe (LSP.Range, LSP.MarkupContent)
                     computed =
-                      renderHoverContent env.allClasses ds.classes
+                      renderHoverContent classes ds.classes
                         <$> queryHover (line, col) ds.hoverIdx
                 for_ computed $ \r ->
                   writeTVar tvar ds{hoverCache = IntMap.insert pt r ds.hoverCache}
@@ -432,24 +385,24 @@ runLspWithConfig mods ctys cfg =
       LSP.Server.getVirtualFile uri >>= \case
         Nothing -> respond . Right . LSP.InL $ LSP.List mempty
         Just vf -> do
-          env <- lift ask
-          idents <- liftIO env.getIdents
+          interpreter <- lift $ asks (.interpreter)
+          classes <- lift $ asks (.allClasses)
+          idents <- liftIO =<< lift (asks (.getIdents))
 
-          let
-              txt :: Text
+          let txt :: Text
               txt = LSP.VFS.virtualFileText vf
 
               prefix :: Text
               (_, prefix) = completionQueryAt txt pos
 
               ctx :: CompletionCtx
-              ctx = CompletionCtx{classes = env.allClasses, prefix}
+              ctx = CompletionCtx{classes, prefix}
 
               preludeItems :: [LSP.CompletionItem]
               preludeItems =
                 fmap (uncurry (mkCompletionItem ctx))
                   . Map.toList
-                  $ findInPrelude env.interpreter.nameToTypeMap prefix
+                  $ findInPrelude interpreter.nameToTypeMap prefix
 
               identItems :: [LSP.CompletionItem]
               identItems =
@@ -460,7 +413,7 @@ runLspWithConfig mods ctys cfg =
 
               moduleItems :: [LSP.CompletionItem]
               moduleItems =
-                filterModuleNameCompletionItems env.interpreter.nameToTypeMap prefix
+                filterModuleNameCompletionItems interpreter.nameToTypeMap prefix
 
               rwsItems :: [LSP.CompletionItem]
               rwsItems = rwsCompletionItems prefix
@@ -472,10 +425,9 @@ runLspWithConfig mods ctys cfg =
               , identItems
               , preludeItems
               ]
-
       where
         uri :: LSP.NormalizedUri
-        uri = req ^. LSP.params . LSP.textDocument . LSP.uri . to LSP.toNormalizedUri
+        uri = req ^. LSP.params . LSP.textDocument . LSP.uri & LSP.toNormalizedUri
 
         pos :: LSP.Position
         pos = req ^. LSP.params . LSP.position
@@ -541,10 +493,52 @@ emptyAnalysisResult version =
     , classes = mempty
     }
 
--- | Wrap an IO action so that 'AsyncCancelled' is caught and silently
+-- | The core analysis cycle shared by @DidOpen@ and @DidChange@. Runs the
+-- parse\/infer pipeline, updates the document state, and publishes diagnostics
+-- via the @afterParse@ callback. Operates in 'InfernoLspM' so it has access to
+-- both the LSP env (for 'publishDiagnostics') and our 'Env' (for config).
+analyzeAndPublish ::
+  (Pretty c, Eq c) =>
+  TVar DocState ->
+  LSP.NormalizedUri ->
+  Int32 ->
+  Text ->
+  InfernoLspM c ()
+analyzeAndPublish tvar uri ver txt = do
+  env <- lift ask
+  idents <- liftIO env.getIdents
+  ts <- liftIO getCurrentTime
+  uuid <- liftIO UUID.V4.nextRandom
+  liftIO $ env.beforeParse (uuid, ts)
+  parsed <- liftIO $ runPipeline env idents txt
+
+  let validated :: Either [LSP.Diagnostic] InferSuccess
+      validated = validateInputs env.validateIn =<< parsed
+
+      raw :: ParsedResult
+      raw = toParsedResult . toInferResult env.allClasses =<< validated
+
+  atomically
+    . updateDoc
+      ( either
+          (const (emptyAnalysisResult ver))
+          (mkAnalysisResult ver)
+          validated
+      )
+    $ tvar
+
+  -- Guard: only publish if no newer edit has superseded this cycle.
+  -- After `updateDoc` sets `analysis = Nothing`, a racing `DidChange`
+  -- cannot cancel us (it sees `Nothing`). Without this check, both the
+  -- stale and fresh asyncs would call `sendDiags`, potentially
+  -- overwriting current diagnostics with outdated ones.
+  whenCurrentVersion tvar ver $
+    publishAfterParse uri ver (uuid, ts) raw
+
+-- | Wrap an action so that 'AsyncCancelled' is caught and silently
 -- discarded. Used in analysis async bodies to ensure partial state updates
 -- do not occur when a newer edit supersedes an in-flight pipeline.
-swallowCancelled :: IO () -> IO ()
+swallowCancelled :: InfernoLspM c () -> InfernoLspM c ()
 swallowCancelled = handleJust (fromException @AsyncCancelled) . const $ pure ()
 
 -- | Execute an action only if the document version in the 'TVar' still matches
@@ -554,10 +548,10 @@ swallowCancelled = handleJust (fromException @AsyncCancelled) . const $ pure ()
 -- would publish diagnostics, potentially overwriting current results with
 -- outdated ones. Reading the version via 'readTVarIO' is safe here because we
 -- only need a point-in-time snapshot; the worst case is a harmless skip.
-whenCurrentVersion :: TVar DocState -> Int32 -> IO () -> IO ()
-whenCurrentVersion tvar ver f =
+whenCurrentVersion :: TVar DocState -> Int32 -> InfernoLspM c () -> InfernoLspM c ()
+whenCurrentVersion tvar version f =
   readTVarIO tvar >>= \ds ->
-    for_ @Maybe (guard (ds.version == ver)) . const $ f
+    for_ @Maybe (guard (ds.version == version)) . const $ f
 
 -- | Run the parse\/infer pipeline with a 2-minute timeout. We force the
 -- result to NF of the outer 'Either' AND the 'InferSuccess' constructor (whose
@@ -574,6 +568,9 @@ runPipeline ::
 runPipeline env idents txt =
   fmap (fromMaybe (Left [timeoutDiagnostic]))
     . timeout 120_000_000
+    -- NOTE We intentionally `evaluate` the inner types here, otherwise we'd
+    -- only get the WHNF of the `Either` (i.e. if we just `evaluate`d
+    -- `parseAndInferDiagnostics` directly)
     $ case parseAndInferDiagnostics env.interpreter idents txt of
       l@(Left _) -> evaluate l
       r@(Right s) -> evaluate s *> evaluate r
@@ -603,26 +600,39 @@ validateInputs validate success =
 -- the error and skip publishing rather than letting the async die silently
 -- (which would leave the user with no diagnostics until the next edit).
 publishAfterParse ::
-  Env c -> LSP.NormalizedUri -> Int32 -> (UUID, UTCTime) -> ParsedResult -> IO ()
-publishAfterParse env uri ver key raw =
-  catchAny publish $
-    traceWith env.tracer
+  LSP.NormalizedUri ->
+  Int32 ->
+  (UUID, UTCTime) ->
+  ParsedResult ->
+  InfernoLspM c ()
+publishAfterParse uri ver key raw = do
+  tracer <- lift $ asks (.tracer)
+  afterParse <- lift $ asks (.afterParse)
+  catchAny (publish afterParse) $
+    liftIO
+      . traceWith tracer
       . ("afterParse callback threw: " <>)
       . Text.pack
       . displayException
   where
-    publish :: IO ()
-    publish =
-      sendDiags env uri (Just ver) . either id (.warnings) . fromParsedResult
-        =<< env.afterParse key raw
+    publish :: ((UUID, UTCTime) -> ParsedResult -> IO ParsedResult) -> InfernoLspM c ()
+    publish afterParse =
+      sendDiags uri (Just ver) . either id (.warnings) . fromParsedResult
+        =<< liftIO (afterParse key raw)
 
 sendDiags ::
-  Env c ->
-  LSP.NormalizedUri ->
-  LSP.TextDocumentVersion ->
-  [LSP.Diagnostic] ->
-  IO ()
-sendDiags = undefined
+  LSP.NormalizedUri -> LSP.TextDocumentVersion -> [LSP.Diagnostic] -> InfernoLspM c ()
+sendDiags uri ver =
+  LSP.Server.publishDiagnostics 100 uri ver . partitionBySource
 
 timeoutDiagnostic :: LSP.Diagnostic
-timeoutDiagnostic = undefined
+timeoutDiagnostic =
+  LSP.Diagnostic
+    { _range = LSP.mkRange 0 0 0 0
+    , _severity = Just LSP.DsError
+    , _code = Nothing
+    , _source = Just "inferno.lsp"
+    , _message = "Inferno timed out in 120s"
+    , _tags = Nothing
+    , _relatedInformation = Nothing
+    }


### PR DESCRIPTION
Final implementation of the `Server` module, completing all remaining work. No more stubs remain. Also switches many things from straight `IO` to `InfernoLspM c` since it's 1. more idiomatic and 2. works with `MonadUnliftIO`, which we've been using all along. Cleans up cabal file and also bumps versions. There were some version bumps missing from `inferno-core` from first UF and then parser rewrite, so I added those too